### PR TITLE
Set up dev environment + document Cursor Cloud instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,16 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+## Cursor Cloud specific instructions
+
+Darkroom is a single-product Electron + Next.js 16 (static-export, webpack) desktop photo library. Standard commands live in `package.json`/`README.md`: `npm run lint`, `npm run build`, and `npm run electron:dev` (dev). No databases, secrets, or external services are needed.
+
+Non-obvious caveats:
+
+- **Run the GUI on the desktop display**: launch with `DISPLAY=:1 ELECTRON_DISABLE_SANDBOX=1 npm run electron:dev`. The container has no Electron sandbox, so it must be disabled, and the D-Bus / GPU-process errors printed to the log are benign. The Electron window (and a detached DevTools window) appear on `DISPLAY=:1`, viewable via computer use.
+- **Auto-load photos without the native dialog**: the `Import` button opens a native OS folder dialog and is disabled outside Electron, so it is hard to drive programmatically. On launch the app auto-restores the last folder from `~/.config/darkroom/settings.json` — seed it with `{"lastFolderPath": "/workspace/public/demo"}` to load the 7 bundled demo photos (`public/demo`).
+- `npm run dev` alone only serves the UI in a browser; native file access / IPC (`window.darkroom`) requires the full Electron app.
+- Renderer console logs (`[darkroom:fs]`, `[Darkroom]`) go to the Electron DevTools console, not the `electron:dev` stdout/log.
+- `scripts/capture-screenshots.mjs` mocks `window.showDirectoryPicker`, which the current import flow no longer uses (it uses Electron IPC), so that script is stale for driving imports.
+- `npm run lint` currently reports pre-existing errors in the repo's existing code.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the development environment for Darkroom (Electron + Next.js 16 photo library). Added durable Cursor Cloud instructions to `AGENTS.md`.

The update script (run on VM startup) is `npm install` — its `postinstall` patches `libraw-wasm` and validates/downloads the Electron binary.

## What was verified

- `npm install` (installs deps, downloads Electron binary)
- `npm run lint` (runs; repo has 4 pre-existing lint errors in existing code — not modified)
- `npm run build` (Next static export + Electron bundle succeed)
- `npm run electron:dev` (dev app runs; auto-loaded demo folder and rendered 7 photos)

## Hello-world task

Launched the dev app, opened a photo into the full detail viewer (full decode + metadata sidebar), and applied a 4-star rating — exercising the Next.js UI + Electron IPC + decode pipeline end to end.

[darkroom_open_photo_and_rate.mp4](https://cursor.com/agents/bc-00b3ad1f-4e6d-4b89-b7c1-7e3284cb1924/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdarkroom_open_photo_and_rate.mp4)

[Library grid with 7 demo photos](https://cursor.com/agents/bc-00b3ad1f-4e6d-4b89-b7c1-7e3284cb1924/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdarkroom_library_grid.webp)
[Photo detail view with metadata](https://cursor.com/agents/bc-00b3ad1f-4e6d-4b89-b7c1-7e3284cb1924/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdarkroom_photo_detail.webp)
[4-star rating applied](https://cursor.com/agents/bc-00b3ad1f-4e6d-4b89-b7c1-7e3284cb1924/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdarkroom_star_rating.webp)

## Notes for future agents (in AGENTS.md)

- Run the GUI with `DISPLAY=:1 ELECTRON_DISABLE_SANDBOX=1 npm run electron:dev`.
- Auto-load photos by seeding `~/.config/darkroom/settings.json` with `{"lastFolderPath": "/workspace/public/demo"}` (the Import button uses a native OS dialog).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00b3ad1f-4e6d-4b89-b7c1-7e3284cb1924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00b3ad1f-4e6d-4b89-b7c1-7e3284cb1924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

