### PR TITLE
Library Management

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -196,6 +196,11 @@ export default function HomePage() {
                     {importStatus}
                   </div>
                 ) : null}
+                {importError ? (
+                  <div className="border-b border-lr-border-subtle bg-lr-panel px-3 py-1.5 text-xs text-red-400">
+                    {importError}
+                  </div>
+                ) : null}
                 {viewMode === "dynamic" ? (
                   <DynamicPhotoGrid
                     entries={visibleEntries}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,6 @@ export default function HomePage() {
   const entryMetadata = useLibraryStore((state) => state.entryMetadata);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
   const selectedEntryIds = useLibraryStore((state) => state.selectedEntryIds);
-  const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
   const folderName = useLibraryStore((state) => state.folderName);
   const albums = useLibraryStore((state) => state.albums);
   const catalogView = useLibraryStore((state) => state.catalogView);
@@ -120,9 +119,9 @@ export default function HomePage() {
   useLibraryGridShortcuts({
     gridRows,
     visibleEntries,
+    visibleOrder,
     selectedEntryId,
     selectedEntryIds,
-    onSelect: setSelectedEntryId,
     onOpen: (id) => router.push(`/photo?id=${encodeURIComponent(id)}`),
     disabled: overlayOpen || actionOverlayOpen,
     metadataShortcutsDisabled: catalogView.type === "archive",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,12 +15,16 @@ import { SidePanel } from "@/components/shell/SidePanel";
 import { TopBar } from "@/components/shell/TopBar";
 import { FolderPickerButton } from "@/components/shell/FolderPickerButton";
 import {
-  countCuration,
   filterByCuration,
   filterByFormat,
   sortLibraryEntries,
 } from "@/lib/library/curation";
+import {
+  filterByAlbum,
+  filterByFolderPath,
+} from "@/lib/library/folders";
 import { useLibraryGridShortcuts } from "@/hooks/useEntryMetadataShortcuts";
+import { useAlbumPickerShortcut } from "@/hooks/useAlbumPickerShortcut";
 import { useLibraryContextMenu } from "@/hooks/useLibraryContextMenu";
 import { useLibraryStore } from "@/stores/library-store";
 
@@ -32,6 +36,8 @@ export default function HomePage() {
   const selectedEntryIds = useLibraryStore((state) => state.selectedEntryIds);
   const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
   const folderName = useLibraryStore((state) => state.folderName);
+  const albums = useLibraryStore((state) => state.albums);
+  const catalogView = useLibraryStore((state) => state.catalogView);
   const needsFolderAccess = useLibraryStore((state) => state.needsFolderAccess);
   const importState = useLibraryStore((state) => state.importState);
   const importStatus = useLibraryStore((state) => state.importStatus);
@@ -47,38 +53,33 @@ export default function HomePage() {
   const [viewMode, setViewMode] = useState<GridViewMode>("grid");
   const [gridRows, setGridRows] = useState<string[][]>([]);
 
-  const { rawCount, standardCount } = useMemo(() => {
-    let raw = 0;
-    let standard = 0;
+  const visibleEntries = useMemo(() => {
+    let scoped = entries;
 
-    for (const entry of entries) {
-      if (entry.profileId === "standard") {
-        standard += 1;
-      } else {
-        raw += 1;
-      }
+    if (catalogView.type === "folder") {
+      scoped = filterByFolderPath(scoped, catalogView.path);
+    } else if (catalogView.type === "album") {
+      const album = albums.find((item) => item.id === catalogView.albumId);
+      scoped = filterByAlbum(scoped, album);
     }
 
-    return { rawCount: raw, standardCount: standard };
-  }, [entries]);
-
-  const curationCounts = useMemo(
-    () => countCuration(entries, entryMetadata),
-    [entries, entryMetadata],
-  );
-
-  const visibleEntries = useMemo(
-    () =>
-      sortLibraryEntries(
-        filterByFormat(
-          filterByCuration(entries, entryMetadata, curationFilter),
-          filter,
-        ),
-        entryMetadata,
-        sort,
+    return sortLibraryEntries(
+      filterByFormat(
+        filterByCuration(scoped, entryMetadata, curationFilter),
+        filter,
       ),
-    [entries, entryMetadata, curationFilter, filter, sort],
-  );
+      entryMetadata,
+      sort,
+    );
+  }, [
+    entries,
+    entryMetadata,
+    albums,
+    catalogView,
+    curationFilter,
+    filter,
+    sort,
+  ]);
 
   const visibleOrder = useMemo(
     () => visibleEntries.map((entry) => entry.id),
@@ -87,6 +88,11 @@ export default function HomePage() {
 
   const { openContextMenu, contextMenu } = useLibraryContextMenu(visibleOrder);
 
+  const { albumPicker, albumPickerOpen } = useAlbumPickerShortcut({
+    selectedEntryId,
+    selectedEntryIds,
+  });
+
   useLibraryGridShortcuts({
     gridRows,
     visibleEntries,
@@ -94,25 +100,17 @@ export default function HomePage() {
     selectedEntryIds,
     onSelect: setSelectedEntryId,
     onOpen: (id) => router.push(`/photo?id=${encodeURIComponent(id)}`),
+    disabled: albumPickerOpen,
   });
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       {contextMenu}
+      {albumPicker}
       <TopBar activeModule="library" />
 
       <div className="flex min-h-0 flex-1">
-        <SidePanel
-          folderName={folderName}
-          photoCount={entries.length}
-          rawCount={rawCount}
-          standardCount={standardCount}
-          curationCounts={curationCounts}
-          filter={filter}
-          curationFilter={curationFilter}
-          onFilterChange={setFilter}
-          onCurationFilterChange={setCurationFilter}
-        />
+        <SidePanel />
 
         <div className="flex min-w-0 flex-1 flex-col">
           <LibraryToolbar

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,6 +43,7 @@ export default function HomePage() {
   const [curationFilter, setCurationFilter] = useState<CurationFilter>("all");
   const [thumbSize, setThumbSize] = useState(180);
   const [viewMode, setViewMode] = useState<GridViewMode>("grid");
+  const [gridRows, setGridRows] = useState<string[][]>([]);
 
   const { rawCount, standardCount } = useMemo(() => {
     let raw = 0;
@@ -78,6 +79,7 @@ export default function HomePage() {
   );
 
   useLibraryGridShortcuts({
+    gridRows,
     visibleEntries,
     selectedEntryId,
     onSelect: setSelectedEntryId,
@@ -164,9 +166,14 @@ export default function HomePage() {
                   <DynamicPhotoGrid
                     entries={visibleEntries}
                     rowHeight={thumbSize}
+                    onGridRowsChange={setGridRows}
                   />
                 ) : (
-                  <PhotoGrid entries={visibleEntries} thumbSize={thumbSize} />
+                  <PhotoGrid
+                    entries={visibleEntries}
+                    thumbSize={thumbSize}
+                    onGridRowsChange={setGridRows}
+                  />
                 )}
               </>
             ) : importState === "importing" || importState === "restoring" ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { DynamicPhotoGrid } from "@/components/library/DynamicPhotoGrid";
 import { PhotoGrid } from "@/components/library/PhotoGrid";
 import {
   LibraryToolbar,
+  type CurationFilter,
   type FilterOption,
   type GridViewMode,
   type SortOption,
@@ -12,36 +14,21 @@ import {
 import { SidePanel } from "@/components/shell/SidePanel";
 import { TopBar } from "@/components/shell/TopBar";
 import { FolderPickerButton } from "@/components/shell/FolderPickerButton";
+import {
+  countCuration,
+  filterByCuration,
+  filterByFormat,
+  sortLibraryEntries,
+} from "@/lib/library/curation";
+import { useLibraryGridShortcuts } from "@/hooks/useEntryMetadataShortcuts";
 import { useLibraryStore } from "@/stores/library-store";
 
-function filterEntries(
-  entries: ReturnType<typeof useLibraryStore.getState>["entries"],
-  filter: FilterOption,
-) {
-  if (filter === "raw") {
-    return entries.filter((entry) => entry.profileId !== "standard");
-  }
-  if (filter === "standard") {
-    return entries.filter((entry) => entry.profileId === "standard");
-  }
-  return entries;
-}
-
-function sortEntries(
-  entries: ReturnType<typeof useLibraryStore.getState>["entries"],
-  sort: SortOption,
-) {
-  const sorted = [...entries];
-  if (sort === "date") {
-    sorted.sort((a, b) => b.lastModified - a.lastModified);
-    return sorted;
-  }
-  sorted.sort((a, b) => a.name.localeCompare(b.name));
-  return sorted;
-}
-
 export default function HomePage() {
+  const router = useRouter();
   const entries = useLibraryStore((state) => state.entries);
+  const entryMetadata = useLibraryStore((state) => state.entryMetadata);
+  const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
+  const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
   const folderName = useLibraryStore((state) => state.folderName);
   const needsFolderAccess = useLibraryStore((state) => state.needsFolderAccess);
   const importState = useLibraryStore((state) => state.importState);
@@ -53,6 +40,7 @@ export default function HomePage() {
 
   const [sort, setSort] = useState<SortOption>("name");
   const [filter, setFilter] = useState<FilterOption>("all");
+  const [curationFilter, setCurationFilter] = useState<CurationFilter>("all");
   const [thumbSize, setThumbSize] = useState(180);
   const [viewMode, setViewMode] = useState<GridViewMode>("grid");
 
@@ -71,10 +59,30 @@ export default function HomePage() {
     return { rawCount: raw, standardCount: standard };
   }, [entries]);
 
-  const visibleEntries = useMemo(
-    () => sortEntries(filterEntries(entries, filter), sort),
-    [entries, filter, sort],
+  const curationCounts = useMemo(
+    () => countCuration(entries, entryMetadata),
+    [entries, entryMetadata],
   );
+
+  const visibleEntries = useMemo(
+    () =>
+      sortLibraryEntries(
+        filterByFormat(
+          filterByCuration(entries, entryMetadata, curationFilter),
+          filter,
+        ),
+        entryMetadata,
+        sort,
+      ),
+    [entries, entryMetadata, curationFilter, filter, sort],
+  );
+
+  useLibraryGridShortcuts({
+    visibleEntries,
+    selectedEntryId,
+    onSelect: setSelectedEntryId,
+    onOpen: (id) => router.push(`/photo?id=${encodeURIComponent(id)}`),
+  });
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
@@ -86,8 +94,11 @@ export default function HomePage() {
           photoCount={entries.length}
           rawCount={rawCount}
           standardCount={standardCount}
+          curationCounts={curationCounts}
           filter={filter}
+          curationFilter={curationFilter}
           onFilterChange={setFilter}
+          onCurationFilterChange={setCurationFilter}
         />
 
         <div className="flex min-w-0 flex-1 flex-col">
@@ -95,10 +106,12 @@ export default function HomePage() {
             photoCount={visibleEntries.length}
             sort={sort}
             filter={filter}
+            curationFilter={curationFilter}
             thumbSize={thumbSize}
             viewMode={viewMode}
             onSortChange={setSort}
             onFilterChange={setFilter}
+            onCurationFilterChange={setCurationFilter}
             onThumbSizeChange={setThumbSize}
             onViewModeChange={setViewMode}
           />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ import {
   sortLibraryEntries,
 } from "@/lib/library/curation";
 import { useLibraryGridShortcuts } from "@/hooks/useEntryMetadataShortcuts";
+import { useLibraryContextMenu } from "@/hooks/useLibraryContextMenu";
 import { useLibraryStore } from "@/stores/library-store";
 
 export default function HomePage() {
@@ -28,6 +29,7 @@ export default function HomePage() {
   const entries = useLibraryStore((state) => state.entries);
   const entryMetadata = useLibraryStore((state) => state.entryMetadata);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
+  const selectedEntryIds = useLibraryStore((state) => state.selectedEntryIds);
   const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
   const folderName = useLibraryStore((state) => state.folderName);
   const needsFolderAccess = useLibraryStore((state) => state.needsFolderAccess);
@@ -78,16 +80,25 @@ export default function HomePage() {
     [entries, entryMetadata, curationFilter, filter, sort],
   );
 
+  const visibleOrder = useMemo(
+    () => visibleEntries.map((entry) => entry.id),
+    [visibleEntries],
+  );
+
+  const { openContextMenu, contextMenu } = useLibraryContextMenu(visibleOrder);
+
   useLibraryGridShortcuts({
     gridRows,
     visibleEntries,
     selectedEntryId,
+    selectedEntryIds,
     onSelect: setSelectedEntryId,
     onOpen: (id) => router.push(`/photo?id=${encodeURIComponent(id)}`),
   });
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
+      {contextMenu}
       <TopBar activeModule="library" />
 
       <div className="flex min-h-0 flex-1">
@@ -167,12 +178,14 @@ export default function HomePage() {
                     entries={visibleEntries}
                     rowHeight={thumbSize}
                     onGridRowsChange={setGridRows}
+                    onPhotoContextMenu={openContextMenu}
                   />
                 ) : (
                   <PhotoGrid
                     entries={visibleEntries}
                     thumbSize={thumbSize}
                     onGridRowsChange={setGridRows}
+                    onPhotoContextMenu={openContextMenu}
                   />
                 )}
               </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { DynamicPhotoGrid } from "@/components/library/DynamicPhotoGrid";
 import { PhotoGrid } from "@/components/library/PhotoGrid";
@@ -23,6 +23,10 @@ import {
   filterByAlbum,
   filterByFolderPath,
 } from "@/lib/library/folders";
+import {
+  filterArchivedEntries,
+  filterOnlyArchivedEntries,
+} from "@/lib/library/archive";
 import { useLibraryGridShortcuts } from "@/hooks/useEntryMetadataShortcuts";
 import { useAlbumPickerShortcut } from "@/hooks/useAlbumPickerShortcut";
 import { useLibraryContextMenu } from "@/hooks/useLibraryContextMenu";
@@ -31,6 +35,7 @@ import { useLibraryStore } from "@/stores/library-store";
 export default function HomePage() {
   const router = useRouter();
   const entries = useLibraryStore((state) => state.entries);
+  const archivedEntryIds = useLibraryStore((state) => state.archivedEntryIds);
   const entryMetadata = useLibraryStore((state) => state.entryMetadata);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
   const selectedEntryIds = useLibraryStore((state) => state.selectedEntryIds);
@@ -45,6 +50,13 @@ export default function HomePage() {
   const cancelFolderOperation = useLibraryStore(
     (state) => state.cancelFolderOperation,
   );
+  const setCatalogView = useLibraryStore((state) => state.setCatalogView);
+
+  useEffect(() => {
+    if (catalogView.type === "archive" && archivedEntryIds.length === 0) {
+      setCatalogView({ type: "all" });
+    }
+  }, [archivedEntryIds.length, catalogView.type, setCatalogView]);
 
   const [sort, setSort] = useState<SortOption>("name");
   const [filter, setFilter] = useState<FilterOption>("all");
@@ -53,8 +65,16 @@ export default function HomePage() {
   const [viewMode, setViewMode] = useState<GridViewMode>("grid");
   const [gridRows, setGridRows] = useState<string[][]>([]);
 
+  const libraryEntries = useMemo(
+    () => filterArchivedEntries(entries, archivedEntryIds),
+    [entries, archivedEntryIds],
+  );
+
   const visibleEntries = useMemo(() => {
-    let scoped = entries;
+    let scoped =
+      catalogView.type === "archive"
+        ? filterOnlyArchivedEntries(entries, archivedEntryIds)
+        : libraryEntries;
 
     if (catalogView.type === "folder") {
       scoped = filterByFolderPath(scoped, catalogView.path);
@@ -73,6 +93,8 @@ export default function HomePage() {
     );
   }, [
     entries,
+    archivedEntryIds,
+    libraryEntries,
     entryMetadata,
     albums,
     catalogView,
@@ -86,11 +108,13 @@ export default function HomePage() {
     [visibleEntries],
   );
 
-  const { openContextMenu, contextMenu } = useLibraryContextMenu(visibleOrder);
+  const { openContextMenu, contextMenu, actionOverlayOpen } =
+    useLibraryContextMenu(visibleOrder);
 
-  const { albumPicker, albumPickerOpen } = useAlbumPickerShortcut({
+  const { albumPicker, removePopup, overlayOpen } = useAlbumPickerShortcut({
     selectedEntryId,
     selectedEntryIds,
+    disabled: actionOverlayOpen,
   });
 
   useLibraryGridShortcuts({
@@ -100,13 +124,15 @@ export default function HomePage() {
     selectedEntryIds,
     onSelect: setSelectedEntryId,
     onOpen: (id) => router.push(`/photo?id=${encodeURIComponent(id)}`),
-    disabled: albumPickerOpen,
+    disabled: overlayOpen || actionOverlayOpen,
+    metadataShortcutsDisabled: catalogView.type === "archive",
   });
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       {contextMenu}
       {albumPicker}
+      {removePopup}
       <TopBar activeModule="library" />
 
       <div className="flex min-h-0 flex-1">

--- a/components/library/AlbumPickerPopup.tsx
+++ b/components/library/AlbumPickerPopup.tsx
@@ -84,12 +84,14 @@ export function AlbumPickerPopup({ entryIds, onClose }: AlbumPickerPopupProps) {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
+        event.stopPropagation();
         onClose();
         return;
       }
 
       if (event.key === "ArrowDown") {
         event.preventDefault();
+        event.stopPropagation();
         setHighlightIndex((index) =>
           rows.length === 0 ? 0 : Math.min(index + 1, rows.length - 1),
         );
@@ -98,12 +100,14 @@ export function AlbumPickerPopup({ entryIds, onClose }: AlbumPickerPopupProps) {
 
       if (event.key === "ArrowUp") {
         event.preventDefault();
+        event.stopPropagation();
         setHighlightIndex((index) => Math.max(index - 1, 0));
         return;
       }
 
       if (event.key === "Enter") {
         event.preventDefault();
+        event.stopPropagation();
         const row = rows[highlightIndex];
         if (row) {
           confirmRow(row);
@@ -185,11 +189,23 @@ export function AlbumPickerPopup({ entryIds, onClose }: AlbumPickerPopupProps) {
                     ].join(" ")}
                   >
                     <span className="flex min-w-0 items-center gap-2">
-                      <IconAlbum className="h-3.5 w-3.5 shrink-0 text-lr-text-dim" />
+                      <IconAlbum
+                        className={[
+                          "h-3.5 w-3.5 shrink-0",
+                          isActive ? "text-lr-text-muted" : "text-lr-text-dim",
+                        ].join(" ")}
+                      />
                       <span className="truncate">{label}</span>
                     </span>
                     {count !== null ? (
-                      <span className="shrink-0 text-lr-text-dim">{count}</span>
+                      <span
+                        className={[
+                          "shrink-0",
+                          isActive ? "text-lr-text-muted" : "text-lr-text-dim",
+                        ].join(" ")}
+                      >
+                        {count}
+                      </span>
                     ) : null}
                   </button>
                 </li>

--- a/components/library/AlbumPickerPopup.tsx
+++ b/components/library/AlbumPickerPopup.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { IconAlbum } from "@/components/shell/icons";
+import type { Album } from "@/lib/catalog/types";
+import { rankByFuzzyScore } from "@/lib/library/fuzzy-match";
+import { useLibraryStore } from "@/stores/library-store";
+
+interface AlbumPickerPopupProps {
+  entryIds: string[];
+  onClose: () => void;
+}
+
+type PickerRow =
+  | { kind: "album"; album: Album }
+  | { kind: "create"; name: string };
+
+export function AlbumPickerPopup({ entryIds, onClose }: AlbumPickerPopupProps) {
+  const albums = useLibraryStore((state) => state.albums);
+  const createAlbum = useLibraryStore((state) => state.createAlbum);
+  const addEntriesToAlbum = useLibraryStore((state) => state.addEntriesToAlbum);
+
+  const [query, setQuery] = useState("");
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const rows = useMemo(() => {
+    const trimmed = query.trim();
+    const matched = rankByFuzzyScore(albums, query, (album) => album.name);
+    const result: PickerRow[] = matched.map((album) => ({
+      kind: "album",
+      album,
+    }));
+
+    const exactMatch = albums.some(
+      (album) => album.name.toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (trimmed && !exactMatch) {
+      result.push({ kind: "create", name: trimmed });
+    }
+
+    if (result.length === 0 && !trimmed) {
+      result.push({ kind: "create", name: "New album" });
+    }
+
+    return result;
+  }, [albums, query]);
+
+  useEffect(() => {
+    setHighlightIndex(0);
+  }, [query, rows.length]);
+
+  const confirmRow = useCallback(
+    (row: PickerRow) => {
+      if (row.kind === "album") {
+        addEntriesToAlbum(row.album.id, entryIds);
+        onClose();
+        return;
+      }
+
+      const albumId = createAlbum(row.name);
+      if (albumId) {
+        addEntriesToAlbum(albumId, entryIds);
+      }
+      onClose();
+    },
+    [addEntriesToAlbum, createAlbum, entryIds, onClose],
+  );
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const highlighted = listRef.current?.children[highlightIndex] as
+      | HTMLElement
+      | undefined;
+    highlighted?.scrollIntoView({ block: "nearest" });
+  }, [highlightIndex]);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setHighlightIndex((index) =>
+          rows.length === 0 ? 0 : Math.min(index + 1, rows.length - 1),
+        );
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setHighlightIndex((index) => Math.max(index - 1, 0));
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        const row = rows[highlightIndex];
+        if (row) {
+          confirmRow(row);
+        }
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [confirmRow, highlightIndex, onClose, rows]);
+
+  const photoLabel =
+    entryIds.length === 1 ? "1 photo" : `${entryIds.length} photos`;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[18vh]"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        className="w-80 overflow-hidden rounded-lg border border-lr-border bg-lr-panel shadow-xl"
+        role="dialog"
+        aria-label="Add to album"
+      >
+        <div className="border-b border-lr-border-subtle px-3 py-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-lr-text-dim">
+            Add to album
+          </p>
+          <p className="text-[11px] text-lr-text-dim">{photoLabel}</p>
+        </div>
+
+        <div className="border-b border-lr-border-subtle p-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search albums…"
+            className="w-full rounded border border-lr-border-subtle bg-lr-panel-raised px-2.5 py-1.5 text-sm text-lr-text outline-none focus:border-lr-accent"
+          />
+        </div>
+
+        <ul
+          ref={listRef}
+          className="max-h-56 overflow-auto py-1"
+          role="listbox"
+        >
+          {rows.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-lr-text-dim">
+              No matching albums
+            </li>
+          ) : (
+            rows.map((row, index) => {
+              const isActive = index === highlightIndex;
+              const label =
+                row.kind === "album"
+                  ? row.album.name
+                  : `Create "${row.name}"`;
+              const count =
+                row.kind === "album" ? row.album.entryIds.length : null;
+
+              return (
+                <li key={row.kind === "album" ? row.album.id : `create-${row.name}`}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isActive}
+                    onMouseEnter={() => setHighlightIndex(index)}
+                    onClick={() => confirmRow(row)}
+                    className={[
+                      "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-xs transition",
+                      isActive
+                        ? "bg-lr-selection text-lr-text"
+                        : "text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text",
+                    ].join(" ")}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <IconAlbum className="h-3.5 w-3.5 shrink-0 text-lr-text-dim" />
+                      <span className="truncate">{label}</span>
+                    </span>
+                    {count !== null ? (
+                      <span className="shrink-0 text-lr-text-dim">{count}</span>
+                    ) : null}
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+
+        <div className="border-t border-lr-border-subtle px-3 py-1.5 text-[10px] text-lr-text-dim">
+          ↑↓ navigate · Enter confirm · Esc cancel
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/components/library/DeleteAlbumConfirm.tsx
+++ b/components/library/DeleteAlbumConfirm.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import type { Album } from "@/lib/catalog/types";
+
+interface DeleteAlbumConfirmProps {
+  album: Album;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function DeleteAlbumConfirm({
+  album,
+  onConfirm,
+  onClose,
+}: DeleteAlbumConfirmProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        onConfirm();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [onConfirm, onClose]);
+
+  const photoLabel =
+    album.entryIds.length === 1
+      ? "1 photo"
+      : `${album.entryIds.length} photos`;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[18vh]"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="w-80 overflow-hidden rounded-lg border border-lr-border bg-lr-panel shadow-xl outline-none"
+        role="alertdialog"
+        aria-label={`Delete album ${album.name}`}
+      >
+        <div className="px-3 py-3">
+          <p className="text-sm text-lr-text">
+            Delete &ldquo;{album.name}&rdquo;?
+          </p>
+          <p className="mt-1.5 text-xs text-lr-text-dim">
+            {photoLabel} will stay in your library. Only the album is removed.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-lr-border-subtle px-3 py-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2.5 py-1 text-xs text-lr-text-muted transition hover:bg-lr-panel-raised hover:text-lr-text"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded bg-red-500/20 px-2.5 py-1 text-xs text-red-400 transition hover:bg-red-500/30"
+          >
+            Delete album
+          </button>
+        </div>
+
+        <div className="border-t border-lr-border-subtle px-3 py-1.5 text-[10px] text-lr-text-dim">
+          Enter confirm · Esc cancel
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/components/library/DeleteFromDiskConfirm.tsx
+++ b/components/library/DeleteFromDiskConfirm.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+interface DeleteFromDiskConfirmProps {
+  entryIds: string[];
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function DeleteFromDiskConfirm({
+  entryIds,
+  onConfirm,
+  onClose,
+}: DeleteFromDiskConfirmProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        onConfirm();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [onConfirm, onClose]);
+
+  const photoLabel =
+    entryIds.length === 1 ? "1 photo" : `${entryIds.length} photos`;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[60] flex items-start justify-center bg-black/60 pt-[18vh]"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="w-80 overflow-hidden rounded-lg border border-red-500/30 bg-lr-panel shadow-xl outline-none"
+        role="alertdialog"
+        aria-label="Remove photos from disk"
+      >
+        <div className="border-b border-lr-border-subtle px-3 py-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-red-400">
+            Remove from disk
+          </p>
+          <p className="text-[11px] text-lr-text-dim">{photoLabel}</p>
+        </div>
+
+        <div className="px-3 py-3">
+          <p className="text-sm text-lr-text">
+            Remove {entryIds.length === 1 ? "this file" : "these files"} from
+            disk?
+          </p>
+          <p className="mt-1.5 text-xs text-lr-text-dim">
+            Files will be moved to the system trash (Recycle Bin or Trash) and
+            removed from your library. You can restore them from the system
+            trash if needed.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-lr-border-subtle px-3 py-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2.5 py-1 text-xs text-lr-text-muted transition hover:bg-lr-panel-raised hover:text-lr-text"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded bg-red-500/20 px-2.5 py-1 text-xs text-red-400 transition hover:bg-red-500/30"
+          >
+            Remove from disk
+          </button>
+        </div>
+
+        <div className="border-t border-lr-border-subtle px-3 py-1.5 text-[10px] text-lr-text-dim">
+          Enter confirm · Esc cancel
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/components/library/DynamicPhotoGrid.tsx
+++ b/components/library/DynamicPhotoGrid.tsx
@@ -7,6 +7,7 @@ import { getEntryMetadata } from "@/lib/catalog/defaults";
 import { packDynamicRows } from "@/lib/library/grid-layout";
 import { collectVisibleEntryIds } from "@/lib/library/visible-entry-ids";
 import { useGridContainerWidth } from "@/hooks/useGridContainerWidth";
+import { useScrollToSelectedRow } from "@/hooks/useScrollToSelectedRow";
 import { useLibraryStore } from "@/stores/library-store";
 import { PhotoTile } from "./PhotoTile";
 import { useEntryAspectRatios } from "./useEntryAspectRatios";
@@ -68,8 +69,6 @@ export function DynamicPhotoGrid({
     estimateSize: (index) => (rows[index]?.height ?? rowHeight) + ROW_GAP,
     overscan: 4,
   });
-  const virtualizerRef = useRef(virtualizer);
-  virtualizerRef.current = virtualizer;
 
   const layoutReady = containerWidth > 0 && rows.length > 0;
 
@@ -95,13 +94,11 @@ export function DynamicPhotoGrid({
     );
   }, [rows, selectedEntryId]);
 
-  useEffect(() => {
-    if (!layoutReady || selectedRowIndex < 0) {
-      return;
-    }
-
-    virtualizerRef.current.scrollToIndex(selectedRowIndex, { align: "auto" });
-  }, [layoutReady, selectedRowIndex]);
+  useScrollToSelectedRow({
+    layoutReady,
+    selectedRowIndex,
+    virtualizer,
+  });
 
   const visibleRows = useMemo(
     () =>

--- a/components/library/DynamicPhotoGrid.tsx
+++ b/components/library/DynamicPhotoGrid.tsx
@@ -3,6 +3,7 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
+import { getEntryMetadata } from "@/lib/catalog/defaults";
 import { measureContentWidth, packDynamicRows } from "@/lib/library/grid-layout";
 import { collectVisibleEntryIds } from "@/lib/library/visible-entry-ids";
 import { useLibraryStore } from "@/stores/library-store";
@@ -22,6 +23,7 @@ export function DynamicPhotoGrid({ entries, rowHeight }: DynamicPhotoGridProps) 
   const didScrollToSelectedRef = useRef(false);
   const [containerWidth, setContainerWidth] = useState(0);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
+  const entryMetadata = useLibraryStore((state) => state.entryMetadata);
   const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
   const [visibleEntryIds, setVisibleEntryIds] = useState<string[]>([]);
   const getScrollRoot = useCallback(() => parentRef.current, []);
@@ -189,6 +191,7 @@ export function DynamicPhotoGrid({ entries, rowHeight }: DynamicPhotoGridProps) 
                     height={tile.height}
                     fit="cover"
                     selected={tile.entry.id === selectedEntryId}
+                    metadata={getEntryMetadata(entryMetadata, tile.entry.id)}
                     onSelect={setSelectedEntryId}
                     getScrollRoot={getScrollRoot}
                   />

--- a/components/library/DynamicPhotoGrid.tsx
+++ b/components/library/DynamicPhotoGrid.tsx
@@ -13,14 +13,18 @@ import { useEntryAspectRatios } from "./useEntryAspectRatios";
 interface DynamicPhotoGridProps {
   entries: LibraryEntry[];
   rowHeight: number;
+  onGridRowsChange?: (rows: string[][]) => void;
 }
 
 const ROW_GAP = 4;
 const TILE_GAP = 2;
 
-export function DynamicPhotoGrid({ entries, rowHeight }: DynamicPhotoGridProps) {
+export function DynamicPhotoGrid({
+  entries,
+  rowHeight,
+  onGridRowsChange,
+}: DynamicPhotoGridProps) {
   const parentRef = useRef<HTMLDivElement>(null);
-  const didScrollToSelectedRef = useRef(false);
   const [containerWidth, setContainerWidth] = useState(0);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
   const entryMetadata = useLibraryStore((state) => state.entryMetadata);
@@ -71,6 +75,20 @@ export function DynamicPhotoGrid({ entries, rowHeight }: DynamicPhotoGridProps) 
   });
 
   const layoutReady = containerWidth > 0 && rows.length > 0;
+
+  useEffect(() => {
+    if (!onGridRowsChange) {
+      return;
+    }
+    if (!layoutReady) {
+      onGridRowsChange([]);
+      return;
+    }
+    onGridRowsChange(
+      rows.map((row) => row.tiles.map((tile) => tile.entry.id)),
+    );
+  }, [rows, layoutReady, onGridRowsChange]);
+
   const selectedRowIndex = useMemo(() => {
     if (!selectedEntryId) {
       return -1;
@@ -82,16 +100,11 @@ export function DynamicPhotoGrid({ entries, rowHeight }: DynamicPhotoGridProps) 
   }, [rows, selectedEntryId]);
 
   useEffect(() => {
-    if (
-      !layoutReady ||
-      didScrollToSelectedRef.current ||
-      selectedRowIndex < 0
-    ) {
+    if (!layoutReady || selectedRowIndex < 0) {
       return;
     }
 
-    didScrollToSelectedRef.current = true;
-    virtualizer.scrollToIndex(selectedRowIndex, { align: "center" });
+    virtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
   }, [layoutReady, selectedRowIndex, virtualizer]);
 
   const visibleRows = useMemo(

--- a/components/library/DynamicPhotoGrid.tsx
+++ b/components/library/DynamicPhotoGrid.tsx
@@ -4,8 +4,9 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
 import { getEntryMetadata } from "@/lib/catalog/defaults";
-import { measureContentWidth, packDynamicRows } from "@/lib/library/grid-layout";
+import { packDynamicRows } from "@/lib/library/grid-layout";
 import { collectVisibleEntryIds } from "@/lib/library/visible-entry-ids";
+import { useGridContainerWidth } from "@/hooks/useGridContainerWidth";
 import { useLibraryStore } from "@/stores/library-store";
 import { PhotoTile } from "./PhotoTile";
 import { useEntryAspectRatios } from "./useEntryAspectRatios";
@@ -14,6 +15,7 @@ interface DynamicPhotoGridProps {
   entries: LibraryEntry[];
   rowHeight: number;
   onGridRowsChange?: (rows: string[][]) => void;
+  onPhotoContextMenu?: (entryId: string, event: React.MouseEvent) => void;
 }
 
 const ROW_GAP = 4;
@@ -23,14 +25,28 @@ export function DynamicPhotoGrid({
   entries,
   rowHeight,
   onGridRowsChange,
+  onPhotoContextMenu,
 }: DynamicPhotoGridProps) {
   const parentRef = useRef<HTMLDivElement>(null);
-  const [containerWidth, setContainerWidth] = useState(0);
+  const containerWidth = useGridContainerWidth(parentRef, entries);
+  const selectedEntryIds = useLibraryStore((state) => state.selectedEntryIds);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
   const entryMetadata = useLibraryStore((state) => state.entryMetadata);
-  const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
+  const selectEntry = useLibraryStore((state) => state.selectEntry);
   const [visibleEntryIds, setVisibleEntryIds] = useState<string[]>([]);
   const getScrollRoot = useCallback(() => parentRef.current, []);
+
+  const visibleOrder = useMemo(
+    () => entries.map((entry) => entry.id),
+    [entries],
+  );
+
+  const handleSelect = useCallback(
+    (entryId: string, modifiers: { shift?: boolean; toggle?: boolean }) => {
+      selectEntry(entryId, modifiers, visibleOrder);
+    },
+    [selectEntry, visibleOrder],
+  );
 
   const { aspectRatios } = useEntryAspectRatios(entries, visibleEntryIds);
 
@@ -46,33 +62,14 @@ export function DynamicPhotoGrid({
     [entries, aspectRatios, containerWidth, rowHeight],
   );
 
-  useLayoutEffect(() => {
-    const element = parentRef.current;
-    if (element) {
-      setContainerWidth(measureContentWidth(element));
-    }
-  }, []);
-
-  useEffect(() => {
-    const element = parentRef.current;
-    if (!element) {
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      setContainerWidth(measureContentWidth(element));
-    });
-    observer.observe(element);
-
-    return () => observer.disconnect();
-  }, []);
-
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => parentRef.current,
     estimateSize: (index) => (rows[index]?.height ?? rowHeight) + ROW_GAP,
     overscan: 4,
   });
+  const virtualizerRef = useRef(virtualizer);
+  virtualizerRef.current = virtualizer;
 
   const layoutReady = containerWidth > 0 && rows.length > 0;
 
@@ -81,7 +78,6 @@ export function DynamicPhotoGrid({
       return;
     }
     if (!layoutReady) {
-      onGridRowsChange([]);
       return;
     }
     onGridRowsChange(
@@ -104,8 +100,8 @@ export function DynamicPhotoGrid({
       return;
     }
 
-    virtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
-  }, [layoutReady, selectedRowIndex, virtualizer]);
+    virtualizerRef.current.scrollToIndex(selectedRowIndex, { align: "auto" });
+  }, [layoutReady, selectedRowIndex]);
 
   const visibleRows = useMemo(
     () =>
@@ -168,6 +164,14 @@ export function DynamicPhotoGrid({
     setVisibleEntryIds(next);
   }, [layoutReady, visibleRows, selectedEntryId, virtualizer]);
 
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-center text-xs text-lr-text-dim">
+        No photos match the current filters
+      </div>
+    );
+  }
+
   return (
     <div ref={parentRef} className="h-full overflow-auto p-1">
       {!layoutReady ? (
@@ -203,9 +207,10 @@ export function DynamicPhotoGrid({
                     width={tile.width}
                     height={tile.height}
                     fit="cover"
-                    selected={tile.entry.id === selectedEntryId}
+                    selected={selectedEntryIds.includes(tile.entry.id)}
                     metadata={getEntryMetadata(entryMetadata, tile.entry.id)}
-                    onSelect={setSelectedEntryId}
+                    onSelect={handleSelect}
+                    onContextMenu={onPhotoContextMenu}
                     getScrollRoot={getScrollRoot}
                   />
                 ))}

--- a/components/library/EntryMetadataBar.tsx
+++ b/components/library/EntryMetadataBar.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  COLOR_LABEL_HEX,
+  getEntryMetadata,
+} from "@/lib/catalog/defaults";
+import type { EntryMetadata } from "@/lib/catalog/types";
+import { COLOR_LABELS } from "@/lib/catalog/types";
+import { StarRatingControl } from "@/components/library/StarRatingControl";
+import { useLibraryStore } from "@/stores/library-store";
+
+interface EntryMetadataBadgesProps {
+  metadata: EntryMetadata;
+}
+
+export function EntryMetadataBadges({
+  metadata,
+}: EntryMetadataBadgesProps) {
+  const { pick, colorLabel } = metadata;
+  const showPick = pick === "pick";
+
+  return (
+    <>
+      {colorLabel ? (
+        <div
+          className="pointer-events-none absolute bottom-0 left-0 top-0 w-1"
+          style={{ backgroundColor: COLOR_LABEL_HEX[colorLabel] }}
+        />
+      ) : null}
+
+      {showPick ? (
+        <div className="pointer-events-none absolute right-0 top-0 h-0 w-0 border-l-[10px] border-t-[10px] border-l-transparent border-t-white/90" />
+      ) : null}
+    </>
+  );
+}
+
+interface EntryMetadataBarProps {
+  entryId: string;
+  metadata: EntryMetadata;
+  onPick: () => void;
+  onReject: () => void;
+  onClearPick: () => void;
+  onRating: (rating: EntryMetadata["rating"]) => void;
+  onColorLabel: (label: (typeof COLOR_LABELS)[number]) => void;
+}
+
+export function EntryMetadataBar({
+  metadata,
+  onPick,
+  onReject,
+  onClearPick,
+  onRating,
+  onColorLabel,
+}: EntryMetadataBarProps) {
+  return (
+    <div className="flex h-9 shrink-0 items-center gap-3 border-b border-lr-border-subtle bg-lr-panel px-3">
+      <div className="flex items-center gap-1">
+        <MetadataButton
+          active={metadata.pick === "pick"}
+          onClick={onPick}
+          title="Pick (P)"
+        >
+          <span className="text-[11px]">Pick</span>
+        </MetadataButton>
+        <MetadataButton
+          active={metadata.pick === "reject"}
+          onClick={onReject}
+          title="Reject (X)"
+        >
+          <span className="text-[11px]">Reject</span>
+        </MetadataButton>
+        <MetadataButton
+          active={metadata.pick === "none"}
+          onClick={onClearPick}
+          title="Clear pick (U)"
+        >
+          <span className="text-[11px]">Unflagged</span>
+        </MetadataButton>
+      </div>
+
+      <div className="h-4 w-px bg-lr-border-subtle" />
+
+      <StarRatingControl
+        value={metadata.rating}
+        onChange={onRating}
+      />
+
+      <div className="h-4 w-px bg-lr-border-subtle" />
+
+      <div className="flex items-center gap-1.5">
+        {COLOR_LABELS.map((label) => (
+          <button
+            key={label}
+            type="button"
+            onClick={() => onColorLabel(label)}
+            title={`${label} label`}
+            className={[
+              "h-3.5 w-3.5 rounded-full border transition",
+              metadata.colorLabel === label
+                ? "border-white/80 ring-1 ring-white/40"
+                : "border-transparent opacity-70 hover:opacity-100",
+            ].join(" ")}
+            style={{ backgroundColor: COLOR_LABEL_HEX[label] }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MetadataButton({
+  active,
+  onClick,
+  title,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={[
+        "rounded px-2 py-1 transition",
+        active
+          ? "bg-lr-selection text-lr-text"
+          : "text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text",
+      ].join(" ")}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function useEntryMetadataForId(entryId: string): EntryMetadata {
+  const entryMetadata = useLibraryStore((state) => state.entryMetadata);
+  return getEntryMetadata(entryMetadata, entryId);
+}

--- a/components/library/PhotoGrid.tsx
+++ b/components/library/PhotoGrid.tsx
@@ -2,6 +2,7 @@
 
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useScrollToSelectedRow } from "@/hooks/useScrollToSelectedRow";
 import type { LibraryEntry } from "@/lib/fs/types";
 import { getEntryMetadata } from "@/lib/catalog/defaults";
 import { packSquareRows } from "@/lib/library/grid-layout";
@@ -51,8 +52,6 @@ export function PhotoGrid({ entries, thumbSize, onGridRowsChange, onPhotoContext
     estimateSize: (index) => (rows[index]?.cellSize ?? thumbSize) + ROW_GAP,
     overscan: 6,
   });
-  const virtualizerRef = useRef(virtualizer);
-  virtualizerRef.current = virtualizer;
 
   const layoutReady = containerWidth > 0 && rows.length > 0;
 
@@ -76,13 +75,11 @@ export function PhotoGrid({ entries, thumbSize, onGridRowsChange, onPhotoContext
     );
   }, [rows, selectedEntryId]);
 
-  useEffect(() => {
-    if (!layoutReady || selectedRowIndex < 0) {
-      return;
-    }
-
-    virtualizerRef.current.scrollToIndex(selectedRowIndex, { align: "auto" });
-  }, [layoutReady, selectedRowIndex]);
+  useScrollToSelectedRow({
+    layoutReady,
+    selectedRowIndex,
+    virtualizer,
+  });
 
   if (entries.length === 0) {
     return (

--- a/components/library/PhotoGrid.tsx
+++ b/components/library/PhotoGrid.tsx
@@ -11,14 +11,14 @@ import { PhotoTile } from "./PhotoTile";
 interface PhotoGridProps {
   entries: LibraryEntry[];
   thumbSize: number;
+  onGridRowsChange?: (rows: string[][]) => void;
 }
 
 const ROW_GAP = 4;
 const TILE_GAP = 2;
 
-export function PhotoGrid({ entries, thumbSize }: PhotoGridProps) {
+export function PhotoGrid({ entries, thumbSize, onGridRowsChange }: PhotoGridProps) {
   const parentRef = useRef<HTMLDivElement>(null);
-  const didScrollToSelectedRef = useRef(false);
   const [containerWidth, setContainerWidth] = useState(0);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
   const entryMetadata = useLibraryStore((state) => state.entryMetadata);
@@ -59,6 +59,18 @@ export function PhotoGrid({ entries, thumbSize }: PhotoGridProps) {
   });
 
   const layoutReady = containerWidth > 0 && rows.length > 0;
+
+  useEffect(() => {
+    if (!onGridRowsChange) {
+      return;
+    }
+    if (!layoutReady) {
+      onGridRowsChange([]);
+      return;
+    }
+    onGridRowsChange(rows.map((row) => row.entries.map((entry) => entry.id)));
+  }, [rows, layoutReady, onGridRowsChange]);
+
   const selectedRowIndex = useMemo(() => {
     if (!selectedEntryId) {
       return -1;
@@ -70,16 +82,11 @@ export function PhotoGrid({ entries, thumbSize }: PhotoGridProps) {
   }, [rows, selectedEntryId]);
 
   useEffect(() => {
-    if (
-      !layoutReady ||
-      didScrollToSelectedRef.current ||
-      selectedRowIndex < 0
-    ) {
+    if (!layoutReady || selectedRowIndex < 0) {
       return;
     }
 
-    didScrollToSelectedRef.current = true;
-    virtualizer.scrollToIndex(selectedRowIndex, { align: "center" });
+    virtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
   }, [layoutReady, selectedRowIndex, virtualizer]);
 
   return (

--- a/components/library/PhotoGrid.tsx
+++ b/components/library/PhotoGrid.tsx
@@ -3,6 +3,7 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
+import { getEntryMetadata } from "@/lib/catalog/defaults";
 import { measureContentWidth, packSquareRows } from "@/lib/library/grid-layout";
 import { useLibraryStore } from "@/stores/library-store";
 import { PhotoTile } from "./PhotoTile";
@@ -20,6 +21,7 @@ export function PhotoGrid({ entries, thumbSize }: PhotoGridProps) {
   const didScrollToSelectedRef = useRef(false);
   const [containerWidth, setContainerWidth] = useState(0);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
+  const entryMetadata = useLibraryStore((state) => state.entryMetadata);
   const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
   const getScrollRoot = useCallback(() => parentRef.current, []);
 
@@ -116,6 +118,7 @@ export function PhotoGrid({ entries, thumbSize }: PhotoGridProps) {
                     height={row.cellSize}
                     fit="contain"
                     selected={entry.id === selectedEntryId}
+                    metadata={getEntryMetadata(entryMetadata, entry.id)}
                     onSelect={setSelectedEntryId}
                     getScrollRoot={getScrollRoot}
                   />

--- a/components/library/PhotoGrid.tsx
+++ b/components/library/PhotoGrid.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
 import { getEntryMetadata } from "@/lib/catalog/defaults";
-import { measureContentWidth, packSquareRows } from "@/lib/library/grid-layout";
+import { packSquareRows } from "@/lib/library/grid-layout";
+import { useGridContainerWidth } from "@/hooks/useGridContainerWidth";
 import { useLibraryStore } from "@/stores/library-store";
 import { PhotoTile } from "./PhotoTile";
 
@@ -12,44 +13,37 @@ interface PhotoGridProps {
   entries: LibraryEntry[];
   thumbSize: number;
   onGridRowsChange?: (rows: string[][]) => void;
+  onPhotoContextMenu?: (entryId: string, event: React.MouseEvent) => void;
 }
 
 const ROW_GAP = 4;
 const TILE_GAP = 2;
 
-export function PhotoGrid({ entries, thumbSize, onGridRowsChange }: PhotoGridProps) {
+export function PhotoGrid({ entries, thumbSize, onGridRowsChange, onPhotoContextMenu }: PhotoGridProps) {
   const parentRef = useRef<HTMLDivElement>(null);
-  const [containerWidth, setContainerWidth] = useState(0);
+  const containerWidth = useGridContainerWidth(parentRef, entries);
+  const selectedEntryIds = useLibraryStore((state) => state.selectedEntryIds);
   const selectedEntryId = useLibraryStore((state) => state.selectedEntryId);
   const entryMetadata = useLibraryStore((state) => state.entryMetadata);
-  const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
+  const selectEntry = useLibraryStore((state) => state.selectEntry);
   const getScrollRoot = useCallback(() => parentRef.current, []);
+
+  const visibleOrder = useMemo(
+    () => entries.map((entry) => entry.id),
+    [entries],
+  );
+
+  const handleSelect = useCallback(
+    (entryId: string, modifiers: { shift?: boolean; toggle?: boolean }) => {
+      selectEntry(entryId, modifiers, visibleOrder);
+    },
+    [selectEntry, visibleOrder],
+  );
 
   const { rows } = useMemo(
     () => packSquareRows(entries, containerWidth, thumbSize, TILE_GAP),
     [entries, containerWidth, thumbSize],
   );
-
-  useLayoutEffect(() => {
-    const element = parentRef.current;
-    if (element) {
-      setContainerWidth(measureContentWidth(element));
-    }
-  }, []);
-
-  useEffect(() => {
-    const element = parentRef.current;
-    if (!element) {
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      setContainerWidth(measureContentWidth(element));
-    });
-    observer.observe(element);
-
-    return () => observer.disconnect();
-  }, []);
 
   const virtualizer = useVirtualizer({
     count: rows.length,
@@ -57,6 +51,8 @@ export function PhotoGrid({ entries, thumbSize, onGridRowsChange }: PhotoGridPro
     estimateSize: (index) => (rows[index]?.cellSize ?? thumbSize) + ROW_GAP,
     overscan: 6,
   });
+  const virtualizerRef = useRef(virtualizer);
+  virtualizerRef.current = virtualizer;
 
   const layoutReady = containerWidth > 0 && rows.length > 0;
 
@@ -65,7 +61,6 @@ export function PhotoGrid({ entries, thumbSize, onGridRowsChange }: PhotoGridPro
       return;
     }
     if (!layoutReady) {
-      onGridRowsChange([]);
       return;
     }
     onGridRowsChange(rows.map((row) => row.entries.map((entry) => entry.id)));
@@ -86,8 +81,16 @@ export function PhotoGrid({ entries, thumbSize, onGridRowsChange }: PhotoGridPro
       return;
     }
 
-    virtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
-  }, [layoutReady, selectedRowIndex, virtualizer]);
+    virtualizerRef.current.scrollToIndex(selectedRowIndex, { align: "auto" });
+  }, [layoutReady, selectedRowIndex]);
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-center text-xs text-lr-text-dim">
+        No photos match the current filters
+      </div>
+    );
+  }
 
   return (
     <div ref={parentRef} className="h-full overflow-auto p-1">
@@ -124,9 +127,10 @@ export function PhotoGrid({ entries, thumbSize, onGridRowsChange }: PhotoGridPro
                     width={row.cellSize}
                     height={row.cellSize}
                     fit="contain"
-                    selected={entry.id === selectedEntryId}
+                    selected={selectedEntryIds.includes(entry.id)}
                     metadata={getEntryMetadata(entryMetadata, entry.id)}
-                    onSelect={setSelectedEntryId}
+                    onSelect={handleSelect}
+                    onContextMenu={onPhotoContextMenu}
                     getScrollRoot={getScrollRoot}
                   />
                 ))}

--- a/components/library/PhotoTile.tsx
+++ b/components/library/PhotoTile.tsx
@@ -154,10 +154,10 @@ export const PhotoTile = memo(function PhotoTile({
     <div
       ref={tileRef}
       className={[
-        "group relative shrink-0 overflow-hidden bg-[#141414]",
+        "group relative shrink-0 overflow-hidden border-2 bg-[#141414]",
         selected
-          ? "ring-2 ring-lr-accent ring-offset-1 ring-offset-lr-bg"
-          : "hover:ring-1 hover:ring-lr-border",
+          ? "border-lr-accent"
+          : "border-transparent hover:border-lr-border",
         compact ? "" : "transition-shadow duration-100 ease-out",
       ].join(" ")}
       style={{ width, height }}

--- a/components/library/PhotoTile.tsx
+++ b/components/library/PhotoTile.tsx
@@ -158,7 +158,7 @@ export const PhotoTile = memo(function PhotoTile({
         selected
           ? "ring-2 ring-lr-accent ring-offset-1 ring-offset-lr-bg"
           : "hover:ring-1 hover:ring-lr-border",
-        compact ? "" : "transition-shadow",
+        compact ? "" : "transition-shadow duration-100 ease-out",
       ].join(" ")}
       style={{ width, height }}
     >

--- a/components/library/PhotoTile.tsx
+++ b/components/library/PhotoTile.tsx
@@ -45,11 +45,7 @@ export const PhotoTile = memo(function PhotoTile({
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [isNearViewport, setIsNearViewport] = useState(false);
   const [intersectionRatio, setIntersectionRatio] = useState(0);
-  const selectedRef = useRef(selected);
-  const intersectionRatioRef = useRef(intersectionRatio);
   const objectUrlRef = useRef<string | null>(null);
-  selectedRef.current = selected;
-  intersectionRatioRef.current = intersectionRatio;
   const decodeEdge = Math.max(width, height, MIN_THUMBNAIL_EDGE);
 
   useEffect(() => {
@@ -110,10 +106,10 @@ export const PhotoTile = memo(function PhotoTile({
     let active = true;
     const controller = new AbortController();
 
-    const loadPriority = selectedRef.current
+    const loadPriority = selected
       ? 30
-      : intersectionRatioRef.current >= 0.5
-        ? 20 + Math.round(intersectionRatioRef.current * 5)
+      : intersectionRatio >= 0.5
+        ? 20 + Math.round(intersectionRatio * 5)
         : 12;
 
     async function loadThumbnail() {
@@ -145,7 +141,7 @@ export const PhotoTile = memo(function PhotoTile({
       active = false;
       controller.abort();
     };
-  }, [entry, decodeEdge, isNearViewport]);
+  }, [entry, decodeEdge, isNearViewport, selected, intersectionRatio]);
 
   const imageFit = compact ? "object-cover" : `object-${fit}`;
   const isRejected = metadata?.pick === "reject";

--- a/components/library/PhotoTile.tsx
+++ b/components/library/PhotoTile.tsx
@@ -122,6 +122,9 @@ export const PhotoTile = memo(function PhotoTile({
           return;
         }
 
+        if (objectUrlRef.current) {
+          URL.revokeObjectURL(objectUrlRef.current);
+        }
         objectUrlRef.current = createThumbnailObjectUrl(blob);
         setThumbnailUrl(objectUrlRef.current);
         setStatus("ready");

--- a/components/library/PhotoTile.tsx
+++ b/components/library/PhotoTile.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { memo, useEffect, useRef, useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
 import type { EntryMetadata } from "@/lib/catalog/types";
+import type { SelectEntryModifiers } from "@/stores/library-store";
 import {
   createThumbnailObjectUrl,
   loadThumbnailBlob,
@@ -19,7 +20,8 @@ interface PhotoTileProps {
   compact?: boolean;
   fit?: "contain" | "cover";
   metadata?: EntryMetadata;
-  onSelect?: (entryId: string) => void;
+  onSelect?: (entryId: string, modifiers: SelectEntryModifiers) => void;
+  onContextMenu?: (entryId: string, event: React.MouseEvent) => void;
   getScrollRoot?: () => HTMLElement | null;
 }
 
@@ -34,6 +36,7 @@ export const PhotoTile = memo(function PhotoTile({
   fit = "contain",
   metadata,
   onSelect,
+  onContextMenu,
   getScrollRoot,
 }: PhotoTileProps) {
   const router = useRouter();
@@ -192,10 +195,16 @@ export const PhotoTile = memo(function PhotoTile({
       <button
         type="button"
         className="block shrink-0 cursor-pointer border-0 bg-transparent p-0 text-left"
-        onClick={() => onSelect(entry.id)}
+        onClick={(event) =>
+          onSelect(entry.id, {
+            shift: event.shiftKey,
+            toggle: event.metaKey || event.ctrlKey,
+          })
+        }
         onDoubleClick={() =>
           router.push(`/photo?id=${encodeURIComponent(entry.id)}`)
         }
+        onContextMenu={(event) => onContextMenu?.(entry.id, event)}
       >
         {content}
       </button>

--- a/components/library/PhotoTile.tsx
+++ b/components/library/PhotoTile.tsx
@@ -45,7 +45,30 @@ export const PhotoTile = memo(function PhotoTile({
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [isNearViewport, setIsNearViewport] = useState(false);
   const [intersectionRatio, setIntersectionRatio] = useState(0);
+  const selectedRef = useRef(selected);
+  const intersectionRatioRef = useRef(intersectionRatio);
+  const objectUrlRef = useRef<string | null>(null);
+  selectedRef.current = selected;
+  intersectionRatioRef.current = intersectionRatio;
   const decodeEdge = Math.max(width, height, MIN_THUMBNAIL_EDGE);
+
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+    setThumbnailUrl(null);
+    setStatus("loading");
+  }, [entry.id, decodeEdge]);
 
   useEffect(() => {
     const element = tileRef.current;
@@ -80,23 +103,17 @@ export const PhotoTile = memo(function PhotoTile({
   }, [compact, getScrollRoot]);
 
   useEffect(() => {
-    let active = true;
-    let objectUrl: string | null = null;
-    const controller = new AbortController();
-    setThumbnailUrl(null);
-    setStatus("loading");
-
     if (!isNearViewport) {
-      return () => {
-        active = false;
-        controller.abort();
-      };
+      return;
     }
 
-    const loadPriority = selected
+    let active = true;
+    const controller = new AbortController();
+
+    const loadPriority = selectedRef.current
       ? 30
-      : intersectionRatio >= 0.5
-        ? 20 + Math.round(intersectionRatio * 5)
+      : intersectionRatioRef.current >= 0.5
+        ? 20 + Math.round(intersectionRatioRef.current * 5)
         : 12;
 
     async function loadThumbnail() {
@@ -109,8 +126,8 @@ export const PhotoTile = memo(function PhotoTile({
           return;
         }
 
-        objectUrl = createThumbnailObjectUrl(blob);
-        setThumbnailUrl(objectUrl);
+        objectUrlRef.current = createThumbnailObjectUrl(blob);
+        setThumbnailUrl(objectUrlRef.current);
         setStatus("ready");
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {
@@ -127,11 +144,8 @@ export const PhotoTile = memo(function PhotoTile({
     return () => {
       active = false;
       controller.abort();
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
     };
-  }, [entry, decodeEdge, isNearViewport, intersectionRatio, selected]);
+  }, [entry, decodeEdge, isNearViewport]);
 
   const imageFit = compact ? "object-cover" : `object-${fit}`;
   const isRejected = metadata?.pick === "reject";

--- a/components/library/PhotoTile.tsx
+++ b/components/library/PhotoTile.tsx
@@ -151,10 +151,7 @@ export const PhotoTile = memo(function PhotoTile({
           alt={entry.name}
           fill
           unoptimized
-          className={[
-            imageFit,
-            isRejected ? "grayscale opacity-45" : "",
-          ].join(" ")}
+          className={imageFit}
           sizes={`${width}px`}
         />
       ) : (
@@ -172,6 +169,10 @@ export const PhotoTile = memo(function PhotoTile({
             </p>
           ) : null}
         </div>
+      ) : null}
+
+      {isRejected ? (
+        <div className="pointer-events-none absolute inset-0 bg-black/50" />
       ) : null}
 
       {metadata ? <EntryMetadataBadges metadata={metadata} /> : null}

--- a/components/library/PhotoTile.tsx
+++ b/components/library/PhotoTile.tsx
@@ -4,10 +4,12 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { memo, useEffect, useRef, useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
+import type { EntryMetadata } from "@/lib/catalog/types";
 import {
   createThumbnailObjectUrl,
   loadThumbnailBlob,
 } from "@/lib/cache/thumbnail-cache";
+import { EntryMetadataBadges } from "./EntryMetadataBar";
 
 interface PhotoTileProps {
   entry: LibraryEntry;
@@ -16,6 +18,7 @@ interface PhotoTileProps {
   selected?: boolean;
   compact?: boolean;
   fit?: "contain" | "cover";
+  metadata?: EntryMetadata;
   onSelect?: (entryId: string) => void;
   getScrollRoot?: () => HTMLElement | null;
 }
@@ -29,6 +32,7 @@ export const PhotoTile = memo(function PhotoTile({
   selected = false,
   compact = false,
   fit = "contain",
+  metadata,
   onSelect,
   getScrollRoot,
 }: PhotoTileProps) {
@@ -127,6 +131,7 @@ export const PhotoTile = memo(function PhotoTile({
   }, [entry, decodeEdge, isNearViewport, intersectionRatio, selected]);
 
   const imageFit = compact ? "object-cover" : `object-${fit}`;
+  const isRejected = metadata?.pick === "reject";
 
   const content = (
     <div
@@ -146,7 +151,10 @@ export const PhotoTile = memo(function PhotoTile({
           alt={entry.name}
           fill
           unoptimized
-          className={imageFit}
+          className={[
+            imageFit,
+            isRejected ? "grayscale opacity-45" : "",
+          ].join(" ")}
           sizes={`${width}px`}
         />
       ) : (
@@ -165,6 +173,8 @@ export const PhotoTile = memo(function PhotoTile({
           ) : null}
         </div>
       ) : null}
+
+      {metadata ? <EntryMetadataBadges metadata={metadata} /> : null}
 
       {selected ? (
         <div className="absolute left-0 top-0 h-0 w-0 border-r-[10px] border-t-[10px] border-r-transparent border-t-lr-accent" />

--- a/components/library/RemovePhotosPopup.tsx
+++ b/components/library/RemovePhotosPopup.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { DeleteFromDiskConfirm } from "@/components/library/DeleteFromDiskConfirm";
+import {
+  IconAlbum,
+  IconArchive,
+  IconFolder,
+  IconTrash,
+} from "@/components/shell/icons";
+import { useLibraryStore } from "@/stores/library-store";
+
+interface RemovePhotosPopupProps {
+  entryIds: string[];
+  onClose: () => void;
+}
+
+type ActionOption = {
+  id: "album" | "imported" | "restore" | "disk";
+  label: string;
+  description: string;
+};
+
+export function RemovePhotosPopup({ entryIds, onClose }: RemovePhotosPopupProps) {
+  const albums = useLibraryStore((state) => state.albums);
+  const catalogView = useLibraryStore((state) => state.catalogView);
+  const removeEntriesFromAlbum = useLibraryStore(
+    (state) => state.removeEntriesFromAlbum,
+  );
+  const removeEntriesFromAllAlbums = useLibraryStore(
+    (state) => state.removeEntriesFromAllAlbums,
+  );
+  const archiveEntries = useLibraryStore((state) => state.archiveEntries);
+  const restoreEntries = useLibraryStore((state) => state.restoreEntries);
+  const deleteEntriesFromDisk = useLibraryStore(
+    (state) => state.deleteEntriesFromDisk,
+  );
+
+  const isArchiveView = catalogView.type === "archive";
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const [confirmDiskDelete, setConfirmDiskDelete] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const options = useMemo(() => {
+    if (isArchiveView) {
+      return [
+        {
+          id: "restore" as const,
+          label: "Restore to imported",
+          description: "Move back into your library.",
+        },
+        {
+          id: "disk" as const,
+          label: "Remove from disk",
+          description: "Remove files from your library.",
+        },
+      ];
+    }
+
+    const result: ActionOption[] = [];
+    const targetSet = new Set(entryIds);
+    const inAlbum =
+      catalogView.type === "album" ||
+      albums.some((album) => album.entryIds.some((id) => targetSet.has(id)));
+
+    if (inAlbum) {
+      if (catalogView.type === "album") {
+        const album = albums.find((item) => item.id === catalogView.albumId);
+        result.push({
+          id: "album",
+          label: `Remove from "${album?.name ?? "album"}"`,
+          description: "Photos stay in your imported library.",
+        });
+      } else {
+        result.push({
+          id: "album",
+          label: "Remove from all albums",
+          description: "Photos stay in your imported library.",
+        });
+      }
+    }
+
+    result.push({
+      id: "imported",
+      label: "Remove from imported",
+      description: "Move to archive. Files stay on disk.",
+    });
+    result.push({
+      id: "disk",
+      label: "Remove from disk",
+      description: "Remove files from your library.",
+    });
+
+    return result;
+  }, [albums, catalogView, entryIds, isArchiveView]);
+
+  useEffect(() => {
+    setHighlightIndex(0);
+  }, [options.length, isArchiveView]);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const highlighted = listRef.current?.children[highlightIndex] as
+      | HTMLElement
+      | undefined;
+    highlighted?.scrollIntoView({ block: "nearest" });
+  }, [highlightIndex]);
+
+  const runAction = useCallback(
+    async (option: ActionOption) => {
+      if (option.id === "album") {
+        if (catalogView.type === "album") {
+          removeEntriesFromAlbum(catalogView.albumId, entryIds);
+        } else {
+          removeEntriesFromAllAlbums(entryIds);
+        }
+        onClose();
+        return;
+      }
+
+      if (option.id === "imported") {
+        archiveEntries(entryIds);
+        onClose();
+        return;
+      }
+
+      if (option.id === "restore") {
+        restoreEntries(entryIds);
+        onClose();
+        return;
+      }
+
+      setConfirmDiskDelete(true);
+    },
+    [
+      archiveEntries,
+      catalogView,
+      entryIds,
+      onClose,
+      removeEntriesFromAlbum,
+      removeEntriesFromAllAlbums,
+      restoreEntries,
+    ],
+  );
+
+  useEffect(() => {
+    if (confirmDiskDelete) {
+      return;
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        event.stopPropagation();
+        setHighlightIndex((index) =>
+          options.length === 0 ? 0 : Math.min(index + 1, options.length - 1),
+        );
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        event.stopPropagation();
+        setHighlightIndex((index) => Math.max(index - 1, 0));
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        const option = options[highlightIndex];
+        if (option) {
+          void runAction(option);
+        }
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [confirmDiskDelete, highlightIndex, onClose, options, runAction]);
+
+  const photoLabel =
+    entryIds.length === 1 ? "1 photo" : `${entryIds.length} photos`;
+
+  function iconForOption(id: ActionOption["id"]) {
+    switch (id) {
+      case "album":
+        return IconAlbum;
+      case "imported":
+        return IconArchive;
+      case "restore":
+        return IconFolder;
+      case "disk":
+        return IconTrash;
+    }
+  }
+
+  return createPortal(
+    <>
+      <div
+        className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[18vh]"
+        onMouseDown={(event) => {
+          if (event.target === event.currentTarget && !confirmDiskDelete) {
+            onClose();
+          }
+        }}
+      >
+        <div
+          ref={dialogRef}
+          tabIndex={-1}
+          className="w-80 overflow-hidden rounded-lg border border-lr-border bg-lr-panel shadow-xl outline-none"
+          role="dialog"
+          aria-label={isArchiveView ? "Archive actions" : "Remove photos"}
+        >
+          <div className="border-b border-lr-border-subtle px-3 py-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-lr-text-dim">
+              {isArchiveView ? "Archive actions" : "Remove photos"}
+            </p>
+            <p className="text-[11px] text-lr-text-dim">{photoLabel}</p>
+          </div>
+
+          <ul ref={listRef} className="py-1" role="listbox">
+            {options.map((option, index) => {
+              const isActive = index === highlightIndex;
+              const Icon = iconForOption(option.id);
+              const isTrash = option.id === "disk";
+
+              return (
+                <li key={option.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isActive}
+                    onMouseEnter={() => setHighlightIndex(index)}
+                    onClick={() => void runAction(option)}
+                    className={[
+                      "flex w-full flex-col gap-0.5 px-3 py-2 text-left transition",
+                      isActive
+                        ? "bg-lr-selection text-lr-text"
+                        : "text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text",
+                    ].join(" ")}
+                  >
+                    <span className="flex items-center gap-2 text-xs">
+                      <Icon
+                        className={[
+                          "h-3.5 w-3.5 shrink-0",
+                          isTrash
+                            ? "text-red-400"
+                            : isActive
+                              ? "text-lr-text-muted"
+                              : "text-lr-text-dim",
+                        ].join(" ")}
+                      />
+                      <span className={isTrash ? "text-red-400" : ""}>
+                        {option.label}
+                      </span>
+                    </span>
+                    <span
+                      className={[
+                        "pl-5 text-[11px]",
+                        isActive
+                          ? isTrash
+                            ? "text-red-300"
+                            : "text-lr-text-muted"
+                          : isTrash
+                            ? "text-red-400/70"
+                            : "text-lr-text-dim",
+                      ].join(" ")}
+                    >
+                      {option.description}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <div className="border-t border-lr-border-subtle px-3 py-1.5 text-[10px] text-lr-text-dim">
+            ↑↓ navigate · Enter confirm · Esc cancel
+          </div>
+        </div>
+      </div>
+
+      {confirmDiskDelete ? (
+        <DeleteFromDiskConfirm
+          entryIds={entryIds}
+          onClose={() => {
+            setConfirmDiskDelete(false);
+            onClose();
+          }}
+          onConfirm={() => {
+            void deleteEntriesFromDisk(entryIds).then(() => {
+              setConfirmDiskDelete(false);
+              onClose();
+            });
+          }}
+        />
+      ) : null}
+    </>,
+    document.body,
+  );
+}

--- a/components/library/RemovePhotosPopup.tsx
+++ b/components/library/RemovePhotosPopup.tsx
@@ -301,10 +301,12 @@ export function RemovePhotosPopup({ entryIds, onClose }: RemovePhotosPopupProps)
             onClose();
           }}
           onConfirm={() => {
-            void deleteEntriesFromDisk(entryIds).then(() => {
-              setConfirmDiskDelete(false);
-              onClose();
-            });
+            void deleteEntriesFromDisk(entryIds)
+              .then(() => {
+                setConfirmDiskDelete(false);
+                onClose();
+              })
+              .catch(() => {});
           }}
         />
       ) : null}

--- a/components/library/StarRatingControl.tsx
+++ b/components/library/StarRatingControl.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { StarRating } from "@/lib/catalog/types";
+
+interface StarRatingControlProps {
+  value: StarRating;
+  onChange: (value: StarRating) => void;
+  className?: string;
+  starClassName?: string;
+}
+
+export function StarRatingControl({
+  value,
+  onChange,
+  className = "",
+  starClassName = "text-sm",
+}: StarRatingControlProps) {
+  return (
+    <div className={`flex items-center gap-0.5 ${className}`}>
+      {([0, 1, 2, 3, 4, 5] as const).map((starValue) => (
+        <button
+          key={starValue}
+          type="button"
+          onClick={() => onChange(starValue)}
+          title={
+            starValue === 0 ? "Clear rating" : `${starValue} star${starValue === 1 ? "" : "s"}`
+          }
+          className={[
+            "px-0.5 transition",
+            starClassName,
+            value >= starValue && starValue > 0
+              ? "text-amber-400"
+              : "text-lr-text-dim hover:text-lr-text-muted",
+          ].join(" ")}
+        >
+          {starValue === 0 ? "∅" : "★"}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/library/useEntryAspectRatios.ts
+++ b/components/library/useEntryAspectRatios.ts
@@ -33,6 +33,11 @@ export function useEntryAspectRatios(
     () => new Map(entries.map((entry) => [entry.id, entry])),
     [entries],
   );
+  const entrySetKey = useMemo(() => {
+    const ids = entries.map((entry) => entry.id);
+    ids.sort();
+    return ids.join("\0");
+  }, [entries]);
   const [aspectRatios, setAspectRatios] = useState<Map<string, number>>(() =>
     seedAspectRatios(entries),
   );
@@ -42,7 +47,8 @@ export function useEntryAspectRatios(
   const flushFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const seeded = seedAspectRatios(entries);
+    const catalogEntries = [...entriesById.values()];
+    const seeded = seedAspectRatios(catalogEntries);
     loadedRef.current = new Set(seeded.keys());
     setAspectRatios((current) => {
       const next = new Map(seeded);
@@ -56,7 +62,7 @@ export function useEntryAspectRatios(
     });
     inFlightRef.current.clear();
     pendingUpdatesRef.current.clear();
-  }, [entries, entriesById]);
+  }, [entrySetKey, entriesById]);
 
   useEffect(() => {
     let cancelled = false;

--- a/components/shell/LibraryBootstrap.tsx
+++ b/components/shell/LibraryBootstrap.tsx
@@ -8,6 +8,20 @@ import { useLibraryStore } from "@/stores/library-store";
 export function LibraryBootstrap() {
   const bootstrapLibrary = useLibraryStore((state) => state.bootstrapLibrary);
   const setDesktopApp = useLibraryStore((state) => state.setDesktopApp);
+  const importStatus = useLibraryStore((state) => state.importStatus);
+  const importError = useLibraryStore((state) => state.importError);
+
+  useEffect(() => {
+    if (importStatus) {
+      console.log(`[Darkroom] ${importStatus}`);
+    }
+  }, [importStatus]);
+
+  useEffect(() => {
+    if (importError) {
+      console.error(`[Darkroom] ${importError}`);
+    }
+  }, [importError]);
 
   useEffect(() => {
     const desktop = isElectronApp();

--- a/components/shell/LibraryToolbar.tsx
+++ b/components/shell/LibraryToolbar.tsx
@@ -2,20 +2,33 @@
 
 import { useLibraryStore } from "@/stores/library-store";
 import { FolderPickerButton } from "@/components/shell/FolderPickerButton";
+import { StarRatingControl } from "@/components/library/StarRatingControl";
+import type {
+  CurationFilter,
+  FilterOption,
+  GridViewMode,
+  SortOption,
+} from "@/lib/library/filter-types";
+import {
+  curationFilterFromRating,
+  getRatingFromCurationFilter,
+  isRatingCurationFilter,
+} from "@/lib/library/rating-filter";
+import type { StarRating } from "@/lib/catalog/types";
 import { IconDynamicGrid, IconFolder, IconGrid } from "./icons";
 
-export type SortOption = "name" | "date";
-export type FilterOption = "all" | "raw" | "standard";
-export type GridViewMode = "grid" | "dynamic";
+export type { CurationFilter, FilterOption, GridViewMode, SortOption };
 
 interface LibraryToolbarProps {
   photoCount: number;
   sort: SortOption;
   filter: FilterOption;
+  curationFilter: CurationFilter;
   thumbSize: number;
   viewMode: GridViewMode;
   onSortChange: (sort: SortOption) => void;
   onFilterChange: (filter: FilterOption) => void;
+  onCurationFilterChange: (filter: CurationFilter) => void;
   onThumbSizeChange: (size: number) => void;
   onViewModeChange: (mode: GridViewMode) => void;
 }
@@ -24,10 +37,12 @@ export function LibraryToolbar({
   photoCount,
   sort,
   filter,
+  curationFilter,
   thumbSize,
   viewMode,
   onSortChange,
   onFilterChange,
+  onCurationFilterChange,
   onThumbSizeChange,
   onViewModeChange,
 }: LibraryToolbarProps) {
@@ -40,6 +55,12 @@ export function LibraryToolbar({
     isDesktopApp,
     clearLibrary,
   } = useLibraryStore();
+
+  const activeRatingFilter = getRatingFromCurationFilter(curationFilter);
+
+  function handleRatingFilterChange(rating: StarRating) {
+    onCurationFilterChange(curationFilterFromRating(rating, curationFilter));
+  }
 
   return (
     <div className="flex h-9 shrink-0 items-center gap-2 border-b border-lr-border-subtle bg-lr-panel px-2">
@@ -146,6 +167,32 @@ export function LibraryToolbar({
         />
       </label>
 
+      <StarRatingControl
+        value={activeRatingFilter}
+        onChange={handleRatingFilterChange}
+        starClassName="text-xs"
+      />
+
+      <select
+        value={
+          isRatingCurationFilter(curationFilter) ? "all" : curationFilter
+        }
+        onChange={(event) =>
+          onCurationFilterChange(event.target.value as CurationFilter)
+        }
+        className="h-7 rounded border border-lr-border-subtle bg-lr-panel-raised px-2 text-xs text-lr-text outline-none"
+      >
+        <option value="all">All Curation</option>
+        <option value="picked">Picked</option>
+        <option value="rejected">Rejected</option>
+        <option value="unpicked">Unflagged</option>
+        <option value="label-red">Red Label</option>
+        <option value="label-yellow">Yellow Label</option>
+        <option value="label-green">Green Label</option>
+        <option value="label-blue">Blue Label</option>
+        <option value="label-purple">Purple Label</option>
+      </select>
+
       <select
         value={filter}
         onChange={(event) =>
@@ -165,6 +212,8 @@ export function LibraryToolbar({
       >
         <option value="name">Sort: File Name</option>
         <option value="date">Sort: Capture Date</option>
+        <option value="rating">Sort: Rating</option>
+        <option value="pick">Sort: Pick Status</option>
       </select>
 
       {importStatus ? (

--- a/components/shell/LibraryToolbar.tsx
+++ b/components/shell/LibraryToolbar.tsx
@@ -49,8 +49,6 @@ export function LibraryToolbar({
   const {
     folderName,
     importState,
-    importStatus,
-    importError,
     needsFolderAccess,
     isDesktopApp,
     clearLibrary,
@@ -215,18 +213,6 @@ export function LibraryToolbar({
         <option value="rating">Sort: Rating</option>
         <option value="pick">Sort: Pick Status</option>
       </select>
-
-      {importStatus ? (
-        <span className="max-w-[220px] truncate text-xs text-lr-text-muted" title={importStatus}>
-          {importStatus}
-        </span>
-      ) : null}
-
-      {importError ? (
-        <span className="max-w-[200px] truncate text-xs text-red-400" title={importError}>
-          {importError}
-        </span>
-      ) : null}
 
       {!isDesktopApp ? (
         <span className="text-xs text-amber-400">Desktop app required</span>

--- a/components/shell/SidePanel.tsx
+++ b/components/shell/SidePanel.tsx
@@ -1,14 +1,25 @@
 "use client";
 
-import type { FilterOption } from "./LibraryToolbar";
+import { COLOR_LABEL_HEX } from "@/lib/catalog/defaults";
+import { StarRatingControl } from "@/components/library/StarRatingControl";
+import type { CurationCounts } from "@/lib/library/curation";
+import {
+  curationFilterFromRating,
+  getRatingFromCurationFilter,
+} from "@/lib/library/rating-filter";
+import type { CurationFilter, FilterOption } from "@/lib/library/filter-types";
+import type { StarRating } from "@/lib/catalog/types";
 
 interface SidePanelProps {
   folderName: string | null;
   photoCount: number;
   rawCount: number;
   standardCount: number;
+  curationCounts: CurationCounts;
   filter: FilterOption;
+  curationFilter: CurationFilter;
   onFilterChange: (filter: FilterOption) => void;
+  onCurationFilterChange: (filter: CurationFilter) => void;
 }
 
 export function SidePanel({
@@ -16,14 +27,64 @@ export function SidePanel({
   photoCount,
   rawCount,
   standardCount,
+  curationCounts,
   filter,
+  curationFilter,
   onFilterChange,
+  onCurationFilterChange,
 }: SidePanelProps) {
-  const filters: Array<{ id: FilterOption; label: string; count: number }> = [
+  const formatFilters: Array<{ id: FilterOption; label: string; count: number }> = [
     { id: "all", label: "All Photographs", count: photoCount },
     { id: "raw", label: "RAW", count: rawCount },
     { id: "standard", label: "JPEG / PNG", count: standardCount },
   ];
+
+  const curationFilters: Array<{
+    id: CurationFilter;
+    label: string;
+    count: number;
+    dotColor?: string;
+  }> = [
+    { id: "picked", label: "Picked", count: curationCounts.picked },
+    { id: "rejected", label: "Rejected", count: curationCounts.rejected },
+    { id: "unpicked", label: "Unflagged", count: curationCounts.unpicked },
+    {
+      id: "label-red",
+      label: "Red",
+      count: curationCounts.labelRed,
+      dotColor: COLOR_LABEL_HEX.red,
+    },
+    {
+      id: "label-yellow",
+      label: "Yellow",
+      count: curationCounts.labelYellow,
+      dotColor: COLOR_LABEL_HEX.yellow,
+    },
+    {
+      id: "label-green",
+      label: "Green",
+      count: curationCounts.labelGreen,
+      dotColor: COLOR_LABEL_HEX.green,
+    },
+    {
+      id: "label-blue",
+      label: "Blue",
+      count: curationCounts.labelBlue,
+      dotColor: COLOR_LABEL_HEX.blue,
+    },
+    {
+      id: "label-purple",
+      label: "Purple",
+      count: curationCounts.labelPurple,
+      dotColor: COLOR_LABEL_HEX.purple,
+    },
+  ];
+
+  const activeRatingFilter = getRatingFromCurationFilter(curationFilter);
+
+  function handleRatingFilterChange(rating: StarRating) {
+    onCurationFilterChange(curationFilterFromRating(rating, curationFilter));
+  }
 
   return (
     <aside className="flex w-52 shrink-0 flex-col border-r border-lr-border-subtle bg-lr-panel">
@@ -50,34 +111,101 @@ export function SidePanel({
           </div>
         </section>
 
+        <FilterSection
+          title="Format"
+          items={formatFilters.map((item) => ({
+            id: item.id,
+            label: item.label,
+            count: item.count,
+            isActive: filter === item.id,
+            onClick: () => onFilterChange(item.id),
+          }))}
+        />
+
+        <FilterSection
+          title="Curation"
+          items={[
+            {
+              id: "all",
+              label: "All",
+              count: photoCount,
+              isActive: curationFilter === "all",
+              onClick: () => onCurationFilterChange("all"),
+            },
+            ...curationFilters.map((item) => ({
+              id: item.id,
+              label: item.label,
+              count: item.count,
+              dotColor: item.dotColor,
+              isActive: curationFilter === item.id,
+              onClick: () => onCurationFilterChange(item.id),
+            })),
+          ]}
+        />
+
         <section className="mt-2 px-2 py-1">
           <h3 className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
-            Filters
+            Rating
           </h3>
-          <ul className="space-y-0.5">
-            {filters.map((item) => {
-              const isActive = filter === item.id;
-              return (
-                <li key={item.id}>
-                  <button
-                    type="button"
-                    onClick={() => onFilterChange(item.id)}
-                    className={[
-                      "flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs transition",
-                      isActive
-                        ? "bg-lr-selection text-lr-text"
-                        : "text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text",
-                    ].join(" ")}
-                  >
-                    <span>{item.label}</span>
-                    <span className="text-lr-text-dim">{item.count}</span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
+          <div className="px-2 py-1.5">
+            <StarRatingControl
+              value={activeRatingFilter}
+              onChange={handleRatingFilterChange}
+              starClassName="text-xs"
+            />
+          </div>
         </section>
       </div>
     </aside>
+  );
+}
+
+function FilterSection({
+  title,
+  items,
+}: {
+  title: string;
+  items: Array<{
+    id: string;
+    label: string;
+    count: number;
+    dotColor?: string;
+    isActive: boolean;
+    onClick: () => void;
+  }>;
+}) {
+  return (
+    <section className="mt-2 px-2 py-1">
+      <h3 className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+        {title}
+      </h3>
+      <ul className="space-y-0.5">
+        {items.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              onClick={item.onClick}
+              className={[
+                "flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs transition",
+                item.isActive
+                  ? "bg-lr-selection text-lr-text"
+                  : "text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text",
+              ].join(" ")}
+            >
+              <span className="flex items-center gap-1.5">
+                {item.dotColor ? (
+                  <span
+                    className="inline-block h-2 w-2 rounded-full"
+                    style={{ backgroundColor: item.dotColor }}
+                  />
+                ) : null}
+                <span>{item.label}</span>
+              </span>
+              <span className="text-lr-text-dim">{item.count}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/components/shell/SidePanel.tsx
+++ b/components/shell/SidePanel.tsx
@@ -1,89 +1,54 @@
 "use client";
 
-import { COLOR_LABEL_HEX } from "@/lib/catalog/defaults";
-import { StarRatingControl } from "@/components/library/StarRatingControl";
-import type { CurationCounts } from "@/lib/library/curation";
+import { useMemo, useState, type ReactNode } from "react";
+import { FolderPickerButton } from "@/components/shell/FolderPickerButton";
 import {
-  curationFilterFromRating,
-  getRatingFromCurationFilter,
-} from "@/lib/library/rating-filter";
-import type { CurationFilter, FilterOption } from "@/lib/library/filter-types";
-import type { StarRating } from "@/lib/catalog/types";
+  IconAlbum,
+  IconChevronRight,
+  IconFolder,
+  IconPlus,
+  IconTrash,
+} from "@/components/shell/icons";
+import {
+  buildFolderTree,
+  type FolderNode,
+} from "@/lib/library/folders";
+import { useLibraryStore } from "@/stores/library-store";
 
-interface SidePanelProps {
-  folderName: string | null;
-  photoCount: number;
-  rawCount: number;
-  standardCount: number;
-  curationCounts: CurationCounts;
-  filter: FilterOption;
-  curationFilter: CurationFilter;
-  onFilterChange: (filter: FilterOption) => void;
-  onCurationFilterChange: (filter: CurationFilter) => void;
-}
+export function SidePanel() {
+  const entries = useLibraryStore((state) => state.entries);
+  const folderName = useLibraryStore((state) => state.folderName);
+  const needsFolderAccess = useLibraryStore((state) => state.needsFolderAccess);
+  const isDesktopApp = useLibraryStore((state) => state.isDesktopApp);
+  const albums = useLibraryStore((state) => state.albums);
+  const catalogView = useLibraryStore((state) => state.catalogView);
+  const setCatalogView = useLibraryStore((state) => state.setCatalogView);
+  const createAlbum = useLibraryStore((state) => state.createAlbum);
+  const renameAlbum = useLibraryStore((state) => state.renameAlbum);
+  const deleteAlbum = useLibraryStore((state) => state.deleteAlbum);
 
-export function SidePanel({
-  folderName,
-  photoCount,
-  rawCount,
-  standardCount,
-  curationCounts,
-  filter,
-  curationFilter,
-  onFilterChange,
-  onCurationFilterChange,
-}: SidePanelProps) {
-  const formatFilters: Array<{ id: FilterOption; label: string; count: number }> = [
-    { id: "all", label: "All Photographs", count: photoCount },
-    { id: "raw", label: "RAW", count: rawCount },
-    { id: "standard", label: "JPEG / PNG", count: standardCount },
-  ];
+  const [creatingAlbum, setCreatingAlbum] = useState(false);
+  const [newAlbumName, setNewAlbumName] = useState("");
+  const [renamingAlbumId, setRenamingAlbumId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
 
-  const curationFilters: Array<{
-    id: CurationFilter;
-    label: string;
-    count: number;
-    dotColor?: string;
-  }> = [
-    { id: "picked", label: "Picked", count: curationCounts.picked },
-    { id: "rejected", label: "Rejected", count: curationCounts.rejected },
-    { id: "unpicked", label: "Unflagged", count: curationCounts.unpicked },
-    {
-      id: "label-red",
-      label: "Red",
-      count: curationCounts.labelRed,
-      dotColor: COLOR_LABEL_HEX.red,
-    },
-    {
-      id: "label-yellow",
-      label: "Yellow",
-      count: curationCounts.labelYellow,
-      dotColor: COLOR_LABEL_HEX.yellow,
-    },
-    {
-      id: "label-green",
-      label: "Green",
-      count: curationCounts.labelGreen,
-      dotColor: COLOR_LABEL_HEX.green,
-    },
-    {
-      id: "label-blue",
-      label: "Blue",
-      count: curationCounts.labelBlue,
-      dotColor: COLOR_LABEL_HEX.blue,
-    },
-    {
-      id: "label-purple",
-      label: "Purple",
-      count: curationCounts.labelPurple,
-      dotColor: COLOR_LABEL_HEX.purple,
-    },
-  ];
+  const folderTree = useMemo(() => buildFolderTree(entries), [entries]);
+  const hasLibrary = entries.length > 0 && !needsFolderAccess;
 
-  const activeRatingFilter = getRatingFromCurationFilter(curationFilter);
+  function handleCreateAlbum() {
+    const id = createAlbum(newAlbumName);
+    if (id) {
+      setNewAlbumName("");
+      setCreatingAlbum(false);
+    }
+  }
 
-  function handleRatingFilterChange(rating: StarRating) {
-    onCurationFilterChange(curationFilterFromRating(rating, curationFilter));
+  function handleRenameAlbum(albumId: string) {
+    if (renameValue.trim()) {
+      renameAlbum(albumId, renameValue);
+    }
+    setRenamingAlbumId(null);
+    setRenameValue("");
   }
 
   return (
@@ -96,116 +61,293 @@ export function SidePanel({
 
       <div className="flex-1 overflow-auto py-1">
         <section className="px-2 py-1">
-          <h3 className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
-            Folders
-          </h3>
-          <div className="rounded px-2 py-1.5 text-xs text-lr-text">
-            {folderName ? (
-              <span className="flex items-center gap-1.5">
-                <span className="inline-block h-1.5 w-1.5 rounded-full bg-lr-accent" />
-                <span className="truncate">{folderName}</span>
-              </span>
-            ) : (
-              <span className="text-lr-text-dim">No folder linked</span>
-            )}
+          <div className="flex items-center justify-between px-2 py-1">
+            <h3 className="text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+              Folders
+            </h3>
+            <div className="flex items-center gap-0.5">
+              {needsFolderAccess ? (
+                <FolderPickerButton
+                  mode="restore"
+                  disabled={!isDesktopApp}
+                  className="flex h-5 w-5 items-center justify-center rounded text-lr-accent transition hover:bg-lr-panel-raised disabled:opacity-50"
+                >
+                  <IconFolder className="h-3 w-3" />
+                </FolderPickerButton>
+              ) : null}
+              <FolderPickerButton
+                mode="import"
+                disabled={!isDesktopApp}
+                className="flex h-5 w-5 items-center justify-center rounded text-lr-text-muted transition hover:bg-lr-panel-raised hover:text-lr-text disabled:opacity-50"
+              >
+                <IconPlus className="h-3 w-3" />
+              </FolderPickerButton>
+            </div>
           </div>
+
+          {folderName ? (
+            <div className="mb-1 truncate px-2 text-[11px] text-lr-text-dim">
+              {folderName}
+            </div>
+          ) : (
+            <div className="mb-1 px-2 text-[11px] text-lr-text-dim">
+              No folder linked
+            </div>
+          )}
+
+          {hasLibrary ? (
+            <ul className="space-y-0.5">
+              <CatalogItem
+                label="All Photos"
+                count={entries.length}
+                icon={<IconFolder className="h-3 w-3 text-lr-accent" />}
+                isActive={catalogView.type === "all"}
+                onClick={() => setCatalogView({ type: "all" })}
+              />
+              {folderTree.rootPhotoCount > 0 ? (
+                <CatalogItem
+                  label="Root"
+                  count={folderTree.rootPhotoCount}
+                  icon={<IconFolder className="h-3 w-3 text-lr-text-dim" />}
+                  isActive={
+                    catalogView.type === "folder" && catalogView.path === ""
+                  }
+                  onClick={() =>
+                    setCatalogView({ type: "folder", path: "" })
+                  }
+                />
+              ) : null}
+              {folderTree.folders.map((node) => (
+                <FolderTreeNode
+                  key={node.path}
+                  node={node}
+                  depth={0}
+                  catalogView={catalogView}
+                  onSelect={(path) =>
+                    setCatalogView({ type: "folder", path })
+                  }
+                />
+              ))}
+            </ul>
+          ) : (
+            <p className="px-2 py-1.5 text-xs text-lr-text-dim">
+              Import a folder to browse subfolders.
+            </p>
+          )}
         </section>
 
-        <FilterSection
-          title="Format"
-          items={formatFilters.map((item) => ({
-            id: item.id,
-            label: item.label,
-            count: item.count,
-            isActive: filter === item.id,
-            onClick: () => onFilterChange(item.id),
-          }))}
-        />
-
-        <FilterSection
-          title="Curation"
-          items={[
-            {
-              id: "all",
-              label: "All",
-              count: photoCount,
-              isActive: curationFilter === "all",
-              onClick: () => onCurationFilterChange("all"),
-            },
-            ...curationFilters.map((item) => ({
-              id: item.id,
-              label: item.label,
-              count: item.count,
-              dotColor: item.dotColor,
-              isActive: curationFilter === item.id,
-              onClick: () => onCurationFilterChange(item.id),
-            })),
-          ]}
-        />
-
         <section className="mt-2 px-2 py-1">
-          <h3 className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
-            Rating
-          </h3>
-          <div className="px-2 py-1.5">
-            <StarRatingControl
-              value={activeRatingFilter}
-              onChange={handleRatingFilterChange}
-              starClassName="text-xs"
-            />
+          <div className="flex items-center justify-between px-2 py-1">
+            <h3 className="text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+              Albums
+            </h3>
+            <button
+              type="button"
+              onClick={() => {
+                setCreatingAlbum(true);
+                setNewAlbumName("");
+              }}
+              disabled={!hasLibrary}
+              className="flex h-5 w-5 items-center justify-center rounded text-lr-text-muted transition hover:bg-lr-panel-raised hover:text-lr-text disabled:opacity-40"
+              title="New album"
+            >
+              <IconPlus className="h-3 w-3" />
+            </button>
           </div>
+
+          {creatingAlbum ? (
+            <div className="px-2 py-1">
+              <input
+                type="text"
+                value={newAlbumName}
+                onChange={(event) => setNewAlbumName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    handleCreateAlbum();
+                  }
+                  if (event.key === "Escape") {
+                    setCreatingAlbum(false);
+                    setNewAlbumName("");
+                  }
+                }}
+                onBlur={() => {
+                  if (newAlbumName.trim()) {
+                    handleCreateAlbum();
+                  } else {
+                    setCreatingAlbum(false);
+                  }
+                }}
+                placeholder="Album name"
+                autoFocus
+                className="w-full rounded border border-lr-border-subtle bg-lr-panel-raised px-2 py-1 text-xs text-lr-text outline-none focus:border-lr-accent"
+              />
+            </div>
+          ) : null}
+
+          {albums.length > 0 ? (
+            <ul className="space-y-0.5">
+              {albums.map((album) => (
+                <li key={album.id} className="group flex items-center gap-0.5">
+                  {renamingAlbumId === album.id ? (
+                    <input
+                      type="text"
+                      value={renameValue}
+                      onChange={(event) => setRenameValue(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          handleRenameAlbum(album.id);
+                        }
+                        if (event.key === "Escape") {
+                          setRenamingAlbumId(null);
+                          setRenameValue("");
+                        }
+                      }}
+                      onBlur={() => handleRenameAlbum(album.id)}
+                      autoFocus
+                      className="mx-2 flex-1 rounded border border-lr-border-subtle bg-lr-panel-raised px-2 py-1 text-xs text-lr-text outline-none focus:border-lr-accent"
+                    />
+                  ) : (
+                    <>
+                      <CatalogItem
+                        label={album.name}
+                        count={album.entryIds.length}
+                        icon={
+                          <IconAlbum className="h-3 w-3 text-lr-text-dim" />
+                        }
+                        isActive={
+                          catalogView.type === "album" &&
+                          catalogView.albumId === album.id
+                        }
+                        onClick={() =>
+                          setCatalogView({ type: "album", albumId: album.id })
+                        }
+                        onDoubleClick={() => {
+                          setRenamingAlbumId(album.id);
+                          setRenameValue(album.name);
+                        }}
+                        className="flex-1"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => deleteAlbum(album.id)}
+                        className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded text-lr-text-dim opacity-0 transition hover:bg-lr-panel-raised hover:text-red-400 group-hover:opacity-100"
+                        title="Delete album"
+                      >
+                        <IconTrash className="h-3 w-3" />
+                      </button>
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="px-2 py-1.5 text-xs text-lr-text-dim">
+              Create albums to group photos.
+            </p>
+          )}
         </section>
       </div>
     </aside>
   );
 }
 
-function FilterSection({
-  title,
-  items,
+function FolderTreeNode({
+  node,
+  depth,
+  catalogView,
+  onSelect,
 }: {
-  title: string;
-  items: Array<{
-    id: string;
-    label: string;
-    count: number;
-    dotColor?: string;
-    isActive: boolean;
-    onClick: () => void;
-  }>;
+  node: FolderNode;
+  depth: number;
+  catalogView: ReturnType<typeof useLibraryStore.getState>["catalogView"];
+  onSelect: (path: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(depth < 1);
+  const hasChildren = node.children.length > 0;
+  const isActive =
+    catalogView.type === "folder" && catalogView.path === node.path;
+
+  return (
+    <li>
+      <div className="flex items-center" style={{ paddingLeft: depth * 12 }}>
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            className="flex h-5 w-4 shrink-0 items-center justify-center text-lr-text-dim transition hover:text-lr-text"
+            aria-label={expanded ? "Collapse folder" : "Expand folder"}
+          >
+            <IconChevronRight
+              className={[
+                "h-2.5 w-2.5 transition",
+                expanded ? "rotate-90" : "",
+              ].join(" ")}
+            />
+          </button>
+        ) : (
+          <span className="w-4 shrink-0" />
+        )}
+        <CatalogItem
+          label={node.name}
+          count={node.photoCount}
+          icon={<IconFolder className="h-3 w-3 text-lr-text-dim" />}
+          isActive={isActive}
+          onClick={() => onSelect(node.path)}
+          className="flex-1"
+        />
+      </div>
+      {hasChildren && expanded ? (
+        <ul>
+          {node.children.map((child) => (
+            <FolderTreeNode
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              catalogView={catalogView}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+function CatalogItem({
+  label,
+  count,
+  icon,
+  isActive,
+  onClick,
+  onDoubleClick,
+  className = "",
+}: {
+  label: string;
+  count: number;
+  icon: ReactNode;
+  isActive: boolean;
+  onClick: () => void;
+  onDoubleClick?: () => void;
+  className?: string;
 }) {
   return (
-    <section className="mt-2 px-2 py-1">
-      <h3 className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
-        {title}
-      </h3>
-      <ul className="space-y-0.5">
-        {items.map((item) => (
-          <li key={item.id}>
-            <button
-              type="button"
-              onClick={item.onClick}
-              className={[
-                "flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs transition",
-                item.isActive
-                  ? "bg-lr-selection text-lr-text"
-                  : "text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text",
-              ].join(" ")}
-            >
-              <span className="flex items-center gap-1.5">
-                {item.dotColor ? (
-                  <span
-                    className="inline-block h-2 w-2 rounded-full"
-                    style={{ backgroundColor: item.dotColor }}
-                  />
-                ) : null}
-                <span>{item.label}</span>
-              </span>
-              <span className="text-lr-text-dim">{item.count}</span>
-            </button>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <button
+      type="button"
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      className={[
+        "flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs transition",
+        isActive
+          ? "bg-lr-selection text-lr-text"
+          : "text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text",
+        className,
+      ].join(" ")}
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        {icon}
+        <span className="truncate">{label}</span>
+      </span>
+      <span className="ml-2 shrink-0 text-lr-text-dim">{count}</span>
+    </button>
   );
 }

--- a/components/shell/SidePanel.tsx
+++ b/components/shell/SidePanel.tsx
@@ -2,8 +2,10 @@
 
 import { useMemo, useState, type ReactNode } from "react";
 import { FolderPickerButton } from "@/components/shell/FolderPickerButton";
+import { DeleteAlbumConfirm } from "@/components/library/DeleteAlbumConfirm";
 import {
   IconAlbum,
+  IconArchive,
   IconChevronRight,
   IconFolder,
   IconPlus,
@@ -13,10 +15,16 @@ import {
   buildFolderTree,
   type FolderNode,
 } from "@/lib/library/folders";
+import {
+  filterArchivedEntries,
+  filterOnlyArchivedEntries,
+} from "@/lib/library/archive";
+import type { Album } from "@/lib/catalog/types";
 import { useLibraryStore } from "@/stores/library-store";
 
 export function SidePanel() {
   const entries = useLibraryStore((state) => state.entries);
+  const archivedEntryIds = useLibraryStore((state) => state.archivedEntryIds);
   const folderName = useLibraryStore((state) => state.folderName);
   const needsFolderAccess = useLibraryStore((state) => state.needsFolderAccess);
   const isDesktopApp = useLibraryStore((state) => state.isDesktopApp);
@@ -31,9 +39,25 @@ export function SidePanel() {
   const [newAlbumName, setNewAlbumName] = useState("");
   const [renamingAlbumId, setRenamingAlbumId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  const [albumPendingDelete, setAlbumPendingDelete] = useState<Album | null>(
+    null,
+  );
 
-  const folderTree = useMemo(() => buildFolderTree(entries), [entries]);
-  const hasLibrary = entries.length > 0 && !needsFolderAccess;
+  const libraryEntries = useMemo(
+    () => filterArchivedEntries(entries, archivedEntryIds),
+    [entries, archivedEntryIds],
+  );
+
+  const archivedEntries = useMemo(
+    () => filterOnlyArchivedEntries(entries, archivedEntryIds),
+    [entries, archivedEntryIds],
+  );
+
+  const folderTree = useMemo(
+    () => buildFolderTree(libraryEntries),
+    [libraryEntries],
+  );
+  const hasImportedFolder = entries.length > 0 && !needsFolderAccess;
 
   function handleCreateAlbum() {
     const id = createAlbum(newAlbumName);
@@ -51,7 +75,16 @@ export function SidePanel() {
     setRenameValue("");
   }
 
+  function handleDeleteAlbum(album: Album) {
+    if (album.entryIds.length > 0) {
+      setAlbumPendingDelete(album);
+      return;
+    }
+    deleteAlbum(album.id);
+  }
+
   return (
+    <>
     <aside className="flex w-52 shrink-0 flex-col border-r border-lr-border-subtle bg-lr-panel">
       <div className="border-b border-lr-border-subtle px-3 py-2">
         <h2 className="text-[11px] font-semibold uppercase tracking-wider text-lr-text-dim">
@@ -95,11 +128,11 @@ export function SidePanel() {
             </div>
           )}
 
-          {hasLibrary ? (
+          {hasImportedFolder ? (
             <ul className="space-y-0.5">
               <CatalogItem
                 label="All Photos"
-                count={entries.length}
+                count={libraryEntries.length}
                 icon={<IconFolder className="h-3 w-3 text-lr-accent" />}
                 isActive={catalogView.type === "all"}
                 onClick={() => setCatalogView({ type: "all" })}
@@ -128,6 +161,15 @@ export function SidePanel() {
                   }
                 />
               ))}
+              {archivedEntries.length > 0 ? (
+                <CatalogItem
+                  label="Archive"
+                  count={archivedEntries.length}
+                  icon={<IconArchive className="h-3 w-3 text-lr-text-dim" />}
+                  isActive={catalogView.type === "archive"}
+                  onClick={() => setCatalogView({ type: "archive" })}
+                />
+              ) : null}
             </ul>
           ) : (
             <p className="px-2 py-1.5 text-xs text-lr-text-dim">
@@ -147,7 +189,7 @@ export function SidePanel() {
                 setCreatingAlbum(true);
                 setNewAlbumName("");
               }}
-              disabled={!hasLibrary}
+              disabled={!hasImportedFolder}
               className="flex h-5 w-5 items-center justify-center rounded text-lr-text-muted transition hover:bg-lr-panel-raised hover:text-lr-text disabled:opacity-40"
               title="New album"
             >
@@ -229,7 +271,7 @@ export function SidePanel() {
                       />
                       <button
                         type="button"
-                        onClick={() => deleteAlbum(album.id)}
+                        onClick={() => handleDeleteAlbum(album)}
                         className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded text-lr-text-dim opacity-0 transition hover:bg-lr-panel-raised hover:text-red-400 group-hover:opacity-100"
                         title="Delete album"
                       >
@@ -248,6 +290,18 @@ export function SidePanel() {
         </section>
       </div>
     </aside>
+
+    {albumPendingDelete ? (
+      <DeleteAlbumConfirm
+        album={albumPendingDelete}
+        onConfirm={() => {
+          deleteAlbum(albumPendingDelete.id);
+          setAlbumPendingDelete(null);
+        }}
+        onClose={() => setAlbumPendingDelete(null)}
+      />
+    ) : null}
+    </>
   );
 }
 

--- a/components/shell/icons.tsx
+++ b/components/shell/icons.tsx
@@ -44,6 +44,35 @@ export function IconChevronRight({ className }: { className?: string }) {
   );
 }
 
+export function IconAlbum({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path d="M2 2.5A1.5 1.5 0 0 1 3.5 1h9A1.5 1.5 0 0 1 14 2.5v11a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 13.5v-11zM3.5 2a.5.5 0 0 0-.5.5v11a.5.5 0 0 0 .5.5h9a.5.5 0 0 0 .5-.5v-11a.5.5 0 0 0-.5-.5h-9z" />
+      <path d="M5 5.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0zm7 0a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0zM5 10.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0zm7 0a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0z" />
+    </svg>
+  );
+}
+
+export function IconPlus({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z" />
+    </svg>
+  );
+}
+
+export function IconTrash({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z" />
+      <path
+        fillRule="evenodd"
+        d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1 0-2h3.086a1 1 0 0 1 .707.293L7.414 4H14.5a1 1 0 0 1 1 1zM4 4v9a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4H4z"
+      />
+    </svg>
+  );
+}
+
 export function IconInfo({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>

--- a/components/shell/icons.tsx
+++ b/components/shell/icons.tsx
@@ -73,6 +73,18 @@ export function IconTrash({ className }: { className?: string }) {
   );
 }
 
+export function IconArchive({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path d="M14.5 3h-13A1.5 1.5 0 0 0 0 4.5v2A1.5 1.5 0 0 0 1.5 8h13A1.5 1.5 0 0 0 16 6.5v-2A1.5 1.5 0 0 0 14.5 3zM1.5 4a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5V4z" />
+      <path
+        fillRule="evenodd"
+        d="M2 8.5A1.5 1.5 0 0 1 3.5 7h9A1.5 1.5 0 0 1 14 8.5v5A1.5 1.5 0 0 1 12.5 15h-9A1.5 1.5 0 0 1 2 13.5v-5zm1.5-.5a.5.5 0 0 0-.5.5v5a.5.5 0 0 0 .5.5h9a.5.5 0 0 0 .5-.5v-5a.5.5 0 0 0-.5-.5h-9z"
+      />
+    </svg>
+  );
+}
+
 export function IconInfo({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>

--- a/components/viewer/Filmstrip.tsx
+++ b/components/viewer/Filmstrip.tsx
@@ -3,7 +3,9 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
+import { getEntryMetadata } from "@/lib/catalog/defaults";
 import { PhotoTile } from "@/components/library/PhotoTile";
+import { useLibraryStore } from "@/stores/library-store";
 import { IconChevronLeft, IconChevronRight } from "@/components/shell/icons";
 
 interface FilmstripProps {
@@ -17,6 +19,7 @@ const THUMB_GAP = 2;
 
 export function Filmstrip({ entries, activeId, onSelect }: FilmstripProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const entryMetadata = useLibraryStore((state) => state.entryMetadata);
   const getScrollRoot = useCallback(() => scrollRef.current, []);
   const activeIndex = useMemo(
     () => entries.findIndex((entry) => entry.id === activeId),
@@ -121,6 +124,7 @@ export function Filmstrip({ entries, activeId, onSelect }: FilmstripProps) {
                   width={THUMB_SIZE}
                   height={THUMB_SIZE}
                   selected={entry.id === activeId}
+                  metadata={getEntryMetadata(entryMetadata, entry.id)}
                   compact
                   getScrollRoot={getScrollRoot}
                 />

--- a/components/viewer/PhotoViewer.tsx
+++ b/components/viewer/PhotoViewer.tsx
@@ -81,7 +81,7 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
     };
   }, [entry, entries, activeIndex]);
 
-  useEntryMetadataShortcuts(entry.id);
+  useEntryMetadataShortcuts([entry.id]);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {

--- a/components/viewer/PhotoViewer.tsx
+++ b/components/viewer/PhotoViewer.tsx
@@ -10,9 +10,14 @@ import {
   preloadDevelopImages,
 } from "@/lib/cache/develop-image-cache";
 import { TopBar } from "@/components/shell/TopBar";
+import {
+  EntryMetadataBar,
+  useEntryMetadataForId,
+} from "@/components/library/EntryMetadataBar";
 import { useLibraryStore } from "@/stores/library-store";
 import { Filmstrip } from "./Filmstrip";
 import { MetadataPanel } from "./MetadataPanel";
+import { useEntryMetadataShortcuts } from "@/hooks/useEntryMetadataShortcuts";
 
 interface PhotoViewerProps {
   entry: LibraryEntry;
@@ -22,6 +27,10 @@ interface PhotoViewerProps {
 export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
   const router = useRouter();
   const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
+  const setPick = useLibraryStore((state) => state.setPick);
+  const setRating = useLibraryStore((state) => state.setRating);
+  const setColorLabel = useLibraryStore((state) => state.setColorLabel);
+  const metadata = useEntryMetadataForId(entry.id);
   const [decoded, setDecoded] = useState<DevelopImage | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -72,6 +81,8 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
     };
   }, [entry, entries, activeIndex]);
 
+  useEntryMetadataShortcuts(entry.id);
+
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "ArrowLeft" && activeIndex > 0) {
@@ -100,6 +111,16 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
         showBack
         title={entry.name}
         developPhotoId={entry.id}
+      />
+
+      <EntryMetadataBar
+        entryId={entry.id}
+        metadata={metadata}
+        onPick={() => setPick(entry.id, "pick")}
+        onReject={() => setPick(entry.id, "reject")}
+        onClearPick={() => setPick(entry.id, "none")}
+        onRating={(rating) => setRating(entry.id, rating)}
+        onColorLabel={(label) => setColorLabel(entry.id, label)}
       />
 
       <div className="flex min-h-0 flex-1">

--- a/electron/catalog-store.ts
+++ b/electron/catalog-store.ts
@@ -1,0 +1,61 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface CatalogEntryMetadata {
+  pick: "none" | "pick" | "reject";
+  rating: 0 | 1 | 2 | 3 | 4 | 5;
+  colorLabel: "red" | "yellow" | "green" | "blue" | "purple" | null;
+  updatedAt: number;
+}
+
+export interface PhotoCatalog {
+  version: 1;
+  rootPath: string;
+  entries: Record<string, CatalogEntryMetadata>;
+}
+
+function catalogKeyForRootPath(rootPath: string): string {
+  const normalized = path.resolve(rootPath);
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}
+
+export function createCatalogStore(userDataPath: string) {
+  const catalogsDir = path.join(userDataPath, "catalogs");
+
+  function catalogPath(rootPath: string): string {
+    return path.join(catalogsDir, `${catalogKeyForRootPath(rootPath)}.json`);
+  }
+
+  async function read(rootPath: string): Promise<PhotoCatalog | null> {
+    try {
+      const raw = await fs.readFile(catalogPath(rootPath), "utf8");
+      const parsed = JSON.parse(raw) as PhotoCatalog;
+      if (parsed.version !== 1 || typeof parsed.entries !== "object") {
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  async function write(catalog: PhotoCatalog): Promise<void> {
+    await fs.mkdir(catalogsDir, { recursive: true });
+    await fs.writeFile(
+      catalogPath(catalog.rootPath),
+      JSON.stringify(catalog, null, 2),
+      "utf8",
+    );
+  }
+
+  async function remove(rootPath: string): Promise<void> {
+    try {
+      await fs.unlink(catalogPath(rootPath));
+    } catch {
+      // Catalog may not exist.
+    }
+  }
+
+  return { read, write, remove };
+}

--- a/electron/fs-service.ts
+++ b/electron/fs-service.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { shell } from "electron";
 import { isSupportedFileName } from "../lib/fs/types";
 
 const SUPPORTED_EXTENSIONS = [".nef", ".jpg", ".jpeg", ".png", ".webp"] as const;
@@ -112,6 +113,26 @@ export async function folderExists(folderPath: string): Promise<boolean> {
 
 export function getFolderName(folderPath: string): string {
   return path.basename(folderPath);
+}
+
+export async function trashFiles(absolutePaths: string[]): Promise<void> {
+  const failures: string[] = [];
+
+  for (const filePath of absolutePaths) {
+    try {
+      await shell.trashItem(filePath);
+    } catch {
+      failures.push(path.basename(filePath));
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      failures.length === 1
+        ? `Could not move "${failures[0]}" to the trash.`
+        : `Could not move ${failures.length} files to the trash.`,
+    );
+  }
 }
 
 export { SUPPORTED_EXTENSIONS };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import {
   scanFolderTree,
   statFile,
 } from "./fs-service";
+import { createCatalogStore } from "./catalog-store";
 import { createSettingsStore } from "./settings";
 import { getAppRoot, getOutDir, startStaticServer } from "./static-server";
 
@@ -18,6 +19,7 @@ let mainWindow: BrowserWindow | null = null;
 let staticServerPort: number | null = null;
 
 const settingsStore = createSettingsStore(app.getPath("userData"));
+const catalogStore = createCatalogStore(app.getPath("userData"));
 
 function getPreloadPath(): string {
   return path.join(__dirname, "preload.js");
@@ -113,6 +115,18 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle("darkroom:folder-exists", async (_event, folderPath: string) => {
     return folderExists(folderPath);
+  });
+
+  ipcMain.handle("darkroom:catalog-read", async (_event, rootPath: string) => {
+    return catalogStore.read(rootPath);
+  });
+
+  ipcMain.handle("darkroom:catalog-write", async (_event, catalog) => {
+    await catalogStore.write(catalog);
+  });
+
+  ipcMain.handle("darkroom:catalog-delete", async (_event, rootPath: string) => {
+    await catalogStore.remove(rootPath);
   });
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,6 +7,7 @@ import {
   readFileHead,
   scanFolderTree,
   statFile,
+  trashFiles,
 } from "./fs-service";
 import { createCatalogStore } from "./catalog-store";
 import { createSettingsStore } from "./settings";
@@ -128,6 +129,13 @@ function registerIpcHandlers(): void {
   ipcMain.handle("darkroom:catalog-delete", async (_event, rootPath: string) => {
     await catalogStore.remove(rootPath);
   });
+
+  ipcMain.handle(
+    "darkroom:delete-files",
+    async (_event, absolutePaths: string[]) => {
+      await trashFiles(absolutePaths);
+    },
+  );
 }
 
 app.whenReady().then(async () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -66,6 +66,10 @@ const darkroom = {
   deleteCatalog(rootPath: string): Promise<void> {
     return ipcRenderer.invoke("darkroom:catalog-delete", rootPath);
   },
+
+  deleteFiles(absolutePaths: string[]): Promise<void> {
+    return ipcRenderer.invoke("darkroom:delete-files", absolutePaths);
+  },
 };
 
 contextBridge.exposeInMainWorld("darkroom", darkroom);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -7,6 +7,19 @@ interface ScannedFile {
   lastModified: number;
 }
 
+interface CatalogEntryMetadata {
+  pick: "none" | "pick" | "reject";
+  rating: 0 | 1 | 2 | 3 | 4 | 5;
+  colorLabel: "red" | "yellow" | "green" | "blue" | "purple" | null;
+  updatedAt: number;
+}
+
+interface PhotoCatalog {
+  version: 1;
+  rootPath: string;
+  entries: Record<string, CatalogEntryMetadata>;
+}
+
 const darkroom = {
   isElectron: true as const,
 
@@ -40,6 +53,18 @@ const darkroom = {
 
   folderExists(folderPath: string): Promise<boolean> {
     return ipcRenderer.invoke("darkroom:folder-exists", folderPath);
+  },
+
+  readCatalog(rootPath: string): Promise<PhotoCatalog | null> {
+    return ipcRenderer.invoke("darkroom:catalog-read", rootPath);
+  },
+
+  writeCatalog(catalog: PhotoCatalog): Promise<void> {
+    return ipcRenderer.invoke("darkroom:catalog-write", catalog);
+  },
+
+  deleteCatalog(rootPath: string): Promise<void> {
+    return ipcRenderer.invoke("darkroom:catalog-delete", rootPath);
   },
 };
 

--- a/hooks/useAlbumPickerShortcut.tsx
+++ b/hooks/useAlbumPickerShortcut.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { AlbumPickerPopup } from "@/components/library/AlbumPickerPopup";
+import { RemovePhotosPopup } from "@/components/library/RemovePhotosPopup";
+import { useLibraryStore } from "@/stores/library-store";
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -17,6 +19,10 @@ function isEditableTarget(target: EventTarget | null): boolean {
   );
 }
 
+function isRemoveKey(key: string): boolean {
+  return key === "Backspace" || key === "Delete";
+}
+
 interface UseAlbumPickerShortcutOptions {
   selectedEntryId: string | null;
   selectedEntryIds: string[];
@@ -28,7 +34,10 @@ export function useAlbumPickerShortcut({
   selectedEntryIds,
   disabled = false,
 }: UseAlbumPickerShortcutOptions) {
-  const [open, setOpen] = useState(false);
+  const [albumPickerOpen, setAlbumPickerOpen] = useState(false);
+  const [removePopupOpen, setRemovePopupOpen] = useState(false);
+  const catalogView = useLibraryStore((state) => state.catalogView);
+  const isArchiveView = catalogView.type === "archive";
 
   const entryIds = useMemo(
     () =>
@@ -40,8 +49,10 @@ export function useAlbumPickerShortcut({
     [selectedEntryIds, selectedEntryId],
   );
 
+  const overlayOpen = albumPickerOpen || removePopupOpen;
+
   useEffect(() => {
-    if (disabled || open || entryIds.length === 0) {
+    if (disabled || overlayOpen || entryIds.length === 0) {
       return;
     }
 
@@ -52,26 +63,46 @@ export function useAlbumPickerShortcut({
 
       if (
         event.key === "b" &&
+        !isArchiveView &&
         !event.metaKey &&
         !event.ctrlKey &&
         !event.altKey &&
         !event.shiftKey
       ) {
         event.preventDefault();
-        setOpen(true);
+        setAlbumPickerOpen(true);
+        return;
+      }
+
+      if (
+        isRemoveKey(event.key) &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
+        event.preventDefault();
+        setRemovePopupOpen(true);
       }
     }
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [disabled, entryIds.length, open]);
+  }, [disabled, entryIds.length, isArchiveView, overlayOpen]);
 
-  const albumPicker = open ? (
-    <AlbumPickerPopup
+  const albumPicker =
+    albumPickerOpen && !isArchiveView ? (
+      <AlbumPickerPopup
+        entryIds={entryIds}
+        onClose={() => setAlbumPickerOpen(false)}
+      />
+    ) : null;
+
+  const removePopup = removePopupOpen ? (
+    <RemovePhotosPopup
       entryIds={entryIds}
-      onClose={() => setOpen(false)}
+      onClose={() => setRemovePopupOpen(false)}
     />
   ) : null;
 
-  return { albumPicker, albumPickerOpen: open };
+  return { albumPicker, removePopup, overlayOpen };
 }

--- a/hooks/useAlbumPickerShortcut.tsx
+++ b/hooks/useAlbumPickerShortcut.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlbumPickerPopup } from "@/components/library/AlbumPickerPopup";
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tag = target.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.isContentEditable
+  );
+}
+
+interface UseAlbumPickerShortcutOptions {
+  selectedEntryId: string | null;
+  selectedEntryIds: string[];
+  disabled?: boolean;
+}
+
+export function useAlbumPickerShortcut({
+  selectedEntryId,
+  selectedEntryIds,
+  disabled = false,
+}: UseAlbumPickerShortcutOptions) {
+  const [open, setOpen] = useState(false);
+
+  const entryIds = useMemo(
+    () =>
+      selectedEntryIds.length > 0
+        ? selectedEntryIds
+        : selectedEntryId
+          ? [selectedEntryId]
+          : [],
+    [selectedEntryIds, selectedEntryId],
+  );
+
+  useEffect(() => {
+    if (disabled || open || entryIds.length === 0) {
+      return;
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
+      if (
+        event.key === "b" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey
+      ) {
+        event.preventDefault();
+        setOpen(true);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [disabled, entryIds.length, open]);
+
+  const albumPicker = open ? (
+    <AlbumPickerPopup
+      entryIds={entryIds}
+      onClose={() => setOpen(false)}
+    />
+  ) : null;
+
+  return { albumPicker, albumPickerOpen: open };
+}

--- a/hooks/useEntryMetadataShortcuts.ts
+++ b/hooks/useEntryMetadataShortcuts.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import {
   COLOR_LABEL_SHORTCUTS,
   isStarRating,
@@ -23,17 +23,18 @@ function isEditableTarget(target: EventTarget | null): boolean {
   );
 }
 
-export function useEntryMetadataShortcuts(activeEntryId: string | null): void {
-  const setPick = useLibraryStore((state) => state.setPick);
-  const setRating = useLibraryStore((state) => state.setRating);
+export function useEntryMetadataShortcuts(activeEntryIds: string[]): void {
+  const applyMetadataToEntries = useLibraryStore(
+    (state) => state.applyMetadataToEntries,
+  );
   const setColorLabel = useLibraryStore((state) => state.setColorLabel);
 
   useEffect(() => {
-    if (!activeEntryId) {
+    if (activeEntryIds.length === 0) {
       return;
     }
 
-    const entryId = activeEntryId;
+    const targets = activeEntryIds;
 
     function onKeyDown(event: KeyboardEvent) {
       if (isEditableTarget(event.target)) {
@@ -44,20 +45,26 @@ export function useEntryMetadataShortcuts(activeEntryId: string | null): void {
       let handled = false;
 
       if (key === "p" || key === "P") {
-        setPick(entryId, "pick");
+        applyMetadataToEntries(targets, { pick: "pick" });
         handled = true;
       } else if (key === "x" || key === "X") {
-        setPick(entryId, "reject");
+        applyMetadataToEntries(targets, { pick: "reject" });
         handled = true;
       } else if (key === "u" || key === "U") {
-        setPick(entryId, "none");
+        applyMetadataToEntries(targets, { pick: "none" });
         handled = true;
       } else if (isStarRating(Number(key))) {
-        setRating(entryId, Number(key) as 0 | 1 | 2 | 3 | 4 | 5);
+        applyMetadataToEntries(targets, {
+          rating: Number(key) as 0 | 1 | 2 | 3 | 4 | 5,
+        });
         handled = true;
       } else if (key in COLOR_LABEL_SHORTCUTS) {
         const label = COLOR_LABEL_SHORTCUTS[key] as Exclude<ColorLabel, null>;
-        setColorLabel(entryId, label);
+        if (targets.length > 1) {
+          applyMetadataToEntries(targets, { colorLabel: label });
+        } else {
+          setColorLabel(targets[0]!, label);
+        }
         handled = true;
       }
 
@@ -68,13 +75,14 @@ export function useEntryMetadataShortcuts(activeEntryId: string | null): void {
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activeEntryId, setColorLabel, setPick, setRating]);
+  }, [activeEntryIds, applyMetadataToEntries, setColorLabel]);
 }
 
 interface LibraryGridShortcutsOptions {
   gridRows: string[][];
   visibleEntries: Array<{ id: string }>;
   selectedEntryId: string | null;
+  selectedEntryIds: string[];
   onSelect: (id: string) => void;
   onOpen?: (id: string) => void;
 }
@@ -83,10 +91,21 @@ export function useLibraryGridShortcuts({
   gridRows,
   visibleEntries,
   selectedEntryId,
+  selectedEntryIds,
   onSelect,
   onOpen,
 }: LibraryGridShortcutsOptions): void {
-  useEntryMetadataShortcuts(selectedEntryId);
+  const shortcutTargets = useMemo(
+    () =>
+      selectedEntryIds.length > 0
+        ? selectedEntryIds
+        : selectedEntryId
+          ? [selectedEntryId]
+          : [],
+    [selectedEntryIds, selectedEntryId],
+  );
+
+  useEntryMetadataShortcuts(shortcutTargets);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {

--- a/hooks/useEntryMetadataShortcuts.ts
+++ b/hooks/useEntryMetadataShortcuts.ts
@@ -104,6 +104,7 @@ export function useLibraryGridShortcuts({
 }: LibraryGridShortcutsOptions): void {
   const selectEntry = useLibraryStore((state) => state.selectEntry);
   const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
+  const clearSelection = useLibraryStore((state) => state.clearSelection);
   const shortcutTargets = useMemo(
     () =>
       selectedEntryIds.length > 0
@@ -126,6 +127,17 @@ export function useLibraryGridShortcuts({
 
     function onKeyDown(event: KeyboardEvent) {
       if (isEditableTarget(event.target)) {
+        return;
+      }
+
+      if (event.key === "Escape") {
+        if (document.querySelector('[role="menu"]')) {
+          return;
+        }
+        if (selectedEntryIds.length > 0) {
+          event.preventDefault();
+          clearSelection();
+        }
         return;
       }
 
@@ -206,8 +218,10 @@ export function useLibraryGridShortcuts({
     visibleEntries,
     visibleOrder,
     selectedEntryId,
+    selectedEntryIds,
     selectEntry,
     setSelectedEntryId,
+    clearSelection,
     onOpen,
     disabled,
   ]);

--- a/hooks/useEntryMetadataShortcuts.ts
+++ b/hooks/useEntryMetadataShortcuts.ts
@@ -89,6 +89,7 @@ interface LibraryGridShortcutsOptions {
   onSelect: (id: string) => void;
   onOpen?: (id: string) => void;
   disabled?: boolean;
+  metadataShortcutsDisabled?: boolean;
 }
 
 export function useLibraryGridShortcuts({
@@ -99,6 +100,7 @@ export function useLibraryGridShortcuts({
   onSelect,
   onOpen,
   disabled = false,
+  metadataShortcutsDisabled = false,
 }: LibraryGridShortcutsOptions): void {
   const shortcutTargets = useMemo(
     () =>
@@ -110,7 +112,10 @@ export function useLibraryGridShortcuts({
     [selectedEntryIds, selectedEntryId],
   );
 
-  useEntryMetadataShortcuts(shortcutTargets, disabled);
+  useEntryMetadataShortcuts(
+    shortcutTargets,
+    disabled || metadataShortcutsDisabled,
+  );
 
   useEffect(() => {
     if (disabled) {
@@ -127,6 +132,9 @@ export function useLibraryGridShortcuts({
       }
 
       if (event.key === "Enter" && selectedEntryId && onOpen) {
+        if (event.defaultPrevented) {
+          return;
+        }
         event.preventDefault();
         onOpen(selectedEntryId);
         return;

--- a/hooks/useEntryMetadataShortcuts.ts
+++ b/hooks/useEntryMetadataShortcuts.ts
@@ -6,6 +6,7 @@ import {
   isStarRating,
 } from "@/lib/catalog/defaults";
 import type { ColorLabel } from "@/lib/catalog/types";
+import { navigateGridRows } from "@/lib/library/grid-navigation";
 import { useLibraryStore } from "@/stores/library-store";
 
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -71,6 +72,7 @@ export function useEntryMetadataShortcuts(activeEntryId: string | null): void {
 }
 
 interface LibraryGridShortcutsOptions {
+  gridRows: string[][];
   visibleEntries: Array<{ id: string }>;
   selectedEntryId: string | null;
   onSelect: (id: string) => void;
@@ -78,6 +80,7 @@ interface LibraryGridShortcutsOptions {
 }
 
 export function useLibraryGridShortcuts({
+  gridRows,
   visibleEntries,
   selectedEntryId,
   onSelect,
@@ -95,16 +98,40 @@ export function useLibraryGridShortcuts({
         return;
       }
 
-      const currentIndex = selectedEntryId
-        ? visibleEntries.findIndex((entry) => entry.id === selectedEntryId)
-        : -1;
-
       if (event.key === "Enter" && selectedEntryId && onOpen) {
         event.preventDefault();
         onOpen(selectedEntryId);
         return;
       }
 
+      let nextId: string | null = null;
+
+      if (event.key === "ArrowRight") {
+        nextId = navigateGridRows(gridRows, selectedEntryId, "right");
+      } else if (event.key === "ArrowLeft") {
+        nextId = navigateGridRows(gridRows, selectedEntryId, "left");
+      } else if (event.key === "ArrowDown") {
+        nextId = navigateGridRows(gridRows, selectedEntryId, "down");
+      } else if (event.key === "ArrowUp") {
+        nextId = navigateGridRows(gridRows, selectedEntryId, "up");
+      } else {
+        return;
+      }
+
+      if (nextId && nextId !== selectedEntryId) {
+        event.preventDefault();
+        onSelect(nextId);
+        return;
+      }
+
+      // Fall back to flat navigation when grid layout is not ready.
+      if (gridRows.length > 0) {
+        return;
+      }
+
+      const currentIndex = selectedEntryId
+        ? visibleEntries.findIndex((entry) => entry.id === selectedEntryId)
+        : -1;
       let nextIndex = currentIndex;
 
       if (event.key === "ArrowRight" || event.key === "ArrowDown") {
@@ -117,8 +144,6 @@ export function useLibraryGridShortcuts({
           currentIndex < 0
             ? visibleEntries.length - 1
             : Math.max(currentIndex - 1, 0);
-      } else {
-        return;
       }
 
       if (nextIndex !== currentIndex && visibleEntries[nextIndex]) {
@@ -129,5 +154,5 @@ export function useLibraryGridShortcuts({
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [visibleEntries, selectedEntryId, onSelect, onOpen]);
+  }, [gridRows, visibleEntries, selectedEntryId, onSelect, onOpen]);
 }

--- a/hooks/useEntryMetadataShortcuts.ts
+++ b/hooks/useEntryMetadataShortcuts.ts
@@ -23,14 +23,17 @@ function isEditableTarget(target: EventTarget | null): boolean {
   );
 }
 
-export function useEntryMetadataShortcuts(activeEntryIds: string[]): void {
+export function useEntryMetadataShortcuts(
+  activeEntryIds: string[],
+  disabled = false,
+): void {
   const applyMetadataToEntries = useLibraryStore(
     (state) => state.applyMetadataToEntries,
   );
   const setColorLabel = useLibraryStore((state) => state.setColorLabel);
 
   useEffect(() => {
-    if (activeEntryIds.length === 0) {
+    if (disabled || activeEntryIds.length === 0) {
       return;
     }
 
@@ -75,7 +78,7 @@ export function useEntryMetadataShortcuts(activeEntryIds: string[]): void {
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activeEntryIds, applyMetadataToEntries, setColorLabel]);
+  }, [activeEntryIds, applyMetadataToEntries, disabled, setColorLabel]);
 }
 
 interface LibraryGridShortcutsOptions {
@@ -85,6 +88,7 @@ interface LibraryGridShortcutsOptions {
   selectedEntryIds: string[];
   onSelect: (id: string) => void;
   onOpen?: (id: string) => void;
+  disabled?: boolean;
 }
 
 export function useLibraryGridShortcuts({
@@ -94,6 +98,7 @@ export function useLibraryGridShortcuts({
   selectedEntryIds,
   onSelect,
   onOpen,
+  disabled = false,
 }: LibraryGridShortcutsOptions): void {
   const shortcutTargets = useMemo(
     () =>
@@ -105,9 +110,13 @@ export function useLibraryGridShortcuts({
     [selectedEntryIds, selectedEntryId],
   );
 
-  useEntryMetadataShortcuts(shortcutTargets);
+  useEntryMetadataShortcuts(shortcutTargets, disabled);
 
   useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
     function onKeyDown(event: KeyboardEvent) {
       if (isEditableTarget(event.target)) {
         return;
@@ -173,5 +182,5 @@ export function useLibraryGridShortcuts({
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [gridRows, visibleEntries, selectedEntryId, onSelect, onOpen]);
+  }, [gridRows, visibleEntries, selectedEntryId, onSelect, onOpen, disabled]);
 }

--- a/hooks/useEntryMetadataShortcuts.ts
+++ b/hooks/useEntryMetadataShortcuts.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  COLOR_LABEL_SHORTCUTS,
+  isStarRating,
+} from "@/lib/catalog/defaults";
+import type { ColorLabel } from "@/lib/catalog/types";
+import { useLibraryStore } from "@/stores/library-store";
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tag = target.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.isContentEditable
+  );
+}
+
+export function useEntryMetadataShortcuts(activeEntryId: string | null): void {
+  const setPick = useLibraryStore((state) => state.setPick);
+  const setRating = useLibraryStore((state) => state.setRating);
+  const setColorLabel = useLibraryStore((state) => state.setColorLabel);
+
+  useEffect(() => {
+    if (!activeEntryId) {
+      return;
+    }
+
+    const entryId = activeEntryId;
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
+      const key = event.key;
+      let handled = false;
+
+      if (key === "p" || key === "P") {
+        setPick(entryId, "pick");
+        handled = true;
+      } else if (key === "x" || key === "X") {
+        setPick(entryId, "reject");
+        handled = true;
+      } else if (key === "u" || key === "U") {
+        setPick(entryId, "none");
+        handled = true;
+      } else if (isStarRating(Number(key))) {
+        setRating(entryId, Number(key) as 0 | 1 | 2 | 3 | 4 | 5);
+        handled = true;
+      } else if (key in COLOR_LABEL_SHORTCUTS) {
+        const label = COLOR_LABEL_SHORTCUTS[key] as Exclude<ColorLabel, null>;
+        setColorLabel(entryId, label);
+        handled = true;
+      }
+
+      if (handled) {
+        event.preventDefault();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeEntryId, setColorLabel, setPick, setRating]);
+}
+
+interface LibraryGridShortcutsOptions {
+  visibleEntries: Array<{ id: string }>;
+  selectedEntryId: string | null;
+  onSelect: (id: string) => void;
+  onOpen?: (id: string) => void;
+}
+
+export function useLibraryGridShortcuts({
+  visibleEntries,
+  selectedEntryId,
+  onSelect,
+  onOpen,
+}: LibraryGridShortcutsOptions): void {
+  useEntryMetadataShortcuts(selectedEntryId);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
+      if (visibleEntries.length === 0) {
+        return;
+      }
+
+      const currentIndex = selectedEntryId
+        ? visibleEntries.findIndex((entry) => entry.id === selectedEntryId)
+        : -1;
+
+      if (event.key === "Enter" && selectedEntryId && onOpen) {
+        event.preventDefault();
+        onOpen(selectedEntryId);
+        return;
+      }
+
+      let nextIndex = currentIndex;
+
+      if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+        nextIndex =
+          currentIndex < 0
+            ? 0
+            : Math.min(currentIndex + 1, visibleEntries.length - 1);
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+        nextIndex =
+          currentIndex < 0
+            ? visibleEntries.length - 1
+            : Math.max(currentIndex - 1, 0);
+      } else {
+        return;
+      }
+
+      if (nextIndex !== currentIndex && visibleEntries[nextIndex]) {
+        event.preventDefault();
+        onSelect(visibleEntries[nextIndex].id);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [visibleEntries, selectedEntryId, onSelect, onOpen]);
+}

--- a/hooks/useEntryMetadataShortcuts.ts
+++ b/hooks/useEntryMetadataShortcuts.ts
@@ -84,9 +84,9 @@ export function useEntryMetadataShortcuts(
 interface LibraryGridShortcutsOptions {
   gridRows: string[][];
   visibleEntries: Array<{ id: string }>;
+  visibleOrder: string[];
   selectedEntryId: string | null;
   selectedEntryIds: string[];
-  onSelect: (id: string) => void;
   onOpen?: (id: string) => void;
   disabled?: boolean;
   metadataShortcutsDisabled?: boolean;
@@ -95,13 +95,15 @@ interface LibraryGridShortcutsOptions {
 export function useLibraryGridShortcuts({
   gridRows,
   visibleEntries,
+  visibleOrder,
   selectedEntryId,
   selectedEntryIds,
-  onSelect,
   onOpen,
   disabled = false,
   metadataShortcutsDisabled = false,
 }: LibraryGridShortcutsOptions): void {
+  const selectEntry = useLibraryStore((state) => state.selectEntry);
+  const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
   const shortcutTargets = useMemo(
     () =>
       selectedEntryIds.length > 0
@@ -156,7 +158,11 @@ export function useLibraryGridShortcuts({
 
       if (nextId && nextId !== selectedEntryId) {
         event.preventDefault();
-        onSelect(nextId);
+        if (event.shiftKey) {
+          selectEntry(nextId, { shift: true }, visibleOrder);
+        } else {
+          setSelectedEntryId(nextId);
+        }
         return;
       }
 
@@ -184,11 +190,25 @@ export function useLibraryGridShortcuts({
 
       if (nextIndex !== currentIndex && visibleEntries[nextIndex]) {
         event.preventDefault();
-        onSelect(visibleEntries[nextIndex].id);
+        const nextId = visibleEntries[nextIndex].id;
+        if (event.shiftKey) {
+          selectEntry(nextId, { shift: true }, visibleOrder);
+        } else {
+          setSelectedEntryId(nextId);
+        }
       }
     }
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [gridRows, visibleEntries, selectedEntryId, onSelect, onOpen, disabled]);
+  }, [
+    gridRows,
+    visibleEntries,
+    visibleOrder,
+    selectedEntryId,
+    selectEntry,
+    setSelectedEntryId,
+    onOpen,
+    disabled,
+  ]);
 }

--- a/hooks/useGridContainerWidth.ts
+++ b/hooks/useGridContainerWidth.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type RefObject,
+} from "react";
+import { measureContentWidth } from "@/lib/library/grid-layout";
+
+export function useGridContainerWidth(
+  parentRef: RefObject<HTMLElement | null>,
+  remeasureKey: unknown,
+): number {
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  const updateWidth = useCallback((element: HTMLElement) => {
+    const width = measureContentWidth(element);
+    if (width > 0) {
+      setContainerWidth(width);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    const element = parentRef.current;
+    if (element) {
+      updateWidth(element);
+    }
+  }, [parentRef, updateWidth, remeasureKey]);
+
+  useEffect(() => {
+    const element = parentRef.current;
+    if (!element) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => updateWidth(element));
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [parentRef, updateWidth]);
+
+  return containerWidth;
+}

--- a/hooks/useLibraryContextMenu.tsx
+++ b/hooks/useLibraryContextMenu.tsx
@@ -12,7 +12,10 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { DeleteFromDiskConfirm } from "@/components/library/DeleteFromDiskConfirm";
-import { COLOR_LABEL_HEX } from "@/lib/catalog/defaults";
+import {
+  COLOR_LABEL_HEX,
+  COLOR_LABEL_SHORTCUT_HINTS,
+} from "@/lib/catalog/defaults";
 import { COLOR_LABELS } from "@/lib/catalog/types";
 import { useLibraryStore } from "@/stores/library-store";
 
@@ -250,7 +253,7 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
             <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
               Color label
             </div>
-            {COLOR_LABELS.map((label, index) => (
+            {COLOR_LABELS.map((label) => (
               <ContextMenuItem
                 key={label}
                 onClick={() => applyToTargets({ colorLabel: label })}
@@ -260,7 +263,7 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
                   style={{ backgroundColor: COLOR_LABEL_HEX[label] }}
                 />
                 <span className="capitalize">{label}</span>
-                <ShortcutHint>{index + 6}</ShortcutHint>
+                <ShortcutHint>{COLOR_LABEL_SHORTCUT_HINTS[label]}</ShortcutHint>
               </ContextMenuItem>
             ))}
             <ContextMenuItem onClick={() => applyToTargets({ colorLabel: null })}>
@@ -360,9 +363,9 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
             entryIds={diskDeleteTargets}
             onClose={() => setDiskDeleteTargets(null)}
             onConfirm={() => {
-              void deleteEntriesFromDisk(diskDeleteTargets).then(() =>
-                setDiskDeleteTargets(null),
-              );
+              void deleteEntriesFromDisk(diskDeleteTargets)
+                .then(() => setDiskDeleteTargets(null))
+                .catch(() => {});
             }}
           />,
           document.body,

--- a/hooks/useLibraryContextMenu.tsx
+++ b/hooks/useLibraryContextMenu.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import { COLOR_LABEL_HEX } from "@/lib/catalog/defaults";
+import { COLOR_LABELS } from "@/lib/catalog/types";
+import { useLibraryStore } from "@/stores/library-store";
+
+interface ContextMenuState {
+  x: number;
+  y: number;
+  entryId: string;
+}
+
+function getActionTargets(
+  entryId: string,
+  selectedEntryIds: string[],
+): string[] {
+  if (selectedEntryIds.includes(entryId)) {
+    return selectedEntryIds;
+  }
+  return [entryId];
+}
+
+export function useLibraryContextMenu(visibleOrder: string[]) {
+  const router = useRouter();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menu, setMenu] = useState<ContextMenuState | null>(null);
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+  const selectedEntryIds = useLibraryStore((state) => state.selectedEntryIds);
+  const selectEntry = useLibraryStore((state) => state.selectEntry);
+  const applyMetadataToEntries = useLibraryStore(
+    (state) => state.applyMetadataToEntries,
+  );
+
+  const actionTargets = useMemo(
+    () => (menu ? getActionTargets(menu.entryId, selectedEntryIds) : []),
+    [menu, selectedEntryIds],
+  );
+
+  const closeMenu = useCallback(() => setMenu(null), []);
+
+  const openContextMenu = useCallback(
+    (entryId: string, event: ReactMouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!selectedEntryIds.includes(entryId)) {
+        selectEntry(entryId, {}, visibleOrder);
+      }
+
+      setMenu({ x: event.clientX, y: event.clientY, entryId });
+      setPosition(null);
+    },
+    [selectEntry, selectedEntryIds, visibleOrder],
+  );
+
+  useLayoutEffect(() => {
+    if (!menu || !menuRef.current) {
+      return;
+    }
+
+    const rect = menuRef.current.getBoundingClientRect();
+    const x = Math.min(menu.x, window.innerWidth - rect.width - 8);
+    const y = Math.min(menu.y, window.innerHeight - rect.height - 8);
+    setPosition({
+      x: Math.max(8, x),
+      y: Math.max(8, y),
+    });
+  }, [menu]);
+
+  useEffect(() => {
+    if (!menu) {
+      return;
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        closeMenu();
+      }
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      if (menuRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      closeMenu();
+    }
+
+    function onScroll() {
+      closeMenu();
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("scroll", onScroll, true);
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+  }, [closeMenu, menu]);
+
+  const applyToTargets = useCallback(
+    (patch: Parameters<typeof applyMetadataToEntries>[1]) => {
+      if (actionTargets.length === 0) {
+        return;
+      }
+      applyMetadataToEntries(actionTargets, patch);
+      closeMenu();
+    },
+    [actionTargets, applyMetadataToEntries, closeMenu],
+  );
+
+  const contextMenu =
+    menu && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            ref={menuRef}
+            className="fixed z-50 min-w-[180px] rounded border border-lr-border bg-lr-panel py-1 shadow-lg"
+            style={{
+              left: position?.x ?? menu.x,
+              top: position?.y ?? menu.y,
+            }}
+            role="menu"
+          >
+            <ContextMenuItem
+              onClick={() => {
+                router.push(
+                  `/photo?id=${encodeURIComponent(menu.entryId)}`,
+                );
+                closeMenu();
+              }}
+            >
+              Open in Develop
+            </ContextMenuItem>
+
+            <ContextMenuSeparator />
+
+            <ContextMenuItem onClick={() => applyToTargets({ pick: "pick" })}>
+              Pick
+              <ShortcutHint>P</ShortcutHint>
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => applyToTargets({ pick: "reject" })}>
+              Reject
+              <ShortcutHint>X</ShortcutHint>
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => applyToTargets({ pick: "none" })}>
+              Unflagged
+              <ShortcutHint>U</ShortcutHint>
+            </ContextMenuItem>
+
+            <ContextMenuSeparator />
+
+            <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+              Rating
+            </div>
+            {([1, 2, 3, 4, 5] as const).map((rating) => (
+              <ContextMenuItem
+                key={rating}
+                onClick={() =>
+                  applyToTargets({ rating })
+                }
+              >
+                {"★".repeat(rating)}
+                <span className="text-lr-text-dim">
+                  {rating === 1 ? " star" : " stars"}
+                </span>
+                <ShortcutHint>{rating}</ShortcutHint>
+              </ContextMenuItem>
+            ))}
+            <ContextMenuItem onClick={() => applyToTargets({ rating: 0 })}>
+              Clear rating
+              <ShortcutHint>0</ShortcutHint>
+            </ContextMenuItem>
+
+            <ContextMenuSeparator />
+
+            <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+              Color label
+            </div>
+            {COLOR_LABELS.map((label, index) => (
+              <ContextMenuItem
+                key={label}
+                onClick={() => applyToTargets({ colorLabel: label })}
+              >
+                <span
+                  className="inline-block h-2.5 w-2.5 rounded-full"
+                  style={{ backgroundColor: COLOR_LABEL_HEX[label] }}
+                />
+                <span className="capitalize">{label}</span>
+                <ShortcutHint>{index + 6}</ShortcutHint>
+              </ContextMenuItem>
+            ))}
+            <ContextMenuItem onClick={() => applyToTargets({ colorLabel: null })}>
+              Clear label
+            </ContextMenuItem>
+
+            {actionTargets.length > 1 ? (
+              <>
+                <ContextMenuSeparator />
+                <div className="px-3 py-1.5 text-[10px] text-lr-text-dim">
+                  {actionTargets.length} photos selected
+                </div>
+              </>
+            ) : null}
+          </div>,
+          document.body,
+        )
+      : null;
+
+  return { openContextMenu, contextMenu };
+}
+
+function ContextMenuItem({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-lr-text transition hover:bg-lr-panel-raised"
+    >
+      {children}
+    </button>
+  );
+}
+
+function ContextMenuSeparator() {
+  return <div className="my-1 h-px bg-lr-border-subtle" role="separator" />;
+}
+
+function ShortcutHint({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="ml-auto text-[10px] text-lr-text-dim">{children}</span>
+  );
+}

--- a/hooks/useLibraryContextMenu.tsx
+++ b/hooks/useLibraryContextMenu.tsx
@@ -40,6 +40,9 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
   );
   const selectedEntryIds = useLibraryStore((state) => state.selectedEntryIds);
   const selectEntry = useLibraryStore((state) => state.selectEntry);
+  const albums = useLibraryStore((state) => state.albums);
+  const createAlbum = useLibraryStore((state) => state.createAlbum);
+  const addEntriesToAlbum = useLibraryStore((state) => state.addEntriesToAlbum);
   const applyMetadataToEntries = useLibraryStore(
     (state) => state.applyMetadataToEntries,
   );
@@ -206,6 +209,36 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
             ))}
             <ContextMenuItem onClick={() => applyToTargets({ colorLabel: null })}>
               Clear label
+            </ContextMenuItem>
+
+            <ContextMenuSeparator />
+
+            <div className="flex items-center px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+              <span>Add to album</span>
+              <ShortcutHint>B</ShortcutHint>
+            </div>
+            {albums.map((album) => (
+              <ContextMenuItem
+                key={album.id}
+                onClick={() => {
+                  addEntriesToAlbum(album.id, actionTargets);
+                  closeMenu();
+                }}
+              >
+                {album.name}
+              </ContextMenuItem>
+            ))}
+            <ContextMenuItem
+              onClick={() => {
+                const name = `Album ${albums.length + 1}`;
+                const albumId = createAlbum(name);
+                if (albumId) {
+                  addEntriesToAlbum(albumId, actionTargets);
+                }
+                closeMenu();
+              }}
+            >
+              New album…
             </ContextMenuItem>
 
             {actionTargets.length > 1 ? (

--- a/hooks/useLibraryContextMenu.tsx
+++ b/hooks/useLibraryContextMenu.tsx
@@ -11,6 +11,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { createPortal } from "react-dom";
+import { DeleteFromDiskConfirm } from "@/components/library/DeleteFromDiskConfirm";
 import { COLOR_LABEL_HEX } from "@/lib/catalog/defaults";
 import { COLOR_LABELS } from "@/lib/catalog/types";
 import { useLibraryStore } from "@/stores/library-store";
@@ -35,6 +36,9 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
   const router = useRouter();
   const menuRef = useRef<HTMLDivElement>(null);
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
+  const [diskDeleteTargets, setDiskDeleteTargets] = useState<string[] | null>(
+    null,
+  );
   const [position, setPosition] = useState<{ x: number; y: number } | null>(
     null,
   );
@@ -43,14 +47,36 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
   const albums = useLibraryStore((state) => state.albums);
   const createAlbum = useLibraryStore((state) => state.createAlbum);
   const addEntriesToAlbum = useLibraryStore((state) => state.addEntriesToAlbum);
+  const removeEntriesFromAlbum = useLibraryStore(
+    (state) => state.removeEntriesFromAlbum,
+  );
+  const archiveEntries = useLibraryStore((state) => state.archiveEntries);
+  const restoreEntries = useLibraryStore((state) => state.restoreEntries);
+  const deleteEntriesFromDisk = useLibraryStore(
+    (state) => state.deleteEntriesFromDisk,
+  );
+  const catalogView = useLibraryStore((state) => state.catalogView);
   const applyMetadataToEntries = useLibraryStore(
     (state) => state.applyMetadataToEntries,
   );
+
+  const isArchiveView = catalogView.type === "archive";
 
   const actionTargets = useMemo(
     () => (menu ? getActionTargets(menu.entryId, selectedEntryIds) : []),
     [menu, selectedEntryIds],
   );
+
+  const albumsContainingSelection = useMemo(() => {
+    if (actionTargets.length === 0) {
+      return [];
+    }
+
+    const targetSet = new Set(actionTargets);
+    return albums.filter((album) =>
+      album.entryIds.some((id) => targetSet.has(id)),
+    );
+  }, [actionTargets, albums]);
 
   const closeMenu = useCallback(() => setMenu(null), []);
 
@@ -139,6 +165,36 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
             }}
             role="menu"
           >
+            {isArchiveView ? (
+              <>
+                <ContextMenuItem
+                  onClick={() => {
+                    restoreEntries(actionTargets);
+                    closeMenu();
+                  }}
+                >
+                  Restore to imported
+                </ContextMenuItem>
+                <ContextMenuItem
+                  onClick={() => {
+                    setDiskDeleteTargets(actionTargets);
+                    closeMenu();
+                  }}
+                >
+                  <span className="text-red-400">Remove from disk</span>
+                </ContextMenuItem>
+
+                {actionTargets.length > 1 ? (
+                  <>
+                    <ContextMenuSeparator />
+                    <div className="px-3 py-1.5 text-[10px] text-lr-text-dim">
+                      {actionTargets.length} photos selected
+                    </div>
+                  </>
+                ) : null}
+              </>
+            ) : (
+              <>
             <ContextMenuItem
               onClick={() => {
                 router.push(
@@ -241,6 +297,47 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
               New album…
             </ContextMenuItem>
 
+            {albumsContainingSelection.length > 0 ? (
+              <>
+                <ContextMenuSeparator />
+                <div className="flex items-center px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+                  <span>Remove from album</span>
+                </div>
+                {albumsContainingSelection.map((album) => (
+                  <ContextMenuItem
+                    key={album.id}
+                    onClick={() => {
+                      removeEntriesFromAlbum(album.id, actionTargets);
+                      closeMenu();
+                    }}
+                  >
+                    {album.name}
+                  </ContextMenuItem>
+                ))}
+              </>
+            ) : null}
+
+            <ContextMenuSeparator />
+
+            <ContextMenuItem
+              onClick={() => {
+                archiveEntries(actionTargets);
+                closeMenu();
+              }}
+            >
+              Remove from imported
+            </ContextMenuItem>
+
+            <ContextMenuItem
+              onClick={() => {
+                setDiskDeleteTargets(actionTargets);
+                closeMenu();
+              }}
+            >
+              <span className="text-red-400">Remove from disk</span>
+              <ShortcutHint>Del</ShortcutHint>
+            </ContextMenuItem>
+
             {actionTargets.length > 1 ? (
               <>
                 <ContextMenuSeparator />
@@ -249,12 +346,39 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
                 </div>
               </>
             ) : null}
+              </>
+            )}
           </div>,
           document.body,
         )
       : null;
 
-  return { openContextMenu, contextMenu };
+  const diskDeleteConfirm =
+    diskDeleteTargets && typeof document !== "undefined"
+      ? createPortal(
+          <DeleteFromDiskConfirm
+            entryIds={diskDeleteTargets}
+            onClose={() => setDiskDeleteTargets(null)}
+            onConfirm={() => {
+              void deleteEntriesFromDisk(diskDeleteTargets).then(() =>
+                setDiskDeleteTargets(null),
+              );
+            }}
+          />,
+          document.body,
+        )
+      : null;
+
+  return {
+    openContextMenu,
+    contextMenu: (
+      <>
+        {contextMenu}
+        {diskDeleteConfirm}
+      </>
+    ),
+    actionOverlayOpen: diskDeleteTargets !== null,
+  };
 }
 
 function ContextMenuItem({

--- a/hooks/useScrollToSelectedRow.ts
+++ b/hooks/useScrollToSelectedRow.ts
@@ -1,0 +1,40 @@
+import { useLayoutEffect, useRef } from "react";
+import type { Virtualizer } from "@tanstack/react-virtual";
+
+interface UseScrollToSelectedRowOptions {
+  layoutReady: boolean;
+  selectedRowIndex: number;
+  virtualizer: Virtualizer<HTMLDivElement, Element>;
+  /** Rows jumped in one step before smooth scroll is used. */
+  smoothRowThreshold?: number;
+}
+
+export function useScrollToSelectedRow({
+  layoutReady,
+  selectedRowIndex,
+  virtualizer,
+  smoothRowThreshold = 3,
+}: UseScrollToSelectedRowOptions): void {
+  const previousRowIndexRef = useRef(-1);
+  const virtualizerRef = useRef(virtualizer);
+  virtualizerRef.current = virtualizer;
+
+  useLayoutEffect(() => {
+    if (!layoutReady || selectedRowIndex < 0) {
+      return;
+    }
+
+    const previousRowIndex = previousRowIndexRef.current;
+    previousRowIndexRef.current = selectedRowIndex;
+
+    const rowDistance =
+      previousRowIndex < 0
+        ? 0
+        : Math.abs(selectedRowIndex - previousRowIndex);
+
+    virtualizerRef.current.scrollToIndex(selectedRowIndex, {
+      align: "auto",
+      behavior: rowDistance >= smoothRowThreshold ? "smooth" : "instant",
+    });
+  }, [layoutReady, selectedRowIndex, smoothRowThreshold]);
+}

--- a/lib/catalog/defaults.ts
+++ b/lib/catalog/defaults.ts
@@ -1,0 +1,53 @@
+import type { ColorLabel, EntryMetadata, StarRating } from "./types";
+
+export const DEFAULT_ENTRY_METADATA: EntryMetadata = {
+  pick: "none",
+  rating: 0,
+  colorLabel: null,
+  updatedAt: 0,
+};
+
+export function createEntryMetadata(
+  patch: Partial<EntryMetadata> = {},
+): EntryMetadata {
+  return {
+    ...DEFAULT_ENTRY_METADATA,
+    ...patch,
+    updatedAt: patch.updatedAt ?? Date.now(),
+  };
+}
+
+export function getEntryMetadata(
+  map: Record<string, EntryMetadata>,
+  entryId: string,
+): EntryMetadata {
+  return map[entryId] ?? DEFAULT_ENTRY_METADATA;
+}
+
+export function hasCuration(metadata: EntryMetadata): boolean {
+  return (
+    metadata.pick !== "none" ||
+    metadata.rating > 0 ||
+    metadata.colorLabel !== null
+  );
+}
+
+export function isStarRating(value: number): value is StarRating {
+  return Number.isInteger(value) && value >= 0 && value <= 5;
+}
+
+export const COLOR_LABEL_HEX: Record<Exclude<ColorLabel, null>, string> = {
+  red: "#e74c3c",
+  yellow: "#f1c40f",
+  green: "#2ecc71",
+  blue: "#3498db",
+  purple: "#9b59b6",
+};
+
+export const COLOR_LABEL_SHORTCUTS: Record<string, Exclude<ColorLabel, null>> = {
+  "6": "red",
+  "7": "yellow",
+  "8": "green",
+  "9": "blue",
+  "\\": "purple",
+};

--- a/lib/catalog/defaults.ts
+++ b/lib/catalog/defaults.ts
@@ -51,3 +51,7 @@ export const COLOR_LABEL_SHORTCUTS: Record<string, Exclude<ColorLabel, null>> = 
   "9": "blue",
   "\\": "purple",
 };
+
+export const COLOR_LABEL_SHORTCUT_HINTS = Object.fromEntries(
+  Object.entries(COLOR_LABEL_SHORTCUTS).map(([key, label]) => [label, key]),
+) as Record<Exclude<ColorLabel, null>, string>;

--- a/lib/catalog/persistence.ts
+++ b/lib/catalog/persistence.ts
@@ -1,0 +1,89 @@
+import { get, set, del } from "idb-keyval";
+import type { EntryMetadata, PhotoCatalog } from "./types";
+import { isElectronApp, getDarkroomAPI } from "@/lib/fs/platform";
+
+const CATALOG_PREFIX = "darkroom-catalog:";
+
+function catalogIdbKey(rootPath: string): string {
+  return `${CATALOG_PREFIX}${rootPath}`;
+}
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingCatalog: PhotoCatalog | null = null;
+
+const PERSIST_DEBOUNCE_MS = 300;
+
+async function flushCatalog(): Promise<void> {
+  const catalog = pendingCatalog;
+  pendingCatalog = null;
+  persistTimer = null;
+
+  if (!catalog) {
+    return;
+  }
+
+  if (isElectronApp()) {
+    await getDarkroomAPI().writeCatalog(catalog);
+    return;
+  }
+
+  await set(catalogIdbKey(catalog.rootPath), catalog);
+}
+
+export function scheduleCatalogPersist(catalog: PhotoCatalog): void {
+  pendingCatalog = catalog;
+
+  if (persistTimer) {
+    clearTimeout(persistTimer);
+  }
+
+  persistTimer = setTimeout(() => {
+    void flushCatalog().catch(() => {
+      // Catalog persistence is best-effort.
+    });
+  }, PERSIST_DEBOUNCE_MS);
+}
+
+export async function loadCatalog(rootPath: string): Promise<PhotoCatalog | null> {
+  if (isElectronApp()) {
+    return getDarkroomAPI().readCatalog(rootPath);
+  }
+
+  const stored = await get<PhotoCatalog>(catalogIdbKey(rootPath));
+  return stored ?? null;
+}
+
+export async function saveCatalog(catalog: PhotoCatalog): Promise<void> {
+  if (isElectronApp()) {
+    await getDarkroomAPI().writeCatalog(catalog);
+    return;
+  }
+
+  await set(catalogIdbKey(catalog.rootPath), catalog);
+}
+
+export async function deleteCatalog(rootPath: string): Promise<void> {
+  if (persistTimer) {
+    clearTimeout(persistTimer);
+    persistTimer = null;
+    pendingCatalog = null;
+  }
+
+  if (isElectronApp()) {
+    await getDarkroomAPI().deleteCatalog(rootPath);
+    return;
+  }
+
+  await del(catalogIdbKey(rootPath));
+}
+
+export function buildPhotoCatalog(
+  rootPath: string,
+  entries: Record<string, EntryMetadata>,
+): PhotoCatalog {
+  return {
+    version: 1,
+    rootPath,
+    entries,
+  };
+}

--- a/lib/catalog/persistence.ts
+++ b/lib/catalog/persistence.ts
@@ -81,11 +81,13 @@ export function buildPhotoCatalog(
   rootPath: string,
   entries: Record<string, EntryMetadata>,
   albums: Album[] = [],
+  archivedEntryIds: string[] = [],
 ): PhotoCatalog {
   return {
     version: 1,
     rootPath,
     entries,
     albums,
+    archivedEntryIds,
   };
 }

--- a/lib/catalog/persistence.ts
+++ b/lib/catalog/persistence.ts
@@ -1,5 +1,5 @@
 import { get, set, del } from "idb-keyval";
-import type { EntryMetadata, PhotoCatalog } from "./types";
+import type { Album, EntryMetadata, PhotoCatalog } from "./types";
 import { isElectronApp, getDarkroomAPI } from "@/lib/fs/platform";
 
 const CATALOG_PREFIX = "darkroom-catalog:";
@@ -80,10 +80,12 @@ export async function deleteCatalog(rootPath: string): Promise<void> {
 export function buildPhotoCatalog(
   rootPath: string,
   entries: Record<string, EntryMetadata>,
+  albums: Album[] = [],
 ): PhotoCatalog {
   return {
     version: 1,
     rootPath,
     entries,
+    albums,
   };
 }

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -9,10 +9,19 @@ export interface EntryMetadata {
   updatedAt: number;
 }
 
+export interface Album {
+  id: string;
+  name: string;
+  entryIds: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface PhotoCatalog {
   version: 1;
   rootPath: string;
   entries: Record<string, EntryMetadata>;
+  albums?: Album[];
 }
 
 export const COLOR_LABELS = [

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -1,0 +1,24 @@
+export type PickStatus = "none" | "pick" | "reject";
+export type StarRating = 0 | 1 | 2 | 3 | 4 | 5;
+export type ColorLabel = "red" | "yellow" | "green" | "blue" | "purple" | null;
+
+export interface EntryMetadata {
+  pick: PickStatus;
+  rating: StarRating;
+  colorLabel: ColorLabel;
+  updatedAt: number;
+}
+
+export interface PhotoCatalog {
+  version: 1;
+  rootPath: string;
+  entries: Record<string, EntryMetadata>;
+}
+
+export const COLOR_LABELS = [
+  "red",
+  "yellow",
+  "green",
+  "blue",
+  "purple",
+] as const satisfies readonly Exclude<ColorLabel, null>[];

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -22,6 +22,7 @@ export interface PhotoCatalog {
   rootPath: string;
   entries: Record<string, EntryMetadata>;
   albums?: Album[];
+  archivedEntryIds?: string[];
 }
 
 export const COLOR_LABELS = [

--- a/lib/catalog/xmp.ts
+++ b/lib/catalog/xmp.ts
@@ -1,0 +1,19 @@
+import type { EntryMetadata } from "./types";
+import type { LibraryEntry } from "@/lib/fs/types";
+
+/** Phase 2: read XMP sidecar and merge into catalog metadata. */
+export async function importXmpForEntry(
+  _entry: LibraryEntry,
+  _rootPath: string,
+): Promise<Partial<EntryMetadata> | null> {
+  return null;
+}
+
+/** Phase 2: write catalog metadata to XMP sidecar. */
+export async function exportXmpForEntry(
+  _entry: LibraryEntry,
+  _rootPath: string,
+  _metadata: EntryMetadata,
+): Promise<void> {
+  // Not implemented in v1.
+}

--- a/lib/fs/platform.ts
+++ b/lib/fs/platform.ts
@@ -13,3 +13,15 @@ export function joinRootPath(rootPath: string, relativePath: string): string {
   const separator = rootPath.includes("\\") ? "\\" : "/";
   return `${rootPath}${separator}${relativePath.split("/").join(separator)}`;
 }
+
+export async function deleteFilesFromDisk(
+  absolutePaths: string[],
+): Promise<void> {
+  const api = getDarkroomAPI();
+  if (typeof api.deleteFiles !== "function") {
+    throw new Error(
+      "Remove from disk is unavailable. Quit and restart the desktop app.",
+    );
+  }
+  await api.deleteFiles(absolutePaths);
+}

--- a/lib/library/archive.ts
+++ b/lib/library/archive.ts
@@ -1,0 +1,32 @@
+import type { LibraryEntry } from "@/lib/fs/types";
+
+export function filterArchivedEntries(
+  entries: LibraryEntry[],
+  archivedEntryIds: string[],
+): LibraryEntry[] {
+  if (archivedEntryIds.length === 0) {
+    return entries;
+  }
+
+  const archived = new Set(archivedEntryIds);
+  return entries.filter((entry) => !archived.has(entry.id));
+}
+
+export function filterOnlyArchivedEntries(
+  entries: LibraryEntry[],
+  archivedEntryIds: string[],
+): LibraryEntry[] {
+  if (archivedEntryIds.length === 0) {
+    return [];
+  }
+
+  const archived = new Set(archivedEntryIds);
+  return entries.filter((entry) => archived.has(entry.id));
+}
+
+export function pruneArchivedEntryIds(
+  archivedEntryIds: string[],
+  entryIds: Set<string>,
+): string[] {
+  return archivedEntryIds.filter((id) => entryIds.has(id));
+}

--- a/lib/library/curation.ts
+++ b/lib/library/curation.ts
@@ -1,0 +1,218 @@
+import type { EntryMetadata } from "@/lib/catalog/types";
+import { getEntryMetadata } from "@/lib/catalog/defaults";
+import type { LibraryEntry } from "@/lib/fs/types";
+import type { CurationFilter, FilterOption, SortOption } from "./filter-types";
+
+export type { CurationFilter } from "./filter-types";
+
+export function filterByFormat(
+  entries: LibraryEntry[],
+  filter: FilterOption,
+): LibraryEntry[] {
+  if (filter === "raw") {
+    return entries.filter((entry) => entry.profileId !== "standard");
+  }
+  if (filter === "standard") {
+    return entries.filter((entry) => entry.profileId === "standard");
+  }
+  return entries;
+}
+
+export function filterByCuration(
+  entries: LibraryEntry[],
+  metadata: Record<string, EntryMetadata>,
+  filter: CurationFilter,
+): LibraryEntry[] {
+  if (filter === "all") {
+    return entries;
+  }
+
+  return entries.filter((entry) => {
+    const meta = getEntryMetadata(metadata, entry.id);
+
+    switch (filter) {
+      case "picked":
+        return meta.pick === "pick";
+      case "rejected":
+        return meta.pick === "reject";
+      case "unpicked":
+        return meta.pick === "none";
+      case "rated":
+        return meta.rating >= 1;
+      case "rating-1":
+        return meta.rating === 1;
+      case "rating-2":
+        return meta.rating === 2;
+      case "rating-3":
+        return meta.rating === 3;
+      case "rating-4":
+        return meta.rating === 4;
+      case "rating-5":
+        return meta.rating === 5;
+      case "label-red":
+        return meta.colorLabel === "red";
+      case "label-yellow":
+        return meta.colorLabel === "yellow";
+      case "label-green":
+        return meta.colorLabel === "green";
+      case "label-blue":
+        return meta.colorLabel === "blue";
+      case "label-purple":
+        return meta.colorLabel === "purple";
+      default:
+        return true;
+    }
+  });
+}
+
+const PICK_ORDER = { pick: 0, none: 1, reject: 2 } as const;
+
+export function sortLibraryEntries(
+  entries: LibraryEntry[],
+  metadata: Record<string, EntryMetadata>,
+  sort: SortOption,
+): LibraryEntry[] {
+  const sorted = [...entries];
+
+  if (sort === "date") {
+    sorted.sort((a, b) => b.lastModified - a.lastModified);
+    return sorted;
+  }
+
+  if (sort === "rating") {
+    sorted.sort((a, b) => {
+      const ratingDiff =
+        getEntryMetadata(metadata, b.id).rating -
+        getEntryMetadata(metadata, a.id).rating;
+      if (ratingDiff !== 0) {
+        return ratingDiff;
+      }
+      return a.name.localeCompare(b.name);
+    });
+    return sorted;
+  }
+
+  if (sort === "pick") {
+    sorted.sort((a, b) => {
+      const pickDiff =
+        PICK_ORDER[getEntryMetadata(metadata, a.id).pick] -
+        PICK_ORDER[getEntryMetadata(metadata, b.id).pick];
+      if (pickDiff !== 0) {
+        return pickDiff;
+      }
+      return a.name.localeCompare(b.name);
+    });
+    return sorted;
+  }
+
+  sorted.sort((a, b) => a.name.localeCompare(b.name));
+  return sorted;
+}
+
+export interface CurationCounts {
+  picked: number;
+  rejected: number;
+  unpicked: number;
+  rated: number;
+  rating1: number;
+  rating2: number;
+  rating3: number;
+  rating4: number;
+  rating5: number;
+  labelRed: number;
+  labelYellow: number;
+  labelGreen: number;
+  labelBlue: number;
+  labelPurple: number;
+}
+
+export function countCuration(
+  entries: LibraryEntry[],
+  metadata: Record<string, EntryMetadata>,
+): CurationCounts {
+  const counts: CurationCounts = {
+    picked: 0,
+    rejected: 0,
+    unpicked: 0,
+    rated: 0,
+    rating1: 0,
+    rating2: 0,
+    rating3: 0,
+    rating4: 0,
+    rating5: 0,
+    labelRed: 0,
+    labelYellow: 0,
+    labelGreen: 0,
+    labelBlue: 0,
+    labelPurple: 0,
+  };
+
+  for (const entry of entries) {
+    const meta = getEntryMetadata(metadata, entry.id);
+
+    if (meta.pick === "pick") {
+      counts.picked += 1;
+    } else if (meta.pick === "reject") {
+      counts.rejected += 1;
+    } else {
+      counts.unpicked += 1;
+    }
+
+    if (meta.rating >= 1) {
+      counts.rated += 1;
+    }
+
+    switch (meta.rating) {
+      case 1:
+        counts.rating1 += 1;
+        break;
+      case 2:
+        counts.rating2 += 1;
+        break;
+      case 3:
+        counts.rating3 += 1;
+        break;
+      case 4:
+        counts.rating4 += 1;
+        break;
+      case 5:
+        counts.rating5 += 1;
+        break;
+    }
+
+    switch (meta.colorLabel) {
+      case "red":
+        counts.labelRed += 1;
+        break;
+      case "yellow":
+        counts.labelYellow += 1;
+        break;
+      case "green":
+        counts.labelGreen += 1;
+        break;
+      case "blue":
+        counts.labelBlue += 1;
+        break;
+      case "purple":
+        counts.labelPurple += 1;
+        break;
+    }
+  }
+
+  return counts;
+}
+
+export function pruneMetadataForEntries(
+  metadata: Record<string, EntryMetadata>,
+  entryIds: Set<string>,
+): Record<string, EntryMetadata> {
+  const pruned: Record<string, EntryMetadata> = {};
+
+  for (const [id, meta] of Object.entries(metadata)) {
+    if (entryIds.has(id)) {
+      pruned[id] = meta;
+    }
+  }
+
+  return pruned;
+}

--- a/lib/library/filter-types.ts
+++ b/lib/library/filter-types.ts
@@ -1,0 +1,20 @@
+export type SortOption = "name" | "date" | "rating" | "pick";
+export type FilterOption = "all" | "raw" | "standard";
+export type GridViewMode = "grid" | "dynamic";
+
+export type CurationFilter =
+  | "all"
+  | "picked"
+  | "rejected"
+  | "unpicked"
+  | "rated"
+  | "rating-1"
+  | "rating-2"
+  | "rating-3"
+  | "rating-4"
+  | "rating-5"
+  | "label-red"
+  | "label-yellow"
+  | "label-green"
+  | "label-blue"
+  | "label-purple";

--- a/lib/library/folders.ts
+++ b/lib/library/folders.ts
@@ -1,0 +1,104 @@
+import type { Album } from "@/lib/catalog/types";
+import type { LibraryEntry } from "@/lib/fs/types";
+
+export interface FolderNode {
+  name: string;
+  path: string;
+  photoCount: number;
+  children: FolderNode[];
+}
+
+export interface FolderTree {
+  rootPhotoCount: number;
+  folders: FolderNode[];
+}
+
+export function getParentFolderPath(relativePath: string): string | null {
+  const slash = relativePath.lastIndexOf("/");
+  if (slash === -1) {
+    return null;
+  }
+  return relativePath.slice(0, slash);
+}
+
+export function buildFolderTree(entries: LibraryEntry[]): FolderTree {
+  const nodes = new Map<string, FolderNode>();
+  let rootPhotoCount = 0;
+
+  function ensureNode(path: string): FolderNode {
+    const existing = nodes.get(path);
+    if (existing) {
+      return existing;
+    }
+
+    const name = path.split("/").pop()!;
+    const node: FolderNode = { name, path, photoCount: 0, children: [] };
+    nodes.set(path, node);
+
+    const slash = path.lastIndexOf("/");
+    if (slash !== -1) {
+      ensureNode(path.slice(0, slash)).children.push(node);
+    }
+
+    return node;
+  }
+
+  for (const entry of entries) {
+    const parent = getParentFolderPath(entry.relativePath);
+    if (!parent) {
+      rootPhotoCount += 1;
+    } else {
+      ensureNode(parent).photoCount += 1;
+    }
+  }
+
+  for (const node of nodes.values()) {
+    node.children.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  const folders = [...nodes.values()]
+    .filter((node) => !node.path.includes("/"))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return { rootPhotoCount, folders };
+}
+
+/** `null` = all photos; `""` = root-level files only. */
+export function filterByFolderPath(
+  entries: LibraryEntry[],
+  folderPath: string | null,
+): LibraryEntry[] {
+  if (folderPath === null) {
+    return entries;
+  }
+
+  if (folderPath === "") {
+    return entries.filter((entry) => !entry.relativePath.includes("/"));
+  }
+
+  return entries.filter(
+    (entry) => getParentFolderPath(entry.relativePath) === folderPath,
+  );
+}
+
+export function filterByAlbum(
+  entries: LibraryEntry[],
+  album: Album | undefined,
+): LibraryEntry[] {
+  if (!album) {
+    return entries;
+  }
+
+  const entryIds = new Set(album.entryIds);
+  return entries.filter((entry) => entryIds.has(entry.id));
+}
+
+export function pruneAlbumsForEntries(
+  albums: Album[],
+  entryIds: Set<string>,
+): Album[] {
+  return albums.map((album) => ({
+    ...album,
+    entryIds: album.entryIds.filter((id) => entryIds.has(id)),
+  }));
+}

--- a/lib/library/fuzzy-match.ts
+++ b/lib/library/fuzzy-match.ts
@@ -1,0 +1,59 @@
+/** Subsequence fuzzy score; 0 = no match, higher = better. */
+export function fuzzyScore(query: string, text: string): number {
+  const q = query.toLowerCase().trim();
+  const t = text.toLowerCase();
+
+  if (!q) {
+    return 1;
+  }
+
+  let score = 0;
+  let textIndex = 0;
+  let consecutive = 0;
+
+  for (let queryIndex = 0; queryIndex < q.length; queryIndex++) {
+    const char = q[queryIndex]!;
+    let found = false;
+
+    while (textIndex < t.length) {
+      if (t[textIndex] === char) {
+        score += 1 + consecutive * 2;
+        consecutive += 1;
+        textIndex += 1;
+        found = true;
+        break;
+      }
+      consecutive = 0;
+      textIndex += 1;
+    }
+
+    if (!found) {
+      return 0;
+    }
+  }
+
+  if (t.startsWith(q)) {
+    score += 10;
+  }
+
+  return score;
+}
+
+export function rankByFuzzyScore<T>(
+  items: T[],
+  query: string,
+  getLabel: (item: T) => string,
+): T[] {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return items;
+  }
+
+  return items
+    .map((item) => ({ item, score: fuzzyScore(trimmed, getLabel(item)) }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || getLabel(a.item).localeCompare(getLabel(b.item)))
+    .map((entry) => entry.item);
+}
+
+// ponytail: naive subsequence scorer; upgrade path = Fuse.js if album count grows large

--- a/lib/library/grid-navigation.ts
+++ b/lib/library/grid-navigation.ts
@@ -40,13 +40,27 @@ export function navigateGridRows(
       if (colIndex > 0) {
         return currentRow[colIndex - 1] ?? null;
       }
-      return currentId;
+      if (rowIndex === 0) {
+        return currentId;
+      }
+      const targetRow = rows[rowIndex - 1];
+      if (!targetRow || targetRow.length === 0) {
+        return currentId;
+      }
+      return targetRow[targetRow.length - 1] ?? null;
     }
     case "right": {
       if (colIndex < currentRow.length - 1) {
         return currentRow[colIndex + 1] ?? null;
       }
-      return currentId;
+      if (rowIndex >= rows.length - 1) {
+        return currentId;
+      }
+      const targetRow = rows[rowIndex + 1];
+      if (!targetRow || targetRow.length === 0) {
+        return currentId;
+      }
+      return targetRow[0] ?? null;
     }
     case "up": {
       if (rowIndex === 0) {

--- a/lib/library/grid-navigation.ts
+++ b/lib/library/grid-navigation.ts
@@ -1,0 +1,72 @@
+export type GridDirection = "left" | "right" | "up" | "down";
+
+function findPosition(
+  rows: string[][],
+  entryId: string,
+): { rowIndex: number; colIndex: number } | null {
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const colIndex = rows[rowIndex]?.indexOf(entryId) ?? -1;
+    if (colIndex >= 0) {
+      return { rowIndex, colIndex };
+    }
+  }
+  return null;
+}
+
+export function navigateGridRows(
+  rows: string[][],
+  currentId: string | null,
+  direction: GridDirection,
+): string | null {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const position = currentId ? findPosition(rows, currentId) : null;
+
+  if (!position) {
+    return rows[0]?.[0] ?? null;
+  }
+
+  const { rowIndex, colIndex } = position;
+  const currentRow = rows[rowIndex];
+
+  if (!currentRow) {
+    return null;
+  }
+
+  switch (direction) {
+    case "left": {
+      if (colIndex > 0) {
+        return currentRow[colIndex - 1] ?? null;
+      }
+      return currentId;
+    }
+    case "right": {
+      if (colIndex < currentRow.length - 1) {
+        return currentRow[colIndex + 1] ?? null;
+      }
+      return currentId;
+    }
+    case "up": {
+      if (rowIndex === 0) {
+        return currentId;
+      }
+      const targetRow = rows[rowIndex - 1];
+      if (!targetRow || targetRow.length === 0) {
+        return currentId;
+      }
+      return targetRow[Math.min(colIndex, targetRow.length - 1)] ?? null;
+    }
+    case "down": {
+      if (rowIndex >= rows.length - 1) {
+        return currentId;
+      }
+      const targetRow = rows[rowIndex + 1];
+      if (!targetRow || targetRow.length === 0) {
+        return currentId;
+      }
+      return targetRow[Math.min(colIndex, targetRow.length - 1)] ?? null;
+    }
+  }
+}

--- a/lib/library/rating-filter.ts
+++ b/lib/library/rating-filter.ts
@@ -1,0 +1,33 @@
+import type { StarRating } from "@/lib/catalog/types";
+import type { CurationFilter } from "./filter-types";
+
+export function getRatingFromCurationFilter(
+  filter: CurationFilter,
+): StarRating {
+  if (filter === "rating-1") return 1;
+  if (filter === "rating-2") return 2;
+  if (filter === "rating-3") return 3;
+  if (filter === "rating-4") return 4;
+  if (filter === "rating-5") return 5;
+  return 0;
+}
+
+export function isRatingCurationFilter(filter: CurationFilter): boolean {
+  return getRatingFromCurationFilter(filter) > 0;
+}
+
+export function curationFilterFromRating(
+  rating: StarRating,
+  currentFilter: CurationFilter,
+): CurationFilter {
+  if (rating === 0) {
+    return isRatingCurationFilter(currentFilter) ? "all" : currentFilter;
+  }
+
+  const next = `rating-${rating}` as CurationFilter;
+  if (currentFilter === next) {
+    return "all";
+  }
+
+  return next;
+}

--- a/stores/library-store.ts
+++ b/stores/library-store.ts
@@ -1,6 +1,23 @@
 import { create } from "zustand";
 import { formatPickerError } from "@/lib/fs/access";
 import {
+  getEntryMetadata,
+  createEntryMetadata,
+} from "@/lib/catalog/defaults";
+import {
+  buildPhotoCatalog,
+  deleteCatalog,
+  loadCatalog,
+  scheduleCatalogPersist,
+} from "@/lib/catalog/persistence";
+import type {
+  ColorLabel,
+  EntryMetadata,
+  PickStatus,
+  StarRating,
+} from "@/lib/catalog/types";
+import { pruneMetadataForEntries } from "@/lib/library/curation";
+import {
   getLibrarySnapshot,
   saveLibrarySnapshot,
   scanDirectory,
@@ -37,7 +54,16 @@ interface LibraryStore {
   needsFolderAccess: boolean;
   isDesktopApp: boolean;
   selectedEntryId: string | null;
+  entryMetadata: Record<string, EntryMetadata>;
   setSelectedEntryId: (id: string | null) => void;
+  setEntryMetadata: (entryId: string, patch: Partial<EntryMetadata>) => void;
+  setPick: (entryId: string, pick: PickStatus) => void;
+  setRating: (entryId: string, rating: StarRating) => void;
+  setColorLabel: (entryId: string, label: ColorLabel) => void;
+  loadCatalogForFolder: (
+    rootPath: string,
+    entryIds: string[],
+  ) => Promise<void>;
   importFromFolderPath: (
     rootPath: string,
     folderName: string,
@@ -78,6 +104,23 @@ function attachProfiles(entries: LibraryEntry[]): LibraryEntry[] {
     ...entry,
     profileId: resolveProfile(entry)?.id ?? null,
   }));
+}
+
+function persistMetadataInBackground(
+  rootPath: string,
+  entryMetadata: Record<string, EntryMetadata>,
+): void {
+  scheduleCatalogPersist(buildPhotoCatalog(rootPath, entryMetadata));
+}
+
+async function loadAndMergeCatalog(
+  rootPath: string,
+  entries: LibraryEntry[],
+): Promise<Record<string, EntryMetadata>> {
+  const entryIds = new Set(entries.map((entry) => entry.id));
+  const catalog = await loadCatalog(rootPath);
+  const stored = catalog?.entries ?? {};
+  return pruneMetadataForEntries(stored, entryIds);
 }
 
 function persistSnapshotInBackground(
@@ -152,6 +195,8 @@ async function completeDirectoryImport(
       );
     }
 
+    const entryMetadata = await loadAndMergeCatalog(rootPath, scanned);
+
     setSessionCatalog(folderName, scanned, rootPath);
 
     fsDebug("completeDirectoryImport: success", {
@@ -161,11 +206,18 @@ async function completeDirectoryImport(
       entryCount: scanned.length,
     });
 
+    const previousSelection = get().selectedEntryId;
+    const selectedEntryId =
+      previousSelection && scanned.some((entry) => entry.id === previousSelection)
+        ? previousSelection
+        : (scanned[0]?.id ?? null);
+
     set({
       folderName,
       rootPath,
       entries: scanned,
-      selectedEntryId: scanned[0]?.id ?? null,
+      entryMetadata,
+      selectedEntryId,
       needsFolderAccess: false,
       importState: "idle",
       importStatus: null,
@@ -198,10 +250,47 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
   needsFolderAccess: false,
   isDesktopApp: false,
   selectedEntryId: null,
+  entryMetadata: {},
 
   setDesktopApp: (desktop) => set({ isDesktopApp: desktop }),
 
   setSelectedEntryId: (id) => set({ selectedEntryId: id }),
+
+  loadCatalogForFolder: async (rootPath, entryIds) => {
+    const entryIdSet = new Set(entryIds);
+    const catalog = await loadCatalog(rootPath);
+    const stored = catalog?.entries ?? {};
+    const entryMetadata = pruneMetadataForEntries(stored, entryIdSet);
+    set({ entryMetadata });
+  },
+
+  setEntryMetadata: (entryId, patch) => {
+    const { rootPath, entryMetadata } = get();
+    const current = getEntryMetadata(entryMetadata, entryId);
+    const next = createEntryMetadata({ ...current, ...patch });
+
+    const updated = { ...entryMetadata, [entryId]: next };
+    set({ entryMetadata: updated });
+
+    if (rootPath) {
+      persistMetadataInBackground(rootPath, updated);
+    }
+  },
+
+  setPick: (entryId, pick) => {
+    get().setEntryMetadata(entryId, { pick });
+  },
+
+  setRating: (entryId, rating) => {
+    get().setEntryMetadata(entryId, { rating });
+  },
+
+  setColorLabel: (entryId, label) => {
+    const { entryMetadata } = get();
+    const current = getEntryMetadata(entryMetadata, entryId);
+    const nextLabel = current.colorLabel === label ? null : label;
+    get().setEntryMetadata(entryId, { colorLabel: nextLabel });
+  },
 
   bootstrapLibrary: async () => {
     fsDebug("bootstrapLibrary: start");
@@ -217,10 +306,15 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
           entryCount: entries.length,
         });
         const restoredEntries = attachProfiles(entries);
+        const entryMetadata = await loadAndMergeCatalog(
+          rootPath,
+          restoredEntries,
+        );
         set({
           folderName,
           rootPath,
           entries: restoredEntries,
+          entryMetadata,
           selectedEntryId:
             get().selectedEntryId &&
             restoredEntries.some((entry) => entry.id === get().selectedEntryId)
@@ -361,12 +455,17 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
 
   clearLibrary: async () => {
     fsDebug("clearLibrary: start");
+    const { rootPath } = get();
     beginFolderOperation();
     await clearPersistedLibrary();
+    if (rootPath) {
+      await deleteCatalog(rootPath);
+    }
     set({
       folderName: null,
       rootPath: null,
       entries: [],
+      entryMetadata: {},
       selectedEntryId: null,
       importState: "idle",
       importStatus: null,

--- a/stores/library-store.ts
+++ b/stores/library-store.ts
@@ -357,6 +357,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
   clearSelection: () =>
     set({
       selectedEntryIds: [],
+      selectedEntryId: null,
       selectionAnchorId: null,
     }),
 

--- a/stores/library-store.ts
+++ b/stores/library-store.ts
@@ -18,6 +18,7 @@ import type {
   StarRating,
 } from "@/lib/catalog/types";
 import { pruneMetadataForEntries } from "@/lib/library/curation";
+import { filterArchivedEntries, filterOnlyArchivedEntries, pruneArchivedEntryIds } from "@/lib/library/archive";
 import { pruneAlbumsForEntries } from "@/lib/library/folders";
 import {
   getLibrarySnapshot,
@@ -26,7 +27,7 @@ import {
   type ScanProgress,
 } from "@/lib/fs/directory";
 import { fsDebug, fsDebugError, fsDebugWarn } from "@/lib/fs/debug";
-import { getDarkroomAPI } from "@/lib/fs/platform";
+import { deleteFilesFromDisk, getDarkroomAPI, joinRootPath } from "@/lib/fs/platform";
 import {
   hasSessionCatalog,
   setSessionCatalog,
@@ -84,13 +85,15 @@ function restoreSelection(
 export type CatalogView =
   | { type: "all" }
   | { type: "folder"; path: string | null }
-  | { type: "album"; albumId: string };
+  | { type: "album"; albumId: string }
+  | { type: "archive" };
 
 interface LibraryStore {
   folderName: string | null;
   rootPath: string | null;
   entries: LibraryEntry[];
   albums: Album[];
+  archivedEntryIds: string[];
   catalogView: CatalogView;
   importState: ImportState;
   importStatus: string | null;
@@ -121,6 +124,10 @@ interface LibraryStore {
   deleteAlbum: (albumId: string) => void;
   addEntriesToAlbum: (albumId: string, entryIds: string[]) => void;
   removeEntriesFromAlbum: (albumId: string, entryIds: string[]) => void;
+  removeEntriesFromAllAlbums: (entryIds: string[]) => void;
+  archiveEntries: (entryIds: string[]) => void;
+  restoreEntries: (entryIds: string[]) => void;
+  deleteEntriesFromDisk: (entryIds: string[]) => Promise<void>;
   loadCatalogForFolder: (
     rootPath: string,
     entryIds: string[],
@@ -171,8 +178,11 @@ function persistCatalogInBackground(
   rootPath: string,
   entryMetadata: Record<string, EntryMetadata>,
   albums: Album[],
+  archivedEntryIds: string[],
 ): void {
-  scheduleCatalogPersist(buildPhotoCatalog(rootPath, entryMetadata, albums));
+  scheduleCatalogPersist(
+    buildPhotoCatalog(rootPath, entryMetadata, albums, archivedEntryIds),
+  );
 }
 
 async function loadAndMergeCatalog(
@@ -181,13 +191,18 @@ async function loadAndMergeCatalog(
 ): Promise<{
   entryMetadata: Record<string, EntryMetadata>;
   albums: Album[];
+  archivedEntryIds: string[];
 }> {
   const entryIds = new Set(entries.map((entry) => entry.id));
   const catalog = await loadCatalog(rootPath);
   const stored = catalog?.entries ?? {};
   const entryMetadata = pruneMetadataForEntries(stored, entryIds);
   const albums = pruneAlbumsForEntries(catalog?.albums ?? [], entryIds);
-  return { entryMetadata, albums };
+  const archivedEntryIds = pruneArchivedEntryIds(
+    catalog?.archivedEntryIds ?? [],
+    entryIds,
+  );
+  return { entryMetadata, albums, archivedEntryIds };
 }
 
 function persistSnapshotInBackground(
@@ -262,7 +277,8 @@ async function completeDirectoryImport(
       );
     }
 
-    const { entryMetadata, albums } = await loadAndMergeCatalog(rootPath, scanned);
+    const { entryMetadata, albums, archivedEntryIds } =
+      await loadAndMergeCatalog(rootPath, scanned);
 
     setSessionCatalog(folderName, scanned, rootPath);
 
@@ -273,8 +289,9 @@ async function completeDirectoryImport(
       entryCount: scanned.length,
     });
 
+    const activeEntries = filterArchivedEntries(scanned, archivedEntryIds);
     const selection = restoreSelection(
-      scanned,
+      activeEntries,
       get().selectedEntryIds,
       get().selectionAnchorId,
     );
@@ -285,6 +302,7 @@ async function completeDirectoryImport(
       entries: scanned,
       entryMetadata,
       albums,
+      archivedEntryIds,
       catalogView: { type: "all" },
       ...selection,
       needsFolderAccess: false,
@@ -314,6 +332,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
   rootPath: null,
   entries: [],
   albums: [],
+  archivedEntryIds: [],
   catalogView: { type: "all" },
   importState: "idle",
   importStatus: null,
@@ -378,7 +397,11 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     const stored = catalog?.entries ?? {};
     const entryMetadata = pruneMetadataForEntries(stored, entryIdSet);
     const albums = pruneAlbumsForEntries(catalog?.albums ?? [], entryIdSet);
-    set({ entryMetadata, albums });
+    const archivedEntryIds = pruneArchivedEntryIds(
+      catalog?.archivedEntryIds ?? [],
+      entryIdSet,
+    );
+    set({ entryMetadata, albums, archivedEntryIds });
   },
 
   setEntryMetadata: (entryId, patch) => {
@@ -390,7 +413,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       return;
     }
 
-    const { rootPath, entryMetadata, albums } = get();
+    const { rootPath, entryMetadata, albums, archivedEntryIds } = get();
     const updated = { ...entryMetadata };
     const updatedAt = Date.now();
 
@@ -406,7 +429,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     set({ entryMetadata: updated });
 
     if (rootPath) {
-      persistCatalogInBackground(rootPath, updated, albums);
+      persistCatalogInBackground(rootPath, updated, albums, archivedEntryIds);
     }
   },
 
@@ -429,9 +452,14 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     const albums = [...get().albums, album];
     set({ albums, catalogView: { type: "album", albumId: album.id } });
 
-    const { rootPath, entryMetadata } = get();
+    const { rootPath, entryMetadata, archivedEntryIds } = get();
     if (rootPath) {
-      persistCatalogInBackground(rootPath, entryMetadata, albums);
+      persistCatalogInBackground(
+        rootPath,
+        entryMetadata,
+        albums,
+        archivedEntryIds,
+      );
     }
 
     return album.id;
@@ -450,9 +478,14 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     );
     set({ albums });
 
-    const { rootPath, entryMetadata } = get();
+    const { rootPath, entryMetadata, archivedEntryIds } = get();
     if (rootPath) {
-      persistCatalogInBackground(rootPath, entryMetadata, albums);
+      persistCatalogInBackground(
+        rootPath,
+        entryMetadata,
+        albums,
+        archivedEntryIds,
+      );
     }
   },
 
@@ -465,9 +498,14 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
         : currentView;
     set({ albums, catalogView });
 
-    const { rootPath, entryMetadata } = get();
+    const { rootPath, entryMetadata, archivedEntryIds } = get();
     if (rootPath) {
-      persistCatalogInBackground(rootPath, entryMetadata, albums);
+      persistCatalogInBackground(
+        rootPath,
+        entryMetadata,
+        albums,
+        archivedEntryIds,
+      );
     }
   },
 
@@ -491,9 +529,14 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     });
     set({ albums });
 
-    const { rootPath, entryMetadata } = get();
+    const { rootPath, entryMetadata, archivedEntryIds } = get();
     if (rootPath) {
-      persistCatalogInBackground(rootPath, entryMetadata, albums);
+      persistCatalogInBackground(
+        rootPath,
+        entryMetadata,
+        albums,
+        archivedEntryIds,
+      );
     }
   },
 
@@ -516,10 +559,178 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     });
     set({ albums });
 
+    const { rootPath, entryMetadata, archivedEntryIds } = get();
+    if (rootPath) {
+      persistCatalogInBackground(
+        rootPath,
+        entryMetadata,
+        albums,
+        archivedEntryIds,
+      );
+    }
+  },
+
+  removeEntriesFromAllAlbums: (entryIds) => {
+    if (entryIds.length === 0) {
+      return;
+    }
+
+    const removeSet = new Set(entryIds);
+    const albums = get().albums.map((album) => ({
+      ...album,
+      entryIds: album.entryIds.filter((id) => !removeSet.has(id)),
+      updatedAt: Date.now(),
+    }));
+    set({ albums });
+
+    const { rootPath, entryMetadata, archivedEntryIds } = get();
+    if (rootPath) {
+      persistCatalogInBackground(
+        rootPath,
+        entryMetadata,
+        albums,
+        archivedEntryIds,
+      );
+    }
+  },
+
+  archiveEntries: (entryIds) => {
+    if (entryIds.length === 0) {
+      return;
+    }
+
+    const removeSet = new Set(entryIds);
+    const archivedEntryIds = [
+      ...new Set([...get().archivedEntryIds, ...entryIds]),
+    ];
+    const albums = get().albums.map((album) => ({
+      ...album,
+      entryIds: album.entryIds.filter((id) => !removeSet.has(id)),
+      updatedAt: Date.now(),
+    }));
+    const activeEntries = filterArchivedEntries(get().entries, archivedEntryIds);
+    const selection = restoreSelection(
+      activeEntries,
+      get().selectedEntryIds,
+      get().selectionAnchorId,
+    );
+
+    set({
+      archivedEntryIds,
+      albums,
+      ...selection,
+    });
+
     const { rootPath, entryMetadata } = get();
     if (rootPath) {
-      persistCatalogInBackground(rootPath, entryMetadata, albums);
+      persistCatalogInBackground(
+        rootPath,
+        entryMetadata,
+        albums,
+        archivedEntryIds,
+      );
     }
+  },
+
+  restoreEntries: (entryIds) => {
+    if (entryIds.length === 0) {
+      return;
+    }
+
+    const removeSet = new Set(entryIds);
+    const archivedEntryIds = get().archivedEntryIds.filter(
+      (id) => !removeSet.has(id),
+    );
+    const { entries, catalogView } = get();
+    const activeEntries =
+      catalogView.type === "archive"
+        ? filterOnlyArchivedEntries(entries, archivedEntryIds)
+        : filterArchivedEntries(entries, archivedEntryIds);
+    const selection = restoreSelection(
+      activeEntries,
+      get().selectedEntryIds.filter((id) => !removeSet.has(id)),
+      get().selectionAnchorId,
+    );
+
+    set({
+      archivedEntryIds,
+      ...selection,
+    });
+
+    const { rootPath, entryMetadata, albums } = get();
+    if (rootPath) {
+      persistCatalogInBackground(
+        rootPath,
+        entryMetadata,
+        albums,
+        archivedEntryIds,
+      );
+    }
+  },
+
+  deleteEntriesFromDisk: async (entryIds) => {
+    if (entryIds.length === 0) {
+      return;
+    }
+
+    const { rootPath, folderName, entries, catalogView } = get();
+    if (!rootPath) {
+      return;
+    }
+
+    const removeSet = new Set(entryIds);
+    const toDelete = entries.filter((entry) => removeSet.has(entry.id));
+    const absolutePaths = toDelete.map((entry) =>
+      joinRootPath(rootPath, entry.relativePath),
+    );
+
+    try {
+      await deleteFilesFromDisk(absolutePaths);
+    } catch (error) {
+      set({ importError: formatPickerError(error) });
+      return;
+    }
+
+    const remainingEntries = entries.filter((entry) => !removeSet.has(entry.id));
+    const remainingIds = new Set(remainingEntries.map((entry) => entry.id));
+    const entryMetadata = pruneMetadataForEntries(
+      get().entryMetadata,
+      remainingIds,
+    );
+    const albums = pruneAlbumsForEntries(get().albums, remainingIds);
+    const archivedEntryIds = get().archivedEntryIds.filter((id) =>
+      remainingIds.has(id),
+    );
+    const activeEntries =
+      catalogView.type === "archive"
+        ? filterOnlyArchivedEntries(remainingEntries, archivedEntryIds)
+        : filterArchivedEntries(remainingEntries, archivedEntryIds);
+    const selection = restoreSelection(
+      activeEntries,
+      get().selectedEntryIds.filter((id) => remainingIds.has(id)),
+      get().selectionAnchorId,
+    );
+
+    set({
+      entries: remainingEntries,
+      entryMetadata,
+      albums,
+      archivedEntryIds,
+      importError: null,
+      ...selection,
+    });
+
+    if (folderName) {
+      setSessionCatalog(folderName, remainingEntries, rootPath);
+      persistSnapshotInBackground(folderName, rootPath, remainingEntries);
+    }
+
+    persistCatalogInBackground(
+      rootPath,
+      entryMetadata,
+      albums,
+      archivedEntryIds,
+    );
   },
 
   setPick: (entryId, pick) => {
@@ -551,9 +762,11 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
           entryCount: entries.length,
         });
         const restoredEntries = attachProfiles(entries);
-        const { entryMetadata, albums } = await loadAndMergeCatalog(
-          rootPath,
+        const { entryMetadata, albums, archivedEntryIds } =
+          await loadAndMergeCatalog(rootPath, restoredEntries);
+        const activeEntries = filterArchivedEntries(
           restoredEntries,
+          archivedEntryIds,
         );
         set({
           folderName,
@@ -561,8 +774,9 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
           entries: restoredEntries,
           entryMetadata,
           albums,
+          archivedEntryIds,
           ...restoreSelection(
-            restoredEntries,
+            activeEntries,
             get().selectedEntryIds,
             get().selectionAnchorId,
           ),
@@ -713,6 +927,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       entries: [],
       entryMetadata: {},
       albums: [],
+      archivedEntryIds: [],
       catalogView: { type: "all" },
       selectedEntryId: null,
       selectedEntryIds: [],

--- a/stores/library-store.ts
+++ b/stores/library-store.ts
@@ -370,17 +370,20 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       return;
     }
 
-    if (modifiers.shift && selectionAnchorId) {
-      const anchorIdx = visibleOrder.indexOf(selectionAnchorId);
-      const clickIdx = visibleOrder.indexOf(id);
-      if (anchorIdx >= 0 && clickIdx >= 0) {
-        const start = Math.min(anchorIdx, clickIdx);
-        const end = Math.max(anchorIdx, clickIdx);
-        set({
-          selectedEntryIds: visibleOrder.slice(start, end + 1),
-          selectedEntryId: id,
-        });
-        return;
+    if (modifiers.shift) {
+      const anchor = selectionAnchorId ?? get().selectedEntryId;
+      if (anchor) {
+        const anchorIdx = visibleOrder.indexOf(anchor);
+        const targetIdx = visibleOrder.indexOf(id);
+        if (anchorIdx >= 0 && targetIdx >= 0) {
+          const start = Math.min(anchorIdx, targetIdx);
+          const end = Math.max(anchorIdx, targetIdx);
+          set({
+            selectedEntryIds: visibleOrder.slice(start, end + 1),
+            selectedEntryId: id,
+          });
+          return;
+        }
       }
     }
 

--- a/stores/library-store.ts
+++ b/stores/library-store.ts
@@ -698,8 +698,9 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     try {
       await deleteFilesFromDisk(absolutePaths);
     } catch (error) {
-      set({ importError: formatPickerError(error) });
-      return;
+      const message = formatPickerError(error);
+      set({ importError: message });
+      throw new Error(message);
     }
 
     const remainingEntries = entries.filter((entry) => !removeSet.has(entry.id));

--- a/stores/library-store.ts
+++ b/stores/library-store.ts
@@ -11,12 +11,14 @@ import {
   scheduleCatalogPersist,
 } from "@/lib/catalog/persistence";
 import type {
+  Album,
   ColorLabel,
   EntryMetadata,
   PickStatus,
   StarRating,
 } from "@/lib/catalog/types";
 import { pruneMetadataForEntries } from "@/lib/library/curation";
+import { pruneAlbumsForEntries } from "@/lib/library/folders";
 import {
   getLibrarySnapshot,
   saveLibrarySnapshot,
@@ -79,10 +81,17 @@ function restoreSelection(
   };
 }
 
+export type CatalogView =
+  | { type: "all" }
+  | { type: "folder"; path: string | null }
+  | { type: "album"; albumId: string };
+
 interface LibraryStore {
   folderName: string | null;
   rootPath: string | null;
   entries: LibraryEntry[];
+  albums: Album[];
+  catalogView: CatalogView;
   importState: ImportState;
   importStatus: string | null;
   importError: string | null;
@@ -106,6 +115,12 @@ interface LibraryStore {
   setPick: (entryId: string, pick: PickStatus) => void;
   setRating: (entryId: string, rating: StarRating) => void;
   setColorLabel: (entryId: string, label: ColorLabel) => void;
+  setCatalogView: (view: CatalogView) => void;
+  createAlbum: (name: string) => string;
+  renameAlbum: (albumId: string, name: string) => void;
+  deleteAlbum: (albumId: string) => void;
+  addEntriesToAlbum: (albumId: string, entryIds: string[]) => void;
+  removeEntriesFromAlbum: (albumId: string, entryIds: string[]) => void;
   loadCatalogForFolder: (
     rootPath: string,
     entryIds: string[],
@@ -152,21 +167,27 @@ function attachProfiles(entries: LibraryEntry[]): LibraryEntry[] {
   }));
 }
 
-function persistMetadataInBackground(
+function persistCatalogInBackground(
   rootPath: string,
   entryMetadata: Record<string, EntryMetadata>,
+  albums: Album[],
 ): void {
-  scheduleCatalogPersist(buildPhotoCatalog(rootPath, entryMetadata));
+  scheduleCatalogPersist(buildPhotoCatalog(rootPath, entryMetadata, albums));
 }
 
 async function loadAndMergeCatalog(
   rootPath: string,
   entries: LibraryEntry[],
-): Promise<Record<string, EntryMetadata>> {
+): Promise<{
+  entryMetadata: Record<string, EntryMetadata>;
+  albums: Album[];
+}> {
   const entryIds = new Set(entries.map((entry) => entry.id));
   const catalog = await loadCatalog(rootPath);
   const stored = catalog?.entries ?? {};
-  return pruneMetadataForEntries(stored, entryIds);
+  const entryMetadata = pruneMetadataForEntries(stored, entryIds);
+  const albums = pruneAlbumsForEntries(catalog?.albums ?? [], entryIds);
+  return { entryMetadata, albums };
 }
 
 function persistSnapshotInBackground(
@@ -241,7 +262,7 @@ async function completeDirectoryImport(
       );
     }
 
-    const entryMetadata = await loadAndMergeCatalog(rootPath, scanned);
+    const { entryMetadata, albums } = await loadAndMergeCatalog(rootPath, scanned);
 
     setSessionCatalog(folderName, scanned, rootPath);
 
@@ -263,6 +284,8 @@ async function completeDirectoryImport(
       rootPath,
       entries: scanned,
       entryMetadata,
+      albums,
+      catalogView: { type: "all" },
       ...selection,
       needsFolderAccess: false,
       importState: "idle",
@@ -290,6 +313,8 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
   folderName: null,
   rootPath: null,
   entries: [],
+  albums: [],
+  catalogView: { type: "all" },
   importState: "idle",
   importStatus: null,
   importError: null,
@@ -352,7 +377,8 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     const catalog = await loadCatalog(rootPath);
     const stored = catalog?.entries ?? {};
     const entryMetadata = pruneMetadataForEntries(stored, entryIdSet);
-    set({ entryMetadata });
+    const albums = pruneAlbumsForEntries(catalog?.albums ?? [], entryIdSet);
+    set({ entryMetadata, albums });
   },
 
   setEntryMetadata: (entryId, patch) => {
@@ -364,7 +390,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       return;
     }
 
-    const { rootPath, entryMetadata } = get();
+    const { rootPath, entryMetadata, albums } = get();
     const updated = { ...entryMetadata };
     const updatedAt = Date.now();
 
@@ -380,7 +406,119 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
     set({ entryMetadata: updated });
 
     if (rootPath) {
-      persistMetadataInBackground(rootPath, updated);
+      persistCatalogInBackground(rootPath, updated, albums);
+    }
+  },
+
+  setCatalogView: (view) => set({ catalogView: view }),
+
+  createAlbum: (name) => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return "";
+    }
+
+    const now = Date.now();
+    const album: Album = {
+      id: crypto.randomUUID(),
+      name: trimmed,
+      entryIds: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    const albums = [...get().albums, album];
+    set({ albums, catalogView: { type: "album", albumId: album.id } });
+
+    const { rootPath, entryMetadata } = get();
+    if (rootPath) {
+      persistCatalogInBackground(rootPath, entryMetadata, albums);
+    }
+
+    return album.id;
+  },
+
+  renameAlbum: (albumId, name) => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const albums = get().albums.map((album) =>
+      album.id === albumId
+        ? { ...album, name: trimmed, updatedAt: Date.now() }
+        : album,
+    );
+    set({ albums });
+
+    const { rootPath, entryMetadata } = get();
+    if (rootPath) {
+      persistCatalogInBackground(rootPath, entryMetadata, albums);
+    }
+  },
+
+  deleteAlbum: (albumId) => {
+    const albums = get().albums.filter((album) => album.id !== albumId);
+    const currentView = get().catalogView;
+    const catalogView =
+      currentView.type === "album" && currentView.albumId === albumId
+        ? { type: "all" as const }
+        : currentView;
+    set({ albums, catalogView });
+
+    const { rootPath, entryMetadata } = get();
+    if (rootPath) {
+      persistCatalogInBackground(rootPath, entryMetadata, albums);
+    }
+  },
+
+  addEntriesToAlbum: (albumId, entryIds) => {
+    if (entryIds.length === 0) {
+      return;
+    }
+
+    const entryIdSet = new Set(entryIds);
+    const albums = get().albums.map((album) => {
+      if (album.id !== albumId) {
+        return album;
+      }
+
+      const merged = new Set([...album.entryIds, ...entryIdSet]);
+      return {
+        ...album,
+        entryIds: [...merged],
+        updatedAt: Date.now(),
+      };
+    });
+    set({ albums });
+
+    const { rootPath, entryMetadata } = get();
+    if (rootPath) {
+      persistCatalogInBackground(rootPath, entryMetadata, albums);
+    }
+  },
+
+  removeEntriesFromAlbum: (albumId, entryIds) => {
+    if (entryIds.length === 0) {
+      return;
+    }
+
+    const removeSet = new Set(entryIds);
+    const albums = get().albums.map((album) => {
+      if (album.id !== albumId) {
+        return album;
+      }
+
+      return {
+        ...album,
+        entryIds: album.entryIds.filter((id) => !removeSet.has(id)),
+        updatedAt: Date.now(),
+      };
+    });
+    set({ albums });
+
+    const { rootPath, entryMetadata } = get();
+    if (rootPath) {
+      persistCatalogInBackground(rootPath, entryMetadata, albums);
     }
   },
 
@@ -413,7 +551,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
           entryCount: entries.length,
         });
         const restoredEntries = attachProfiles(entries);
-        const entryMetadata = await loadAndMergeCatalog(
+        const { entryMetadata, albums } = await loadAndMergeCatalog(
           rootPath,
           restoredEntries,
         );
@@ -422,6 +560,7 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
           rootPath,
           entries: restoredEntries,
           entryMetadata,
+          albums,
           ...restoreSelection(
             restoredEntries,
             get().selectedEntryIds,
@@ -573,6 +712,8 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       rootPath: null,
       entries: [],
       entryMetadata: {},
+      albums: [],
+      catalogView: { type: "all" },
       selectedEntryId: null,
       selectedEntryIds: [],
       selectionAnchorId: null,

--- a/stores/library-store.ts
+++ b/stores/library-store.ts
@@ -44,6 +44,41 @@ interface RestoreLastFolderOptions {
   interactive?: boolean;
 }
 
+export interface SelectEntryModifiers {
+  shift?: boolean;
+  toggle?: boolean;
+}
+
+function restoreSelection(
+  entries: LibraryEntry[],
+  previousIds: string[],
+  previousAnchor: string | null,
+): {
+  selectedEntryIds: string[];
+  selectedEntryId: string | null;
+  selectionAnchorId: string | null;
+} {
+  const validIds = previousIds.filter((id) =>
+    entries.some((entry) => entry.id === id),
+  );
+  const selectedEntryIds =
+    validIds.length > 0
+      ? validIds
+      : entries[0]
+        ? [entries[0].id]
+        : [];
+  const anchorValid =
+    previousAnchor &&
+    entries.some((entry) => entry.id === previousAnchor);
+  return {
+    selectedEntryIds,
+    selectedEntryId: selectedEntryIds.at(-1) ?? null,
+    selectionAnchorId: anchorValid
+      ? previousAnchor
+      : (selectedEntryIds[0] ?? null),
+  };
+}
+
 interface LibraryStore {
   folderName: string | null;
   rootPath: string | null;
@@ -54,9 +89,20 @@ interface LibraryStore {
   needsFolderAccess: boolean;
   isDesktopApp: boolean;
   selectedEntryId: string | null;
+  selectedEntryIds: string[];
+  selectionAnchorId: string | null;
   entryMetadata: Record<string, EntryMetadata>;
   setSelectedEntryId: (id: string | null) => void;
+  selectEntry: (
+    id: string,
+    modifiers: SelectEntryModifiers,
+    visibleOrder: string[],
+  ) => void;
   setEntryMetadata: (entryId: string, patch: Partial<EntryMetadata>) => void;
+  applyMetadataToEntries: (
+    entryIds: string[],
+    patch: Partial<EntryMetadata>,
+  ) => void;
   setPick: (entryId: string, pick: PickStatus) => void;
   setRating: (entryId: string, rating: StarRating) => void;
   setColorLabel: (entryId: string, label: ColorLabel) => void;
@@ -206,18 +252,18 @@ async function completeDirectoryImport(
       entryCount: scanned.length,
     });
 
-    const previousSelection = get().selectedEntryId;
-    const selectedEntryId =
-      previousSelection && scanned.some((entry) => entry.id === previousSelection)
-        ? previousSelection
-        : (scanned[0]?.id ?? null);
+    const selection = restoreSelection(
+      scanned,
+      get().selectedEntryIds,
+      get().selectionAnchorId,
+    );
 
     set({
       folderName,
       rootPath,
       entries: scanned,
       entryMetadata,
-      selectedEntryId,
+      ...selection,
       needsFolderAccess: false,
       importState: "idle",
       importStatus: null,
@@ -250,11 +296,56 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
   needsFolderAccess: false,
   isDesktopApp: false,
   selectedEntryId: null,
+  selectedEntryIds: [],
+  selectionAnchorId: null,
   entryMetadata: {},
 
   setDesktopApp: (desktop) => set({ isDesktopApp: desktop }),
 
-  setSelectedEntryId: (id) => set({ selectedEntryId: id }),
+  setSelectedEntryId: (id) =>
+    set({
+      selectedEntryId: id,
+      selectedEntryIds: id ? [id] : [],
+      selectionAnchorId: id,
+    }),
+
+  selectEntry: (id, modifiers, visibleOrder) => {
+    const { selectedEntryIds, selectionAnchorId } = get();
+
+    if (modifiers.toggle) {
+      const next = selectedEntryIds.includes(id)
+        ? selectedEntryIds.filter((entryId) => entryId !== id)
+        : [...selectedEntryIds, id];
+      set({
+        selectedEntryIds: next,
+        selectedEntryId: next.includes(id)
+          ? id
+          : (next.at(-1) ?? null),
+        selectionAnchorId: selectionAnchorId ?? id,
+      });
+      return;
+    }
+
+    if (modifiers.shift && selectionAnchorId) {
+      const anchorIdx = visibleOrder.indexOf(selectionAnchorId);
+      const clickIdx = visibleOrder.indexOf(id);
+      if (anchorIdx >= 0 && clickIdx >= 0) {
+        const start = Math.min(anchorIdx, clickIdx);
+        const end = Math.max(anchorIdx, clickIdx);
+        set({
+          selectedEntryIds: visibleOrder.slice(start, end + 1),
+          selectedEntryId: id,
+        });
+        return;
+      }
+    }
+
+    set({
+      selectedEntryIds: [id],
+      selectedEntryId: id,
+      selectionAnchorId: id,
+    });
+  },
 
   loadCatalogForFolder: async (rootPath, entryIds) => {
     const entryIdSet = new Set(entryIds);
@@ -265,11 +356,27 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
   },
 
   setEntryMetadata: (entryId, patch) => {
-    const { rootPath, entryMetadata } = get();
-    const current = getEntryMetadata(entryMetadata, entryId);
-    const next = createEntryMetadata({ ...current, ...patch });
+    get().applyMetadataToEntries([entryId], patch);
+  },
 
-    const updated = { ...entryMetadata, [entryId]: next };
+  applyMetadataToEntries: (entryIds, patch) => {
+    if (entryIds.length === 0) {
+      return;
+    }
+
+    const { rootPath, entryMetadata } = get();
+    const updated = { ...entryMetadata };
+    const updatedAt = Date.now();
+
+    for (const entryId of entryIds) {
+      const current = getEntryMetadata(updated, entryId);
+      updated[entryId] = createEntryMetadata({
+        ...current,
+        ...patch,
+        updatedAt,
+      });
+    }
+
     set({ entryMetadata: updated });
 
     if (rootPath) {
@@ -315,11 +422,11 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
           rootPath,
           entries: restoredEntries,
           entryMetadata,
-          selectedEntryId:
-            get().selectedEntryId &&
-            restoredEntries.some((entry) => entry.id === get().selectedEntryId)
-              ? get().selectedEntryId
-              : (restoredEntries[0]?.id ?? null),
+          ...restoreSelection(
+            restoredEntries,
+            get().selectedEntryIds,
+            get().selectionAnchorId,
+          ),
           needsFolderAccess: false,
           importState: "idle",
           importError: null,
@@ -467,6 +574,8 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       entries: [],
       entryMetadata: {},
       selectedEntryId: null,
+      selectedEntryIds: [],
+      selectionAnchorId: null,
       importState: "idle",
       importStatus: null,
       importError: null,

--- a/stores/library-store.ts
+++ b/stores/library-store.ts
@@ -105,6 +105,7 @@ interface LibraryStore {
   selectionAnchorId: string | null;
   entryMetadata: Record<string, EntryMetadata>;
   setSelectedEntryId: (id: string | null) => void;
+  clearSelection: () => void;
   selectEntry: (
     id: string,
     modifiers: SelectEntryModifiers,
@@ -351,6 +352,12 @@ export const useLibraryStore = create<LibraryStore>((set, get) => ({
       selectedEntryId: id,
       selectedEntryIds: id ? [id] : [],
       selectionAnchorId: id,
+    }),
+
+  clearSelection: () =>
+    set({
+      selectedEntryIds: [],
+      selectionAnchorId: null,
     }),
 
   selectEntry: (id, modifiers, visibleOrder) => {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -31,6 +31,7 @@ export interface DarkroomAPI {
   readCatalog(rootPath: string): Promise<PhotoCatalog | null>;
   writeCatalog(catalog: PhotoCatalog): Promise<void>;
   deleteCatalog(rootPath: string): Promise<void>;
+  deleteFiles(absolutePaths: string[]): Promise<void>;
 }
 
 declare global {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -5,6 +5,19 @@ export interface ScannedFile {
   lastModified: number;
 }
 
+export interface CatalogEntryMetadata {
+  pick: "none" | "pick" | "reject";
+  rating: 0 | 1 | 2 | 3 | 4 | 5;
+  colorLabel: "red" | "yellow" | "green" | "blue" | "purple" | null;
+  updatedAt: number;
+}
+
+export interface PhotoCatalog {
+  version: 1;
+  rootPath: string;
+  entries: Record<string, CatalogEntryMetadata>;
+}
+
 export interface DarkroomAPI {
   isElectron: true;
   pickFolder(): Promise<{ path: string; name: string } | null>;
@@ -15,6 +28,9 @@ export interface DarkroomAPI {
   getLastFolder(): Promise<string | null>;
   setLastFolder(folderPath: string | null): Promise<void>;
   folderExists(folderPath: string): Promise<boolean>;
+  readCatalog(rootPath: string): Promise<PhotoCatalog | null>;
+  writeCatalog(catalog: PhotoCatalog): Promise<void>;
+  deleteCatalog(rootPath: string): Promise<void>;
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- Add pick/reject, star ratings, and color labels with keyboard shortcuts in the library grid and Develop viewer
- Persist curation metadata per folder via Electron catalog files (IndexedDB fallback in web dev)
- Add star-based rating filters, curation/format filters, and sort by rating or pick status
- Grey out rejected thumbnails; show pick flags and color labels on tiles (no star overlays)

## Test plan
- [ ] Import a folder and rate/pick/label photos via keyboard and metadata bar
- [ ] Quit and relaunch — metadata persists after restore
- [ ] Filter by star count using the star control in side panel and toolbar
- [ ] Filter by pick state and color labels
- [ ] Verify rejected photos appear greyed out in grid and filmstrip
- [ ] Sort by rating and pick status


Made with [Cursor](https://cursor.com)