### PR TITLE
Add plugin-based RAW editing tools

### DIFF
--- a/components/develop/DevelopCanvas.tsx
+++ b/components/develop/DevelopCanvas.tsx
@@ -113,12 +113,12 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "\\") {
+      if (event.key === "b" || event.key === "B") {
         setShowOriginal(true);
       }
     }
     function onKeyUp(event: KeyboardEvent) {
-      if (event.key === "\\") {
+      if (event.key === "b" || event.key === "B") {
         setShowOriginal(false);
       }
     }

--- a/components/develop/DevelopCanvas.tsx
+++ b/components/develop/DevelopCanvas.tsx
@@ -37,9 +37,9 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
       if (!renderer || !ready) {
         throw new Error("Editor preview is not ready to export.");
       }
-      return renderer.toBlob();
+      return renderer.exportJpeg(image, settings);
     },
-  }), [ready]);
+  }), [image, ready, settings]);
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/components/develop/DevelopCanvas.tsx
+++ b/components/develop/DevelopCanvas.tsx
@@ -46,6 +46,7 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
     if (!canvas) {
       return;
     }
+    const currentCanvas = canvas;
 
     let active = true;
     setReady(false);
@@ -54,7 +55,7 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
     async function loadRenderer() {
       try {
         rendererRef.current?.dispose();
-        const renderer = new DevelopRenderer(canvas);
+        const renderer = new DevelopRenderer(currentCanvas);
         rendererRef.current = renderer;
         await renderer.setImage(image);
         if (!active) {
@@ -89,18 +90,24 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
     if (!canvas || !renderer || !container || !ready) {
       return;
     }
+    const currentCanvas = canvas;
+    const currentContainer = container;
+    const currentRenderer = renderer;
 
     function render() {
-      if (!canvas || !container) {
+      if (!currentCanvas || !currentContainer) {
         return;
       }
-      renderer.resize(container.clientWidth, container.clientHeight);
-      renderer.render(settings, showOriginal);
+      currentRenderer.resize(
+        currentContainer.clientWidth,
+        currentContainer.clientHeight,
+      );
+      currentRenderer.render(settings, showOriginal);
     }
 
     render();
     const observer = new ResizeObserver(render);
-    observer.observe(container);
+    observer.observe(currentContainer);
     return () => observer.disconnect();
   }, [settings, showOriginal, ready]);
 

--- a/components/develop/DevelopCanvas.tsx
+++ b/components/develop/DevelopCanvas.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import Image from "next/image";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import type { DevelopImage } from "@/lib/cache/develop-image-cache";
+import { DevelopRenderer } from "@/lib/develop/renderer";
+import { useDevelopStore } from "@/stores/develop-store";
+
+interface DevelopCanvasProps {
+  image: DevelopImage;
+  alt: string;
+}
+
+export interface DevelopCanvasHandle {
+  exportJpeg(): Promise<Blob>;
+}
+
+export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>(
+  function DevelopCanvas({ image, alt }, ref) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rendererRef = useRef<DevelopRenderer | null>(null);
+  const settings = useDevelopStore((state) => state.settings);
+  const showOriginal = useDevelopStore((state) => state.showOriginal);
+  const setShowOriginal = useDevelopStore((state) => state.setShowOriginal);
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useImperativeHandle(ref, () => ({
+    async exportJpeg() {
+      const renderer = rendererRef.current;
+      if (!renderer || !ready) {
+        throw new Error("Editor preview is not ready to export.");
+      }
+      return renderer.toBlob();
+    },
+  }), [ready]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    let active = true;
+    setReady(false);
+    setError(null);
+
+    async function loadRenderer() {
+      try {
+        rendererRef.current?.dispose();
+        const renderer = new DevelopRenderer(canvas);
+        rendererRef.current = renderer;
+        await renderer.setImage(image);
+        if (!active) {
+          renderer.dispose();
+          return;
+        }
+        setReady(true);
+      } catch (rendererError) {
+        if (active) {
+          setError(
+            rendererError instanceof Error
+              ? rendererError.message
+              : "Could not initialize editor preview.",
+          );
+        }
+      }
+    }
+
+    void loadRenderer();
+
+    return () => {
+      active = false;
+      rendererRef.current?.dispose();
+      rendererRef.current = null;
+    };
+  }, [image]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const renderer = rendererRef.current;
+    const container = canvas?.parentElement;
+    if (!canvas || !renderer || !container || !ready) {
+      return;
+    }
+
+    function render() {
+      if (!canvas || !container) {
+        return;
+      }
+      renderer.resize(container.clientWidth, container.clientHeight);
+      renderer.render(settings, showOriginal);
+    }
+
+    render();
+    const observer = new ResizeObserver(render);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [settings, showOriginal, ready]);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "\\") {
+        setShowOriginal(true);
+      }
+    }
+    function onKeyUp(event: KeyboardEvent) {
+      if (event.key === "\\") {
+        setShowOriginal(false);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, [setShowOriginal]);
+
+  if (error) {
+    return (
+      <div className="relative h-full w-full">
+        <Image
+          src={image.objectUrl}
+          alt={alt}
+          fill
+          unoptimized
+          className="object-contain"
+          priority
+        />
+        <div className="absolute left-3 top-3 rounded border border-red-500/40 bg-red-950/80 px-3 py-2 text-xs text-red-100">
+          Editing preview unavailable: {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full w-full">
+      <canvas ref={canvasRef} className="h-full w-full" />
+      {!ready ? (
+        <div className="absolute inset-0 flex items-center justify-center text-xs uppercase tracking-wider text-lr-text-dim">
+          Preparing editor...
+        </div>
+      ) : null}
+      <CropOverlay />
+      {showOriginal ? (
+        <div className="absolute left-3 top-3 rounded bg-lr-panel/90 px-2 py-1 text-[11px] uppercase tracking-wider text-lr-text-muted">
+          Before
+        </div>
+      ) : null}
+    </div>
+  );
+});
+
+function CropOverlay() {
+  const crop = useDevelopStore((state) => state.settings.crop);
+  if (!crop.enabled) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute border border-white/80 shadow-[0_0_0_9999px_rgba(0,0,0,0.32)]"
+      style={{
+        left: `${crop.x * 100}%`,
+        top: `${crop.y * 100}%`,
+        width: `${crop.width * 100}%`,
+        height: `${crop.height * 100}%`,
+        transform: `rotate(${crop.angle}deg)`,
+      }}
+    >
+      <div className="grid h-full w-full grid-cols-3 grid-rows-3">
+        {Array.from({ length: 9 }, (_, index) => (
+          <div key={index} className="border border-white/20" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/develop/EditPanel.tsx
+++ b/components/develop/EditPanel.tsx
@@ -108,10 +108,10 @@ function CropControls() {
         />
         Enable crop
       </label>
-      <SliderRow label="Left" value={crop.x} min={0} max={0.95} step={0.01} onChange={(x) => updatePlugin("crop", { x })} />
-      <SliderRow label="Top" value={crop.y} min={0} max={0.95} step={0.01} onChange={(y) => updatePlugin("crop", { y })} />
-      <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} onChange={(width) => updatePlugin("crop", { width })} />
-      <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} onChange={(height) => updatePlugin("crop", { height })} />
+      <SliderRow label="Left" value={crop.x} min={0} max={1 - crop.width} step={0.01} onChange={(x) => updatePlugin("crop", { x })} />
+      <SliderRow label="Top" value={crop.y} min={0} max={1 - crop.height} step={0.01} onChange={(y) => updatePlugin("crop", { y })} />
+      <SliderRow label="Width" value={crop.width} min={0.05} max={1 - crop.x} step={0.01} onChange={(width) => updatePlugin("crop", { width })} />
+      <SliderRow label="Height" value={crop.height} min={0.05} max={1 - crop.y} step={0.01} onChange={(height) => updatePlugin("crop", { height })} />
       <SliderRow label="Straighten" value={crop.angle} min={-45} max={45} step={0.1} suffix="deg" onChange={(angle) => updatePlugin("crop", { angle })} />
       <SliderRow label="Perspective X" value={crop.perspectiveX} min={-100} max={100} onChange={(perspectiveX) => updatePlugin("crop", { perspectiveX })} />
       <SliderRow label="Perspective Y" value={crop.perspectiveY} min={-100} max={100} onChange={(perspectiveY) => updatePlugin("crop", { perspectiveY })} />

--- a/components/develop/EditPanel.tsx
+++ b/components/develop/EditPanel.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { DEVELOP_PLUGINS, DEFAULT_DEVELOP_SETTINGS } from "@/lib/develop/registry";
+import { MIXER_COLORS } from "@/lib/develop/plugins/mixer";
+import type { DevelopPluginId, MixerColor } from "@/lib/develop/types";
+import { useDevelopStore } from "@/stores/develop-store";
+import { SliderRow } from "@/components/develop/SliderRow";
+
+const MIXER_LABELS: Record<MixerColor, string> = {
+  red: "Red",
+  orange: "Orange",
+  yellow: "Yellow",
+  green: "Green",
+  aqua: "Aqua",
+  blue: "Blue",
+  purple: "Purple",
+  magenta: "Magenta",
+};
+
+export function EditPanel() {
+  const resetAll = useDevelopStore((state) => state.resetAll);
+  const sidecarStatus = useDevelopStore((state) => state.sidecarStatus);
+  const sidecarError = useDevelopStore((state) => state.sidecarError);
+
+  return (
+    <aside className="flex w-80 shrink-0 flex-col border-l border-lr-border-subtle bg-lr-panel">
+      <div className="flex items-center justify-between border-b border-lr-border-subtle px-3 py-2">
+        <div>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-lr-text-muted">
+            Edit
+          </h2>
+          <p className="text-[10px] text-lr-text-dim">
+            XMP {sidecarStatus}
+            {sidecarError ? `: ${sidecarError}` : ""}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={resetAll}
+          className="rounded border border-lr-border-subtle px-2 py-1 text-[11px] text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text"
+        >
+          Reset All
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        {DEVELOP_PLUGINS.map((plugin) => (
+          <PluginSection key={plugin.id} id={plugin.id} label={plugin.label} />
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function PluginSection({
+  id,
+  label,
+}: {
+  id: DevelopPluginId;
+  label: string;
+}) {
+  const resetPlugin = useDevelopStore((state) => state.resetPlugin);
+
+  return (
+    <details open className="border-b border-lr-border-subtle">
+      <summary className="flex cursor-pointer select-none items-center justify-between px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim hover:text-lr-text-muted">
+        {label}
+      </summary>
+      <div className="px-3 pb-3">
+        {id === "crop" ? <CropControls /> : null}
+        {id === "basic" ? <BasicControls /> : null}
+        {id === "curve" ? <CurveControls /> : null}
+        {id === "mixer" ? <MixerControls /> : null}
+        {id === "effects" ? <EffectsControls /> : null}
+        <button
+          type="button"
+          onClick={() => resetPlugin(id)}
+          className="mt-2 rounded border border-lr-border-subtle px-2 py-1 text-[11px] text-lr-text-dim hover:bg-lr-panel-raised hover:text-lr-text-muted"
+        >
+          Reset {label}
+        </button>
+      </div>
+    </details>
+  );
+}
+
+function CropControls() {
+  const crop = useDevelopStore((state) => state.settings.crop);
+  const updatePlugin = useDevelopStore((state) => state.updatePlugin);
+
+  return (
+    <div>
+      <label className="mb-2 flex items-center gap-2 text-xs text-lr-text-muted">
+        <input
+          type="checkbox"
+          checked={crop.enabled}
+          onChange={(event) =>
+            updatePlugin("crop", { enabled: event.target.checked })
+          }
+        />
+        Enable crop
+      </label>
+      <SliderRow label="Left" value={crop.x} min={0} max={0.95} step={0.01} onChange={(x) => updatePlugin("crop", { x })} />
+      <SliderRow label="Top" value={crop.y} min={0} max={0.95} step={0.01} onChange={(y) => updatePlugin("crop", { y })} />
+      <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} onChange={(width) => updatePlugin("crop", { width })} />
+      <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} onChange={(height) => updatePlugin("crop", { height })} />
+      <SliderRow label="Straighten" value={crop.angle} min={-45} max={45} step={0.1} suffix="deg" onChange={(angle) => updatePlugin("crop", { angle })} />
+      <SliderRow label="Perspective X" value={crop.perspectiveX} min={-100} max={100} onChange={(perspectiveX) => updatePlugin("crop", { perspectiveX })} />
+      <SliderRow label="Perspective Y" value={crop.perspectiveY} min={-100} max={100} onChange={(perspectiveY) => updatePlugin("crop", { perspectiveY })} />
+      <SliderRow label="Distortion" value={crop.distortion} min={-100} max={100} onChange={(distortion) => updatePlugin("crop", { distortion })} />
+    </div>
+  );
+}
+
+function BasicControls() {
+  const basic = useDevelopStore((state) => state.settings.basic);
+  const updatePlugin = useDevelopStore((state) => state.updatePlugin);
+  const defaults = DEFAULT_DEVELOP_SETTINGS.basic;
+
+  return (
+    <div>
+      <SliderRow label="Exposure" value={basic.exposure} min={-5} max={5} step={0.05} onChange={(exposure) => updatePlugin("basic", { exposure })} onReset={() => updatePlugin("basic", { exposure: defaults.exposure })} />
+      <SliderRow label="Contrast" value={basic.contrast} min={-100} max={100} onChange={(contrast) => updatePlugin("basic", { contrast })} />
+      <SliderRow label="Highlights" value={basic.highlights} min={-100} max={100} onChange={(highlights) => updatePlugin("basic", { highlights })} />
+      <SliderRow label="Shadows" value={basic.shadows} min={-100} max={100} onChange={(shadows) => updatePlugin("basic", { shadows })} />
+      <SliderRow label="Whites" value={basic.whites} min={-100} max={100} onChange={(whites) => updatePlugin("basic", { whites })} />
+      <SliderRow label="Blacks" value={basic.blacks} min={-100} max={100} onChange={(blacks) => updatePlugin("basic", { blacks })} />
+      <SliderRow label="Temp" value={basic.temperature} min={-3000} max={3000} step={50} suffix="K" onChange={(temperature) => updatePlugin("basic", { temperature })} />
+      <SliderRow label="Tint" value={basic.tint} min={-150} max={150} onChange={(tint) => updatePlugin("basic", { tint })} />
+      <SliderRow label="Vibrance" value={basic.vibrance} min={-100} max={100} onChange={(vibrance) => updatePlugin("basic", { vibrance })} />
+      <SliderRow label="Saturation" value={basic.saturation} min={-100} max={100} onChange={(saturation) => updatePlugin("basic", { saturation })} />
+    </div>
+  );
+}
+
+function CurveControls() {
+  const curve = useDevelopStore((state) => state.settings.curve);
+  const updatePlugin = useDevelopStore((state) => state.updatePlugin);
+
+  return (
+    <div>
+      <SliderRow label="Shadows" value={curve.shadows} min={-100} max={100} onChange={(shadows) => updatePlugin("curve", { shadows })} />
+      <SliderRow label="Midtones" value={curve.midtones} min={-100} max={100} onChange={(midtones) => updatePlugin("curve", { midtones })} />
+      <SliderRow label="Highlights" value={curve.highlights} min={-100} max={100} onChange={(highlights) => updatePlugin("curve", { highlights })} />
+    </div>
+  );
+}
+
+function MixerControls() {
+  const mixer = useDevelopStore((state) => state.settings.mixer);
+  const updatePlugin = useDevelopStore((state) => state.updatePlugin);
+
+  return (
+    <div className="space-y-3">
+      {MIXER_COLORS.map((color) => (
+        <div key={color}>
+          <h3 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+            {MIXER_LABELS[color]}
+          </h3>
+          <SliderRow label="Hue" value={mixer[color].hue} min={-100} max={100} onChange={(hue) => updatePlugin("mixer", { [color]: { ...mixer[color], hue } })} />
+          <SliderRow label="Sat" value={mixer[color].saturation} min={-100} max={100} onChange={(saturation) => updatePlugin("mixer", { [color]: { ...mixer[color], saturation } })} />
+          <SliderRow label="Lum" value={mixer[color].luminance} min={-100} max={100} onChange={(luminance) => updatePlugin("mixer", { [color]: { ...mixer[color], luminance } })} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EffectsControls() {
+  const effects = useDevelopStore((state) => state.settings.effects);
+  const updatePlugin = useDevelopStore((state) => state.updatePlugin);
+
+  return (
+    <div>
+      <SliderRow label="Vignette" value={effects.vignette} min={-100} max={100} onChange={(vignette) => updatePlugin("effects", { vignette })} />
+      <SliderRow label="Grain" value={effects.grain} min={0} max={100} onChange={(grain) => updatePlugin("effects", { grain })} />
+      <SliderRow label="Sharpen" value={effects.sharpening} min={0} max={100} onChange={(sharpening) => updatePlugin("effects", { sharpening })} />
+      <SliderRow label="Noise NR" value={effects.noiseReduction} min={0} max={100} onChange={(noiseReduction) => updatePlugin("effects", { noiseReduction })} />
+    </div>
+  );
+}

--- a/components/develop/EditPanel.tsx
+++ b/components/develop/EditPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DEVELOP_PLUGINS, DEFAULT_DEVELOP_SETTINGS } from "@/lib/develop/registry";
+import { DEFAULT_DEVELOP_SETTINGS } from "@/lib/develop/registry";
 import { MIXER_COLORS } from "@/lib/develop/plugins/mixer";
 import type { DevelopPluginId, MixerColor } from "@/lib/develop/types";
 import { useDevelopStore } from "@/stores/develop-store";
@@ -16,6 +16,14 @@ const MIXER_LABELS: Record<MixerColor, string> = {
   purple: "Purple",
   magenta: "Magenta",
 };
+
+const EDIT_SECTIONS: ReadonlyArray<{ id: DevelopPluginId; label: string }> = [
+  { id: "crop", label: "Crop & Transform" },
+  { id: "basic", label: "Basic" },
+  { id: "curve", label: "Tone Curve" },
+  { id: "mixer", label: "Color Mixer" },
+  { id: "effects", label: "Effects & Details" },
+];
 
 export function EditPanel() {
   const resetAll = useDevelopStore((state) => state.resetAll);
@@ -44,8 +52,8 @@ export function EditPanel() {
       </div>
 
       <div className="flex-1 overflow-auto">
-        {DEVELOP_PLUGINS.map((plugin) => (
-          <PluginSection key={plugin.id} id={plugin.id} label={plugin.label} />
+        {EDIT_SECTIONS.map((section) => (
+          <PluginSection key={section.id} id={section.id} label={section.label} />
         ))}
       </div>
     </aside>

--- a/components/develop/SliderRow.tsx
+++ b/components/develop/SliderRow.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+interface SliderRowProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  suffix?: string;
+  onChange: (value: number) => void;
+  onReset?: () => void;
+}
+
+export function SliderRow({
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  suffix = "",
+  onChange,
+  onReset,
+}: SliderRowProps) {
+  return (
+    <label
+      className="grid grid-cols-[86px_1fr_42px] items-center gap-2 py-1 text-xs"
+      onDoubleClick={onReset}
+    >
+      <span className="text-lr-text-dim">{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="accent-lr-accent"
+      />
+      <span className="text-right font-mono text-[10px] text-lr-text-muted">
+        {value > 0 ? "+" : ""}
+        {value}
+        {suffix}
+      </span>
+    </label>
+  );
+}

--- a/components/develop/useDevelopSettingsSync.ts
+++ b/components/develop/useDevelopSettingsSync.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { EntryMetadata } from "@/lib/catalog/types";
 import type { LibraryEntry } from "@/lib/fs/types";
 import {
@@ -32,6 +32,7 @@ export function useDevelopSettingsSync({
   const hydratedEntryId = useRef<string | null>(null);
   const skipNextPersist = useRef(false);
   const metadataRef = useRef(metadata);
+  const [hydrationVersion, setHydrationVersion] = useState(0);
 
   useEffect(() => {
     metadataRef.current = metadata;
@@ -55,6 +56,7 @@ export function useDevelopSettingsSync({
           skipNextPersist.current = false;
         }
         hydratedEntryId.current = entry.id;
+        setHydrationVersion((version) => version + 1);
         return;
       }
 
@@ -100,6 +102,7 @@ export function useDevelopSettingsSync({
       } finally {
         if (active) {
           hydratedEntryId.current = entry.id;
+          setHydrationVersion((version) => version + 1);
         }
       }
     }
@@ -159,6 +162,7 @@ export function useDevelopSettingsSync({
     activeEntryId,
     entry.id,
     entry.relativePath,
+    hydrationVersion,
     rootPath,
     settings,
     metadata.rating,

--- a/components/develop/useDevelopSettingsSync.ts
+++ b/components/develop/useDevelopSettingsSync.ts
@@ -19,6 +19,12 @@ interface UseDevelopSettingsSyncOptions {
   applyMetadata: (patch: Partial<EntryMetadata>) => void;
 }
 
+interface PendingPersist {
+  entryId: string;
+  timer: number;
+  flush: () => void;
+}
+
 export function useDevelopSettingsSync({
   entry,
   rootPath,
@@ -32,6 +38,7 @@ export function useDevelopSettingsSync({
   const hydratedEntryId = useRef<string | null>(null);
   const skipNextPersist = useRef(false);
   const metadataRef = useRef(metadata);
+  const pendingPersistRef = useRef<PendingPersist | null>(null);
   const [hydrationVersion, setHydrationVersion] = useState(0);
 
   useEffect(() => {
@@ -122,6 +129,19 @@ export function useDevelopSettingsSync({
   ]);
 
   useEffect(() => {
+    return () => {
+      const pending = pendingPersistRef.current;
+      if (pending?.entryId !== entry.id) {
+        return;
+      }
+
+      window.clearTimeout(pending.timer);
+      pendingPersistRef.current = null;
+      pending.flush();
+    };
+  }, [entry.id]);
+
+  useEffect(() => {
     if (activeEntryId !== entry.id || hydratedEntryId.current !== entry.id) {
       return;
     }
@@ -131,7 +151,7 @@ export function useDevelopSettingsSync({
       return;
     }
 
-    const timer = window.setTimeout(() => {
+    const persist = () => {
       const develop = createDevelopSettings(settings);
       applyMetadata({ develop });
 
@@ -139,25 +159,51 @@ export function useDevelopSettingsSync({
         return;
       }
 
-      setSidecarStatus("saving");
+      const setStatusForEntry = (
+        status: Parameters<typeof setSidecarStatus>[0],
+        error?: string | null,
+      ) => {
+        if (useDevelopStore.getState().activeEntryId === entry.id) {
+          setSidecarStatus(status, error);
+        }
+      };
+
+      setStatusForEntry("saving");
       void writeDevelopSidecar(
         rootPath,
         entry.relativePath,
         develop,
-        metadataRef.current,
+        { rating: metadata.rating, colorLabel: metadata.colorLabel },
       )
-        .then(() => setSidecarStatus("saved"))
+        .then(() => setStatusForEntry("saved"))
         .catch((error) => {
-          setSidecarStatus(
+          setStatusForEntry(
             "error",
             error instanceof Error
               ? error.message
               : "Could not write XMP sidecar.",
           );
         });
+    };
+    const pending: PendingPersist = {
+      entryId: entry.id,
+      timer: 0,
+      flush: persist,
+    };
+    pending.timer = window.setTimeout(() => {
+      if (pendingPersistRef.current === pending) {
+        pendingPersistRef.current = null;
+      }
+      persist();
     }, PERSIST_DEBOUNCE_MS);
+    pendingPersistRef.current = pending;
 
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(pending.timer);
+      if (pendingPersistRef.current === pending) {
+        pendingPersistRef.current = null;
+      }
+    };
   }, [
     activeEntryId,
     entry.id,

--- a/components/develop/useDevelopSettingsSync.ts
+++ b/components/develop/useDevelopSettingsSync.ts
@@ -3,7 +3,10 @@
 import { useEffect, useRef } from "react";
 import type { EntryMetadata } from "@/lib/catalog/types";
 import type { LibraryEntry } from "@/lib/fs/types";
-import { createDevelopSettings } from "@/lib/develop/registry";
+import {
+  createDevelopSettings,
+  developSettingsHash,
+} from "@/lib/develop/registry";
 import { readDevelopSidecar, writeDevelopSidecar } from "@/lib/develop/sidecar";
 import { useDevelopStore } from "@/stores/develop-store";
 
@@ -28,15 +31,29 @@ export function useDevelopSettingsSync({
   const setSidecarStatus = useDevelopStore((state) => state.setSidecarStatus);
   const hydratedEntryId = useRef<string | null>(null);
   const skipNextPersist = useRef(false);
+  const metadataRef = useRef(metadata);
+
+  useEffect(() => {
+    metadataRef.current = metadata;
+  }, [metadata]);
 
   useEffect(() => {
     let active = true;
     skipNextPersist.current = true;
     hydratedEntryId.current = null;
-    setActiveEntry(entry.id, metadata.develop);
+    setActiveEntry(entry.id, metadataRef.current.develop);
+    const hydrationStartHash = developSettingsHash(
+      useDevelopStore.getState().settings,
+    );
 
     async function hydrateFromSidecar() {
       if (!rootPath) {
+        if (
+          developSettingsHash(useDevelopStore.getState().settings) !==
+          hydrationStartHash
+        ) {
+          skipNextPersist.current = false;
+        }
         hydratedEntryId.current = entry.id;
         return;
       }
@@ -48,7 +65,14 @@ export function useDevelopSettingsSync({
           return;
         }
 
-        if (sidecar && sidecar.lastModified > metadata.updatedAt) {
+        const hasLocalEdits =
+          developSettingsHash(useDevelopStore.getState().settings) !==
+          hydrationStartHash;
+        if (
+          sidecar &&
+          !hasLocalEdits &&
+          sidecar.lastModified > metadataRef.current.updatedAt
+        ) {
           const nextMetadata: Partial<EntryMetadata> = {
             develop: sidecar.settings,
           };
@@ -61,6 +85,8 @@ export function useDevelopSettingsSync({
           skipNextPersist.current = true;
           setActiveEntry(entry.id, sidecar.settings);
           applyMetadata(nextMetadata);
+        } else if (hasLocalEdits) {
+          skipNextPersist.current = false;
         }
 
         setSidecarStatus("saved");
@@ -87,10 +113,6 @@ export function useDevelopSettingsSync({
     entry.id,
     entry.relativePath,
     rootPath,
-    metadata.develop,
-    metadata.updatedAt,
-    metadata.rating,
-    metadata.colorLabel,
     applyMetadata,
     setActiveEntry,
     setSidecarStatus,
@@ -115,7 +137,12 @@ export function useDevelopSettingsSync({
       }
 
       setSidecarStatus("saving");
-      void writeDevelopSidecar(rootPath, entry.relativePath, develop, metadata)
+      void writeDevelopSidecar(
+        rootPath,
+        entry.relativePath,
+        develop,
+        metadataRef.current,
+      )
         .then(() => setSidecarStatus("saved"))
         .catch((error) => {
           setSidecarStatus(
@@ -134,7 +161,8 @@ export function useDevelopSettingsSync({
     entry.relativePath,
     rootPath,
     settings,
-    metadata,
+    metadata.rating,
+    metadata.colorLabel,
     applyMetadata,
     setSidecarStatus,
   ]);

--- a/components/develop/useDevelopSettingsSync.ts
+++ b/components/develop/useDevelopSettingsSync.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { EntryMetadata } from "@/lib/catalog/types";
+import type { LibraryEntry } from "@/lib/fs/types";
+import { createDevelopSettings } from "@/lib/develop/registry";
+import { readDevelopSidecar, writeDevelopSidecar } from "@/lib/develop/sidecar";
+import { useDevelopStore } from "@/stores/develop-store";
+
+const PERSIST_DEBOUNCE_MS = 500;
+
+interface UseDevelopSettingsSyncOptions {
+  entry: LibraryEntry;
+  rootPath: string | null;
+  metadata: EntryMetadata;
+  applyMetadata: (patch: Partial<EntryMetadata>) => void;
+}
+
+export function useDevelopSettingsSync({
+  entry,
+  rootPath,
+  metadata,
+  applyMetadata,
+}: UseDevelopSettingsSyncOptions): void {
+  const settings = useDevelopStore((state) => state.settings);
+  const activeEntryId = useDevelopStore((state) => state.activeEntryId);
+  const setActiveEntry = useDevelopStore((state) => state.setActiveEntry);
+  const setSidecarStatus = useDevelopStore((state) => state.setSidecarStatus);
+  const hydratedEntryId = useRef<string | null>(null);
+  const skipNextPersist = useRef(false);
+
+  useEffect(() => {
+    let active = true;
+    skipNextPersist.current = true;
+    hydratedEntryId.current = null;
+    setActiveEntry(entry.id, metadata.develop);
+
+    async function hydrateFromSidecar() {
+      if (!rootPath) {
+        hydratedEntryId.current = entry.id;
+        return;
+      }
+
+      setSidecarStatus("loading");
+      try {
+        const sidecar = await readDevelopSidecar(rootPath, entry.relativePath);
+        if (!active) {
+          return;
+        }
+
+        if (sidecar && sidecar.lastModified > metadata.updatedAt) {
+          const nextMetadata: Partial<EntryMetadata> = {
+            develop: sidecar.settings,
+          };
+          if (sidecar.rating !== undefined) {
+            nextMetadata.rating = sidecar.rating;
+          }
+          if (sidecar.colorLabel !== undefined) {
+            nextMetadata.colorLabel = sidecar.colorLabel;
+          }
+          skipNextPersist.current = true;
+          setActiveEntry(entry.id, sidecar.settings);
+          applyMetadata(nextMetadata);
+        }
+
+        setSidecarStatus("saved");
+      } catch (error) {
+        if (active) {
+          setSidecarStatus(
+            "error",
+            error instanceof Error ? error.message : "Could not read XMP sidecar.",
+          );
+        }
+      } finally {
+        if (active) {
+          hydratedEntryId.current = entry.id;
+        }
+      }
+    }
+
+    void hydrateFromSidecar();
+
+    return () => {
+      active = false;
+    };
+  }, [
+    entry.id,
+    entry.relativePath,
+    rootPath,
+    metadata.develop,
+    metadata.updatedAt,
+    metadata.rating,
+    metadata.colorLabel,
+    applyMetadata,
+    setActiveEntry,
+    setSidecarStatus,
+  ]);
+
+  useEffect(() => {
+    if (activeEntryId !== entry.id || hydratedEntryId.current !== entry.id) {
+      return;
+    }
+
+    if (skipNextPersist.current) {
+      skipNextPersist.current = false;
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      const develop = createDevelopSettings(settings);
+      applyMetadata({ develop });
+
+      if (!rootPath) {
+        return;
+      }
+
+      setSidecarStatus("saving");
+      void writeDevelopSidecar(rootPath, entry.relativePath, develop, metadata)
+        .then(() => setSidecarStatus("saved"))
+        .catch((error) => {
+          setSidecarStatus(
+            "error",
+            error instanceof Error
+              ? error.message
+              : "Could not write XMP sidecar.",
+          );
+        });
+    }, PERSIST_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    activeEntryId,
+    entry.id,
+    entry.relativePath,
+    rootPath,
+    settings,
+    metadata,
+    applyMetadata,
+    setSidecarStatus,
+  ]);
+}

--- a/components/viewer/PhotoViewer.tsx
+++ b/components/viewer/PhotoViewer.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
+import { getDarkroomAPI } from "@/lib/fs/platform";
 import type { DevelopImage } from "@/lib/cache/develop-image-cache";
 import {
   loadDevelopImage,
@@ -15,6 +15,12 @@ import {
   useEntryMetadataForId,
 } from "@/components/library/EntryMetadataBar";
 import { useLibraryStore } from "@/stores/library-store";
+import {
+  DevelopCanvas,
+  type DevelopCanvasHandle,
+} from "@/components/develop/DevelopCanvas";
+import { EditPanel } from "@/components/develop/EditPanel";
+import { useDevelopSettingsSync } from "@/components/develop/useDevelopSettingsSync";
 import { Filmstrip } from "./Filmstrip";
 import { MetadataPanel } from "./MetadataPanel";
 import { useEntryMetadataShortcuts } from "@/hooks/useEntryMetadataShortcuts";
@@ -27,6 +33,7 @@ interface PhotoViewerProps {
 export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
   const router = useRouter();
   const setSelectedEntryId = useLibraryStore((state) => state.setSelectedEntryId);
+  const rootPath = useLibraryStore((state) => state.rootPath);
   const applyMetadataToEntries = useLibraryStore(
     (state) => state.applyMetadataToEntries,
   );
@@ -39,6 +46,21 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
     () => entries.findIndex((item) => item.id === entry.id),
     [entries, entry.id],
   );
+  const applyDevelopMetadata = useCallback(
+    (patch: Parameters<typeof applyMetadataToEntries>[1]) => {
+      applyMetadataToEntries([entry.id], patch);
+    },
+    [applyMetadataToEntries, entry.id],
+  );
+
+  useDevelopSettingsSync({
+    entry,
+    rootPath,
+    metadata,
+    applyMetadata: applyDevelopMetadata,
+  });
+  const canvasRef = useRef<DevelopCanvasHandle>(null);
+  const [exportStatus, setExportStatus] = useState<string | null>(null);
 
   useEffect(() => {
     setSelectedEntryId(entry.id);
@@ -82,6 +104,25 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
   }, [entry, entries, activeIndex]);
 
   useEntryMetadataShortcuts([entry.id]);
+
+  async function exportEditedJpeg() {
+    try {
+      setExportStatus("Exporting...");
+      const blob = await canvasRef.current?.exportJpeg();
+      if (!blob) {
+        throw new Error("Editor preview is not ready.");
+      }
+      const targetPath = await getDarkroomAPI().saveExport(
+        entry.name.replace(/\.[^.]+$/, "-darkroom.jpg"),
+        await blob.arrayBuffer(),
+      );
+      setExportStatus(targetPath ? `Exported ${targetPath}` : "Export canceled");
+    } catch (exportError) {
+      setExportStatus(
+        exportError instanceof Error ? exportError.message : "Export failed.",
+      );
+    }
+  }
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -131,13 +172,27 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
       <div className="flex min-h-0 flex-1">
         <div className="relative flex min-w-0 flex-1 flex-col bg-[#0d0d0d]">
           <div className="absolute right-3 top-3 z-10">
-            <button
-              type="button"
-              onClick={() => setShowMetadata((value) => !value)}
-              className="rounded border border-lr-border-subtle bg-lr-panel/90 px-2.5 py-1 text-[11px] text-lr-text-muted backdrop-blur hover:text-lr-text"
-            >
-              {showMetadata ? "Hide Info" : "Show Info"}
-            </button>
+            <div className="flex items-center gap-2">
+              {exportStatus ? (
+                <span className="max-w-64 truncate rounded bg-lr-panel/90 px-2 py-1 text-[11px] text-lr-text-dim">
+                  {exportStatus}
+                </span>
+              ) : null}
+              <button
+                type="button"
+                onClick={exportEditedJpeg}
+                className="rounded border border-lr-border-subtle bg-lr-panel/90 px-2.5 py-1 text-[11px] text-lr-text-muted backdrop-blur hover:text-lr-text"
+              >
+                Export JPEG
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowMetadata((value) => !value)}
+                className="rounded border border-lr-border-subtle bg-lr-panel/90 px-2.5 py-1 text-[11px] text-lr-text-muted backdrop-blur hover:text-lr-text"
+              >
+                {showMetadata ? "Hide Info" : "Show Info"}
+              </button>
+            </div>
           </div>
 
           {loading ? (
@@ -154,17 +209,12 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
 
           {decoded ? (
             <div className="relative flex-1">
-              <Image
-                src={decoded.objectUrl}
-                alt={entry.name}
-                fill
-                unoptimized
-                className="object-contain"
-                priority
-              />
+              <DevelopCanvas ref={canvasRef} image={decoded} alt={entry.name} />
             </div>
           ) : null}
         </div>
+
+        {decoded ? <EditPanel /> : null}
 
         {showMetadata && decoded ? (
           <MetadataPanel

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,11 @@
-import { app, BrowserWindow, dialog, ipcMain } from "electron";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  type IpcMainInvokeEvent,
+} from "electron";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -19,26 +26,101 @@ const DEV_SERVER_URL = process.env.DARKROOM_DEV_URL ?? "http://localhost:3000";
 
 let mainWindow: BrowserWindow | null = null;
 let staticServerPort: number | null = null;
+let trustedOrigin: string | null = null;
+let activeLibraryRoot: string | null = null;
 
 const settingsStore = createSettingsStore(app.getPath("userData"));
 const catalogStore = createCatalogStore(app.getPath("userData"));
+const MAX_SIDECAR_BYTES = 4 * 1024 * 1024;
 
-function resolveLibraryFile(rootPath: string, relativePath: string): string {
-  const root = path.resolve(rootPath);
+function assertTrustedIpc(event: IpcMainInvokeEvent): void {
+  if (
+    event.sender !== mainWindow?.webContents ||
+    !trustedOrigin ||
+    !event.senderFrame ||
+    new URL(event.senderFrame.url).origin !== trustedOrigin
+  ) {
+    throw new Error("Darkroom IPC request came from an untrusted renderer.");
+  }
+}
+
+async function setActiveLibraryRoot(rootPath: string): Promise<void> {
+  const root = await fs.realpath(rootPath);
+  const stat = await fs.stat(root);
+  if (!stat.isDirectory()) {
+    throw new Error("Active library root must be a directory.");
+  }
+  activeLibraryRoot = root;
+}
+
+async function resolveLibraryFile(
+  rootPath: string,
+  relativePath: string,
+): Promise<string> {
+  const root = await fs.realpath(rootPath);
+  if (root !== activeLibraryRoot) {
+    throw new Error("Sidecar path must use the active library.");
+  }
+  if (!relativePath || path.isAbsolute(relativePath)) {
+    throw new Error("Sidecar path must name a library file.");
+  }
+
   const absolute = path.resolve(root, relativePath);
   const relative = path.relative(root, absolute);
 
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (
+    !relative ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
     throw new Error("Sidecar path must stay inside the active library.");
   }
 
-  return absolute;
+  const source = await fs.realpath(absolute);
+  const sourceRelative = path.relative(root, source);
+  if (
+    sourceRelative === ".." ||
+    sourceRelative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(sourceRelative)
+  ) {
+    throw new Error("Sidecar source resolves outside the active library.");
+  }
+
+  return source;
 }
 
-function getSidecarPath(rootPath: string, relativePath: string): string {
-  const source = resolveLibraryFile(rootPath, relativePath);
+async function getSidecarPath(
+  rootPath: string,
+  relativePath: string,
+): Promise<string> {
+  const source = await resolveLibraryFile(rootPath, relativePath);
   const parsed = path.parse(source);
   return path.join(parsed.dir, `${parsed.name}.xmp`);
+}
+
+async function writeSidecarAtomically(
+  sidecarPath: string,
+  contents: string,
+): Promise<void> {
+  const temporaryPath = path.join(
+    path.dirname(sidecarPath),
+    `.${path.basename(sidecarPath)}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    const handle = await fs.open(temporaryPath, "wx", 0o600);
+    try {
+      await handle.writeFile(contents, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await fs.rename(temporaryPath, sidecarPath);
+  } catch (error) {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
 }
 
 function getPreloadPath(): string {
@@ -46,15 +128,20 @@ function getPreloadPath(): string {
 }
 
 async function loadWindow(window: BrowserWindow): Promise<void> {
+  let windowUrl: string;
   if (isDev) {
-    await window.loadURL(DEV_SERVER_URL);
+    windowUrl = DEV_SERVER_URL;
+    trustedOrigin = new URL(windowUrl).origin;
+    await window.loadURL(windowUrl);
     window.webContents.openDevTools({ mode: "detach" });
     return;
   }
 
   const outDir = getOutDir(getAppRoot());
   staticServerPort ??= await startStaticServer(outDir);
-  await window.loadURL(`http://127.0.0.1:${staticServerPort}`);
+  windowUrl = `http://127.0.0.1:${staticServerPort}`;
+  trustedOrigin = new URL(windowUrl).origin;
+  await window.loadURL(windowUrl);
 }
 
 async function createWindow(): Promise<void> {
@@ -76,12 +163,19 @@ async function createWindow(): Promise<void> {
   mainWindow.on("closed", () => {
     mainWindow = null;
   });
+  mainWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    if (!trustedOrigin || new URL(url).origin !== trustedOrigin) {
+      event.preventDefault();
+    }
+  });
 
   await loadWindow(mainWindow);
 }
 
 function registerIpcHandlers(): void {
-  ipcMain.handle("darkroom:pick-folder", async () => {
+  ipcMain.handle("darkroom:pick-folder", async (event) => {
+    assertTrustedIpc(event);
     const result = await dialog.showOpenDialog({
       properties: ["openDirectory"],
       title: "Select photo folder",
@@ -98,11 +192,15 @@ function registerIpcHandlers(): void {
     };
   });
 
-  ipcMain.handle("darkroom:scan-folder", async (_event, rootPath: string) => {
-    return scanFolderTree(rootPath);
+  ipcMain.handle("darkroom:scan-folder", async (event, rootPath: string) => {
+    assertTrustedIpc(event);
+    const files = await scanFolderTree(rootPath);
+    await setActiveLibraryRoot(rootPath);
+    return files;
   });
 
-  ipcMain.handle("darkroom:read-file", async (_event, absolutePath: string) => {
+  ipcMain.handle("darkroom:read-file", async (event, absolutePath: string) => {
+    assertTrustedIpc(event);
     const buffer = await readFileBuffer(absolutePath);
     return buffer.buffer.slice(
       buffer.byteOffset,
@@ -112,7 +210,8 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(
     "darkroom:read-file-head",
-    async (_event, absolutePath: string, maxBytes: number) => {
+    async (event, absolutePath: string, maxBytes: number) => {
+      assertTrustedIpc(event);
       const buffer = await readFileHead(absolutePath, maxBytes);
       return buffer.buffer.slice(
         buffer.byteOffset,
@@ -121,50 +220,60 @@ function registerIpcHandlers(): void {
     },
   );
 
-  ipcMain.handle("darkroom:stat-file", async (_event, absolutePath: string) => {
+  ipcMain.handle("darkroom:stat-file", async (event, absolutePath: string) => {
+    assertTrustedIpc(event);
     return statFile(absolutePath);
   });
 
-  ipcMain.handle("darkroom:get-last-folder", async () => {
+  ipcMain.handle("darkroom:get-last-folder", async (event) => {
+    assertTrustedIpc(event);
     return settingsStore.getLastFolder();
   });
 
-  ipcMain.handle("darkroom:set-last-folder", async (_event, folderPath: string | null) => {
+  ipcMain.handle("darkroom:set-last-folder", async (event, folderPath: string | null) => {
+    assertTrustedIpc(event);
     await settingsStore.setLastFolder(folderPath);
   });
 
-  ipcMain.handle("darkroom:folder-exists", async (_event, folderPath: string) => {
+  ipcMain.handle("darkroom:folder-exists", async (event, folderPath: string) => {
+    assertTrustedIpc(event);
     return folderExists(folderPath);
   });
 
-  ipcMain.handle("darkroom:catalog-read", async (_event, rootPath: string) => {
+  ipcMain.handle("darkroom:catalog-read", async (event, rootPath: string) => {
+    assertTrustedIpc(event);
     return catalogStore.read(rootPath);
   });
 
-  ipcMain.handle("darkroom:catalog-write", async (_event, catalog) => {
+  ipcMain.handle("darkroom:catalog-write", async (event, catalog) => {
+    assertTrustedIpc(event);
     await catalogStore.write(catalog);
   });
 
-  ipcMain.handle("darkroom:catalog-delete", async (_event, rootPath: string) => {
+  ipcMain.handle("darkroom:catalog-delete", async (event, rootPath: string) => {
+    assertTrustedIpc(event);
     await catalogStore.remove(rootPath);
   });
 
   ipcMain.handle(
     "darkroom:delete-files",
-    async (_event, absolutePaths: string[]) => {
+    async (event, absolutePaths: string[]) => {
+      assertTrustedIpc(event);
       await trashFiles(absolutePaths);
     },
   );
 
   ipcMain.handle(
     "darkroom:read-sidecar",
-    async (_event, rootPath: string, relativePath: string) => {
-      const sidecarPath = getSidecarPath(rootPath, relativePath);
+    async (event, rootPath: string, relativePath: string) => {
+      assertTrustedIpc(event);
+      const sidecarPath = await getSidecarPath(rootPath, relativePath);
       try {
-        const [contents, stat] = await Promise.all([
-          fs.readFile(sidecarPath, "utf8"),
-          fs.stat(sidecarPath),
-        ]);
+        const stat = await fs.stat(sidecarPath);
+        if (!stat.isFile() || stat.size > MAX_SIDECAR_BYTES) {
+          throw new Error("XMP sidecar is not a supported file size.");
+        }
+        const contents = await fs.readFile(sidecarPath, "utf8");
         return { contents, lastModified: stat.mtimeMs };
       } catch (error) {
         if (
@@ -183,39 +292,24 @@ function registerIpcHandlers(): void {
   ipcMain.handle(
     "darkroom:write-sidecar",
     async (
-      _event,
+      event,
       rootPath: string,
       relativePath: string,
-      contents: string | null,
+      contents: string,
     ) => {
-      const sidecarPath = getSidecarPath(rootPath, relativePath);
-      if (contents === null) {
-        try {
-          await fs.unlink(sidecarPath);
-        } catch (error) {
-          if (
-            typeof error === "object" &&
-            error !== null &&
-            "code" in error &&
-            error.code === "ENOENT"
-          ) {
-            return;
-          }
-          throw error;
-        }
-        return;
-      }
-
-      await fs.writeFile(sidecarPath, contents, "utf8");
+      assertTrustedIpc(event);
+      const sidecarPath = await getSidecarPath(rootPath, relativePath);
+      await writeSidecarAtomically(sidecarPath, contents);
     },
   );
 
   ipcMain.handle(
     "darkroom:save-export",
-    async (_event, suggestedName: string, data: ArrayBuffer) => {
+    async (event, suggestedName: string, data: ArrayBuffer) => {
+      assertTrustedIpc(event);
       const result = await dialog.showSaveDialog({
         title: "Export edited photo",
-        defaultPath: suggestedName,
+        defaultPath: path.basename(suggestedName),
         filters: [{ name: "JPEG", extensions: ["jpg", "jpeg"] }],
       });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain } from "electron";
+import fs from "node:fs/promises";
 import path from "node:path";
 import {
   folderExists,
@@ -21,6 +22,24 @@ let staticServerPort: number | null = null;
 
 const settingsStore = createSettingsStore(app.getPath("userData"));
 const catalogStore = createCatalogStore(app.getPath("userData"));
+
+function resolveLibraryFile(rootPath: string, relativePath: string): string {
+  const root = path.resolve(rootPath);
+  const absolute = path.resolve(root, relativePath);
+  const relative = path.relative(root, absolute);
+
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Sidecar path must stay inside the active library.");
+  }
+
+  return absolute;
+}
+
+function getSidecarPath(rootPath: string, relativePath: string): string {
+  const source = resolveLibraryFile(rootPath, relativePath);
+  const parsed = path.parse(source);
+  return path.join(parsed.dir, `${parsed.name}.xmp`);
+}
 
 function getPreloadPath(): string {
   return path.join(__dirname, "preload.js");
@@ -134,6 +153,78 @@ function registerIpcHandlers(): void {
     "darkroom:delete-files",
     async (_event, absolutePaths: string[]) => {
       await trashFiles(absolutePaths);
+    },
+  );
+
+  ipcMain.handle(
+    "darkroom:read-sidecar",
+    async (_event, rootPath: string, relativePath: string) => {
+      const sidecarPath = getSidecarPath(rootPath, relativePath);
+      try {
+        const [contents, stat] = await Promise.all([
+          fs.readFile(sidecarPath, "utf8"),
+          fs.stat(sidecarPath),
+        ]);
+        return { contents, lastModified: stat.mtimeMs };
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === "ENOENT"
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    },
+  );
+
+  ipcMain.handle(
+    "darkroom:write-sidecar",
+    async (
+      _event,
+      rootPath: string,
+      relativePath: string,
+      contents: string | null,
+    ) => {
+      const sidecarPath = getSidecarPath(rootPath, relativePath);
+      if (contents === null) {
+        try {
+          await fs.unlink(sidecarPath);
+        } catch (error) {
+          if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "ENOENT"
+          ) {
+            return;
+          }
+          throw error;
+        }
+        return;
+      }
+
+      await fs.writeFile(sidecarPath, contents, "utf8");
+    },
+  );
+
+  ipcMain.handle(
+    "darkroom:save-export",
+    async (_event, suggestedName: string, data: ArrayBuffer) => {
+      const result = await dialog.showSaveDialog({
+        title: "Export edited photo",
+        defaultPath: suggestedName,
+        filters: [{ name: "JPEG", extensions: ["jpg", "jpeg"] }],
+      });
+
+      if (result.canceled || !result.filePath) {
+        return null;
+      }
+
+      await fs.writeFile(result.filePath, Buffer.from(new Uint8Array(data)));
+      return result.filePath;
     },
   );
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -69,7 +69,7 @@ const darkroom = {
   writeSidecar(
     rootPath: string,
     relativePath: string,
-    contents: string | null,
+    contents: string,
   ): Promise<void> {
     return ipcRenderer.invoke(
       "darkroom:write-sidecar",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -58,6 +58,30 @@ const darkroom = {
   deleteFiles(absolutePaths: string[]): Promise<void> {
     return ipcRenderer.invoke("darkroom:delete-files", absolutePaths);
   },
+
+  readSidecar(
+    rootPath: string,
+    relativePath: string,
+  ): Promise<{ contents: string; lastModified: number } | null> {
+    return ipcRenderer.invoke("darkroom:read-sidecar", rootPath, relativePath);
+  },
+
+  writeSidecar(
+    rootPath: string,
+    relativePath: string,
+    contents: string | null,
+  ): Promise<void> {
+    return ipcRenderer.invoke(
+      "darkroom:write-sidecar",
+      rootPath,
+      relativePath,
+      contents,
+    );
+  },
+
+  saveExport(suggestedName: string, data: ArrayBuffer): Promise<string | null> {
+    return ipcRenderer.invoke("darkroom:save-export", suggestedName, data);
+  },
 };
 
 contextBridge.exposeInMainWorld("darkroom", darkroom);

--- a/lib/cache/develop-image-cache.ts
+++ b/lib/cache/develop-image-cache.ts
@@ -5,6 +5,9 @@ export interface DevelopImage {
   width: number;
   height: number;
   metadata: Record<string, unknown>;
+  rgb: Uint8Array | Uint16Array | Uint8ClampedArray;
+  bits: number;
+  colors: number;
   blob: Blob;
   objectUrl: string;
 }
@@ -58,6 +61,9 @@ export async function loadDevelopImage(entry: LibraryEntry): Promise<DevelopImag
       width: decoded.width,
       height: decoded.height,
       metadata: decoded.metadata,
+      rgb: decoded.rgb,
+      bits: decoded.bits,
+      colors: decoded.colors,
       blob: decoded.blob,
       objectUrl: decoded.objectUrl,
     };

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -1,3 +1,5 @@
+import type { DevelopSettings } from "@/lib/develop/types";
+
 export type PickStatus = "none" | "pick" | "reject";
 export type StarRating = 0 | 1 | 2 | 3 | 4 | 5;
 export type ColorLabel = "red" | "yellow" | "green" | "blue" | "purple" | null;
@@ -6,6 +8,7 @@ export interface EntryMetadata {
   pick: PickStatus;
   rating: StarRating;
   colorLabel: ColorLabel;
+  develop?: DevelopSettings;
   updatedAt: number;
 }
 

--- a/lib/develop/plugins/basic.ts
+++ b/lib/develop/plugins/basic.ts
@@ -1,4 +1,4 @@
-import type { BasicSettings, DevelopPlugin } from "@/lib/develop/types";
+import type { BasicSettings } from "@/lib/develop/types";
 
 export const DEFAULT_BASIC_SETTINGS: BasicSettings = {
   exposure: 0,
@@ -22,43 +22,40 @@ function numberProp(props: Record<string, string>, key: string): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
-function isDefault(settings: BasicSettings): boolean {
+export function isDefaultBasic(settings: BasicSettings): boolean {
   return Object.values(settings).every((value) => value === 0);
 }
 
-export const basicPlugin: DevelopPlugin<"basic"> = {
-  id: "basic",
-  label: "Basic",
-  defaults: DEFAULT_BASIC_SETTINGS,
-  isDefault,
-  xmp: {
-    write: (settings) => ({
-      "crs:ProcessVersion": "15.0",
-      "crs:Exposure2012": settings.exposure.toFixed(2),
-      "crs:Contrast2012": String(Math.round(settings.contrast)),
-      "crs:Highlights2012": String(Math.round(settings.highlights)),
-      "crs:Shadows2012": String(Math.round(settings.shadows)),
-      "crs:Whites2012": String(Math.round(settings.whites)),
-      "crs:Blacks2012": String(Math.round(settings.blacks)),
-      "crs:Temperature": String(Math.round(5500 + settings.temperature)),
-      "crs:Tint": String(Math.round(settings.tint)),
-      "crs:Vibrance": String(Math.round(settings.vibrance)),
-      "crs:Saturation": String(Math.round(settings.saturation)),
-    }),
-    read: (props) => {
-      const temperature = numberProp(props, "crs:Temperature");
-      return {
-        exposure: numberProp(props, "crs:Exposure2012") ?? 0,
-        contrast: numberProp(props, "crs:Contrast2012") ?? 0,
-        highlights: numberProp(props, "crs:Highlights2012") ?? 0,
-        shadows: numberProp(props, "crs:Shadows2012") ?? 0,
-        whites: numberProp(props, "crs:Whites2012") ?? 0,
-        blacks: numberProp(props, "crs:Blacks2012") ?? 0,
-        temperature: temperature === null ? 0 : temperature - 5500,
-        tint: numberProp(props, "crs:Tint") ?? 0,
-        vibrance: numberProp(props, "crs:Vibrance") ?? 0,
-        saturation: numberProp(props, "crs:Saturation") ?? 0,
-      };
-    },
-  },
-};
+export function writeBasicXmp(settings: BasicSettings): Record<string, string> {
+  return {
+    "crs:ProcessVersion": "15.0",
+    "crs:Exposure2012": settings.exposure.toFixed(2),
+    "crs:Contrast2012": String(Math.round(settings.contrast)),
+    "crs:Highlights2012": String(Math.round(settings.highlights)),
+    "crs:Shadows2012": String(Math.round(settings.shadows)),
+    "crs:Whites2012": String(Math.round(settings.whites)),
+    "crs:Blacks2012": String(Math.round(settings.blacks)),
+    "crs:Temperature": String(Math.round(5500 + settings.temperature)),
+    "crs:Tint": String(Math.round(settings.tint)),
+    "crs:Vibrance": String(Math.round(settings.vibrance)),
+    "crs:Saturation": String(Math.round(settings.saturation)),
+  };
+}
+
+export function readBasicXmp(
+  props: Record<string, string>,
+): Partial<BasicSettings> {
+  const temperature = numberProp(props, "crs:Temperature");
+  return {
+    exposure: numberProp(props, "crs:Exposure2012") ?? 0,
+    contrast: numberProp(props, "crs:Contrast2012") ?? 0,
+    highlights: numberProp(props, "crs:Highlights2012") ?? 0,
+    shadows: numberProp(props, "crs:Shadows2012") ?? 0,
+    whites: numberProp(props, "crs:Whites2012") ?? 0,
+    blacks: numberProp(props, "crs:Blacks2012") ?? 0,
+    temperature: temperature === null ? 0 : temperature - 5500,
+    tint: numberProp(props, "crs:Tint") ?? 0,
+    vibrance: numberProp(props, "crs:Vibrance") ?? 0,
+    saturation: numberProp(props, "crs:Saturation") ?? 0,
+  };
+}

--- a/lib/develop/plugins/basic.ts
+++ b/lib/develop/plugins/basic.ts
@@ -1,0 +1,64 @@
+import type { BasicSettings, DevelopPlugin } from "@/lib/develop/types";
+
+export const DEFAULT_BASIC_SETTINGS: BasicSettings = {
+  exposure: 0,
+  contrast: 0,
+  highlights: 0,
+  shadows: 0,
+  whites: 0,
+  blacks: 0,
+  temperature: 0,
+  tint: 0,
+  vibrance: 0,
+  saturation: 0,
+};
+
+function numberProp(props: Record<string, string>, key: string): number | null {
+  const raw = props[key];
+  if (raw === undefined) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function isDefault(settings: BasicSettings): boolean {
+  return Object.values(settings).every((value) => value === 0);
+}
+
+export const basicPlugin: DevelopPlugin<"basic"> = {
+  id: "basic",
+  label: "Basic",
+  defaults: DEFAULT_BASIC_SETTINGS,
+  isDefault,
+  xmp: {
+    write: (settings) => ({
+      "crs:ProcessVersion": "15.0",
+      "crs:Exposure2012": settings.exposure.toFixed(2),
+      "crs:Contrast2012": String(Math.round(settings.contrast)),
+      "crs:Highlights2012": String(Math.round(settings.highlights)),
+      "crs:Shadows2012": String(Math.round(settings.shadows)),
+      "crs:Whites2012": String(Math.round(settings.whites)),
+      "crs:Blacks2012": String(Math.round(settings.blacks)),
+      "crs:Temperature": String(Math.round(5500 + settings.temperature)),
+      "crs:Tint": String(Math.round(settings.tint)),
+      "crs:Vibrance": String(Math.round(settings.vibrance)),
+      "crs:Saturation": String(Math.round(settings.saturation)),
+    }),
+    read: (props) => {
+      const temperature = numberProp(props, "crs:Temperature");
+      return {
+        exposure: numberProp(props, "crs:Exposure2012") ?? 0,
+        contrast: numberProp(props, "crs:Contrast2012") ?? 0,
+        highlights: numberProp(props, "crs:Highlights2012") ?? 0,
+        shadows: numberProp(props, "crs:Shadows2012") ?? 0,
+        whites: numberProp(props, "crs:Whites2012") ?? 0,
+        blacks: numberProp(props, "crs:Blacks2012") ?? 0,
+        temperature: temperature === null ? 0 : temperature - 5500,
+        tint: numberProp(props, "crs:Tint") ?? 0,
+        vibrance: numberProp(props, "crs:Vibrance") ?? 0,
+        saturation: numberProp(props, "crs:Saturation") ?? 0,
+      };
+    },
+  },
+};

--- a/lib/develop/plugins/crop.ts
+++ b/lib/develop/plugins/crop.ts
@@ -1,4 +1,4 @@
-import type { CropSettings, DevelopPlugin } from "@/lib/develop/types";
+import type { CropSettings } from "@/lib/develop/types";
 
 export const DEFAULT_CROP_SETTINGS: CropSettings = {
   enabled: false,
@@ -21,7 +21,7 @@ function numberProp(props: Record<string, string>, key: string): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
-function isDefault(settings: CropSettings): boolean {
+export function isDefaultCrop(settings: CropSettings): boolean {
   return (
     !settings.enabled &&
     settings.x === 0 &&
@@ -35,46 +35,39 @@ function isDefault(settings: CropSettings): boolean {
   );
 }
 
-export const cropPlugin: DevelopPlugin<"crop"> = {
-  id: "crop",
-  label: "Crop & Transform",
-  defaults: DEFAULT_CROP_SETTINGS,
-  isDefault,
-  xmp: {
-    write: (settings) => {
-      if (!settings.enabled) {
-        return {} as Record<string, string>;
-      }
-      return {
-        "crs:HasCrop": "True",
-        "crs:CropLeft": settings.x.toFixed(6),
-        "crs:CropTop": settings.y.toFixed(6),
-        "crs:CropRight": (settings.x + settings.width).toFixed(6),
-        "crs:CropBottom": (settings.y + settings.height).toFixed(6),
-        "crs:CropAngle": settings.angle.toFixed(2),
-        "crs:PerspectiveHorizontal": String(Math.round(settings.perspectiveX)),
-        "crs:PerspectiveVertical": String(Math.round(settings.perspectiveY)),
-        "crs:LensManualDistortionAmount": String(
-          Math.round(settings.distortion),
-        ),
-      };
-    },
-    read: (props) => {
-      const left = numberProp(props, "crs:CropLeft") ?? 0;
-      const top = numberProp(props, "crs:CropTop") ?? 0;
-      const right = numberProp(props, "crs:CropRight") ?? 1;
-      const bottom = numberProp(props, "crs:CropBottom") ?? 1;
-      return {
-        enabled: props["crs:HasCrop"] === "True" || left > 0 || top > 0,
-        x: left,
-        y: top,
-        width: Math.max(0.05, right - left),
-        height: Math.max(0.05, bottom - top),
-        angle: numberProp(props, "crs:CropAngle") ?? 0,
-        perspectiveX: numberProp(props, "crs:PerspectiveHorizontal") ?? 0,
-        perspectiveY: numberProp(props, "crs:PerspectiveVertical") ?? 0,
-        distortion: numberProp(props, "crs:LensManualDistortionAmount") ?? 0,
-      };
-    },
-  },
-};
+export function writeCropXmp(settings: CropSettings): Record<string, string> {
+  if (!settings.enabled) {
+    return {};
+  }
+  return {
+    "crs:HasCrop": "True",
+    "crs:CropLeft": settings.x.toFixed(6),
+    "crs:CropTop": settings.y.toFixed(6),
+    "crs:CropRight": (settings.x + settings.width).toFixed(6),
+    "crs:CropBottom": (settings.y + settings.height).toFixed(6),
+    "crs:CropAngle": settings.angle.toFixed(2),
+    "crs:PerspectiveHorizontal": String(Math.round(settings.perspectiveX)),
+    "crs:PerspectiveVertical": String(Math.round(settings.perspectiveY)),
+    "crs:LensManualDistortionAmount": String(Math.round(settings.distortion)),
+  };
+}
+
+export function readCropXmp(
+  props: Record<string, string>,
+): Partial<CropSettings> {
+  const left = numberProp(props, "crs:CropLeft") ?? 0;
+  const top = numberProp(props, "crs:CropTop") ?? 0;
+  const right = numberProp(props, "crs:CropRight") ?? 1;
+  const bottom = numberProp(props, "crs:CropBottom") ?? 1;
+  return {
+    enabled: props["crs:HasCrop"] === "True" || left > 0 || top > 0,
+    x: left,
+    y: top,
+    width: Math.max(0.05, right - left),
+    height: Math.max(0.05, bottom - top),
+    angle: numberProp(props, "crs:CropAngle") ?? 0,
+    perspectiveX: numberProp(props, "crs:PerspectiveHorizontal") ?? 0,
+    perspectiveY: numberProp(props, "crs:PerspectiveVertical") ?? 0,
+    distortion: numberProp(props, "crs:LensManualDistortionAmount") ?? 0,
+  };
+}

--- a/lib/develop/plugins/crop.ts
+++ b/lib/develop/plugins/crop.ts
@@ -21,6 +21,22 @@ function numberProp(props: Record<string, string>, key: string): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+export function normalizeCrop(settings: CropSettings): CropSettings {
+  const x = clamp(settings.x, 0, 0.95);
+  const y = clamp(settings.y, 0, 0.95);
+  return {
+    ...settings,
+    x,
+    y,
+    width: clamp(settings.width, 0.05, 1 - x),
+    height: clamp(settings.height, 0.05, 1 - y),
+  };
+}
+
 export function isDefaultCrop(settings: CropSettings): boolean {
   return (
     !settings.enabled &&
@@ -36,19 +52,20 @@ export function isDefaultCrop(settings: CropSettings): boolean {
 }
 
 export function writeCropXmp(settings: CropSettings): Record<string, string> {
-  if (!settings.enabled) {
+  const crop = normalizeCrop(settings);
+  if (!crop.enabled) {
     return {};
   }
   return {
     "crs:HasCrop": "True",
-    "crs:CropLeft": settings.x.toFixed(6),
-    "crs:CropTop": settings.y.toFixed(6),
-    "crs:CropRight": (settings.x + settings.width).toFixed(6),
-    "crs:CropBottom": (settings.y + settings.height).toFixed(6),
-    "crs:CropAngle": settings.angle.toFixed(2),
-    "crs:PerspectiveHorizontal": String(Math.round(settings.perspectiveX)),
-    "crs:PerspectiveVertical": String(Math.round(settings.perspectiveY)),
-    "crs:LensManualDistortionAmount": String(Math.round(settings.distortion)),
+    "crs:CropLeft": crop.x.toFixed(6),
+    "crs:CropTop": crop.y.toFixed(6),
+    "crs:CropRight": (crop.x + crop.width).toFixed(6),
+    "crs:CropBottom": (crop.y + crop.height).toFixed(6),
+    "crs:CropAngle": crop.angle.toFixed(2),
+    "crs:PerspectiveHorizontal": String(Math.round(crop.perspectiveX)),
+    "crs:PerspectiveVertical": String(Math.round(crop.perspectiveY)),
+    "crs:LensManualDistortionAmount": String(Math.round(crop.distortion)),
   };
 }
 
@@ -59,7 +76,7 @@ export function readCropXmp(
   const top = numberProp(props, "crs:CropTop") ?? 0;
   const right = numberProp(props, "crs:CropRight") ?? 1;
   const bottom = numberProp(props, "crs:CropBottom") ?? 1;
-  return {
+  return normalizeCrop({
     enabled: props["crs:HasCrop"] === "True" || left > 0 || top > 0,
     x: left,
     y: top,
@@ -69,5 +86,5 @@ export function readCropXmp(
     perspectiveX: numberProp(props, "crs:PerspectiveHorizontal") ?? 0,
     perspectiveY: numberProp(props, "crs:PerspectiveVertical") ?? 0,
     distortion: numberProp(props, "crs:LensManualDistortionAmount") ?? 0,
-  };
+  });
 }

--- a/lib/develop/plugins/crop.ts
+++ b/lib/develop/plugins/crop.ts
@@ -43,7 +43,7 @@ export const cropPlugin: DevelopPlugin<"crop"> = {
   xmp: {
     write: (settings) => {
       if (!settings.enabled) {
-        return {};
+        return {} as Record<string, string>;
       }
       return {
         "crs:HasCrop": "True",

--- a/lib/develop/plugins/crop.ts
+++ b/lib/develop/plugins/crop.ts
@@ -1,0 +1,80 @@
+import type { CropSettings, DevelopPlugin } from "@/lib/develop/types";
+
+export const DEFAULT_CROP_SETTINGS: CropSettings = {
+  enabled: false,
+  x: 0,
+  y: 0,
+  width: 1,
+  height: 1,
+  angle: 0,
+  perspectiveX: 0,
+  perspectiveY: 0,
+  distortion: 0,
+};
+
+function numberProp(props: Record<string, string>, key: string): number | null {
+  const raw = props[key];
+  if (raw === undefined) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function isDefault(settings: CropSettings): boolean {
+  return (
+    !settings.enabled &&
+    settings.x === 0 &&
+    settings.y === 0 &&
+    settings.width === 1 &&
+    settings.height === 1 &&
+    settings.angle === 0 &&
+    settings.perspectiveX === 0 &&
+    settings.perspectiveY === 0 &&
+    settings.distortion === 0
+  );
+}
+
+export const cropPlugin: DevelopPlugin<"crop"> = {
+  id: "crop",
+  label: "Crop & Transform",
+  defaults: DEFAULT_CROP_SETTINGS,
+  isDefault,
+  xmp: {
+    write: (settings) => {
+      if (!settings.enabled) {
+        return {};
+      }
+      return {
+        "crs:HasCrop": "True",
+        "crs:CropLeft": settings.x.toFixed(6),
+        "crs:CropTop": settings.y.toFixed(6),
+        "crs:CropRight": (settings.x + settings.width).toFixed(6),
+        "crs:CropBottom": (settings.y + settings.height).toFixed(6),
+        "crs:CropAngle": settings.angle.toFixed(2),
+        "crs:PerspectiveHorizontal": String(Math.round(settings.perspectiveX)),
+        "crs:PerspectiveVertical": String(Math.round(settings.perspectiveY)),
+        "crs:LensManualDistortionAmount": String(
+          Math.round(settings.distortion),
+        ),
+      };
+    },
+    read: (props) => {
+      const left = numberProp(props, "crs:CropLeft") ?? 0;
+      const top = numberProp(props, "crs:CropTop") ?? 0;
+      const right = numberProp(props, "crs:CropRight") ?? 1;
+      const bottom = numberProp(props, "crs:CropBottom") ?? 1;
+      return {
+        enabled: props["crs:HasCrop"] === "True" || left > 0 || top > 0,
+        x: left,
+        y: top,
+        width: Math.max(0.05, right - left),
+        height: Math.max(0.05, bottom - top),
+        angle: numberProp(props, "crs:CropAngle") ?? 0,
+        perspectiveX: numberProp(props, "crs:PerspectiveHorizontal") ?? 0,
+        perspectiveY: numberProp(props, "crs:PerspectiveVertical") ?? 0,
+        distortion: numberProp(props, "crs:LensManualDistortionAmount") ?? 0,
+      };
+    },
+  },
+};

--- a/lib/develop/plugins/curve.ts
+++ b/lib/develop/plugins/curve.ts
@@ -1,0 +1,54 @@
+import type { CurveSettings, DevelopPlugin } from "@/lib/develop/types";
+
+export const DEFAULT_CURVE_SETTINGS: CurveSettings = {
+  shadows: 0,
+  midtones: 0,
+  highlights: 0,
+};
+
+function numberProp(props: Record<string, string>, key: string): number | null {
+  const raw = props[key];
+  if (raw === undefined) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function isDefault(settings: CurveSettings): boolean {
+  return Object.values(settings).every((value) => value === 0);
+}
+
+export const curvePlugin: DevelopPlugin<"curve"> = {
+  id: "curve",
+  label: "Tone Curve",
+  defaults: DEFAULT_CURVE_SETTINGS,
+  isDefault,
+  xmp: {
+    write: (settings) => ({
+      "crs:ToneCurvePV2012": [
+        "0, 0",
+        `64, ${Math.round(64 + settings.shadows)}`,
+        `128, ${Math.round(128 + settings.midtones)}`,
+        `192, ${Math.round(192 + settings.highlights)}`,
+        "255, 255",
+      ].join("; "),
+    }),
+    read: (props) => {
+      const curve = props["crs:ToneCurvePV2012"];
+      if (!curve) {
+        return {};
+      }
+      const values = curve
+        .split(";")
+        .map((pair) => pair.split(",").map((value) => Number(value.trim())));
+      const pointAt = (x: number) =>
+        values.find(([pointX]) => pointX === x)?.[1] ?? x;
+      return {
+        shadows: pointAt(64) - 64,
+        midtones: pointAt(128) - 128,
+        highlights: pointAt(192) - 192,
+      };
+    },
+  },
+};

--- a/lib/develop/plugins/curve.ts
+++ b/lib/develop/plugins/curve.ts
@@ -1,4 +1,4 @@
-import type { CurveSettings, DevelopPlugin } from "@/lib/develop/types";
+import type { CurveSettings } from "@/lib/develop/types";
 
 export const DEFAULT_CURVE_SETTINGS: CurveSettings = {
   shadows: 0,
@@ -6,40 +6,37 @@ export const DEFAULT_CURVE_SETTINGS: CurveSettings = {
   highlights: 0,
 };
 
-function isDefault(settings: CurveSettings): boolean {
+export function isDefaultCurve(settings: CurveSettings): boolean {
   return Object.values(settings).every((value) => value === 0);
 }
 
-export const curvePlugin: DevelopPlugin<"curve"> = {
-  id: "curve",
-  label: "Tone Curve",
-  defaults: DEFAULT_CURVE_SETTINGS,
-  isDefault,
-  xmp: {
-    write: (settings) => ({
-      "crs:ToneCurvePV2012": [
-        "0, 0",
-        `64, ${Math.round(64 + settings.shadows)}`,
-        `128, ${Math.round(128 + settings.midtones)}`,
-        `192, ${Math.round(192 + settings.highlights)}`,
-        "255, 255",
-      ].join("; "),
-    }),
-    read: (props) => {
-      const curve = props["crs:ToneCurvePV2012"];
-      if (!curve) {
-        return {};
-      }
-      const values = curve
-        .split(";")
-        .map((pair) => pair.split(",").map((value) => Number(value.trim())));
-      const pointAt = (x: number) =>
-        values.find(([pointX]) => pointX === x)?.[1] ?? x;
-      return {
-        shadows: pointAt(64) - 64,
-        midtones: pointAt(128) - 128,
-        highlights: pointAt(192) - 192,
-      };
-    },
-  },
-};
+export function writeCurveXmp(settings: CurveSettings): Record<string, string> {
+  return {
+    "crs:ToneCurvePV2012": [
+      "0, 0",
+      `64, ${Math.round(64 + settings.shadows)}`,
+      `128, ${Math.round(128 + settings.midtones)}`,
+      `192, ${Math.round(192 + settings.highlights)}`,
+      "255, 255",
+    ].join("; "),
+  };
+}
+
+export function readCurveXmp(
+  props: Record<string, string>,
+): Partial<CurveSettings> {
+  const curve = props["crs:ToneCurvePV2012"];
+  if (!curve) {
+    return {};
+  }
+  const values = curve
+    .split(";")
+    .map((pair) => pair.split(",").map((value) => Number(value.trim())));
+  const pointAt = (x: number) =>
+    values.find(([pointX]) => pointX === x)?.[1] ?? x;
+  return {
+    shadows: pointAt(64) - 64,
+    midtones: pointAt(128) - 128,
+    highlights: pointAt(192) - 192,
+  };
+}

--- a/lib/develop/plugins/curve.ts
+++ b/lib/develop/plugins/curve.ts
@@ -6,15 +6,6 @@ export const DEFAULT_CURVE_SETTINGS: CurveSettings = {
   highlights: 0,
 };
 
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
-
 function isDefault(settings: CurveSettings): boolean {
   return Object.values(settings).every((value) => value === 0);
 }

--- a/lib/develop/plugins/effects.ts
+++ b/lib/develop/plugins/effects.ts
@@ -1,0 +1,45 @@
+import type { DevelopPlugin, EffectsSettings } from "@/lib/develop/types";
+
+export const DEFAULT_EFFECTS_SETTINGS: EffectsSettings = {
+  vignette: 0,
+  grain: 0,
+  sharpening: 0,
+  noiseReduction: 0,
+};
+
+function numberProp(props: Record<string, string>, key: string): number | null {
+  const raw = props[key];
+  if (raw === undefined) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function isDefault(settings: EffectsSettings): boolean {
+  return Object.values(settings).every((value) => value === 0);
+}
+
+export const effectsPlugin: DevelopPlugin<"effects"> = {
+  id: "effects",
+  label: "Effects & Details",
+  defaults: DEFAULT_EFFECTS_SETTINGS,
+  isDefault,
+  xmp: {
+    write: (settings) => ({
+      "crs:PostCropVignetteAmount": String(Math.round(settings.vignette)),
+      "crs:GrainAmount": String(Math.round(settings.grain)),
+      "crs:Sharpness": String(Math.round(settings.sharpening)),
+      "crs:LuminanceSmoothing": String(Math.round(settings.noiseReduction)),
+      "crs:ColorNoiseReduction": String(
+        Math.round(settings.noiseReduction / 2),
+      ),
+    }),
+    read: (props) => ({
+      vignette: numberProp(props, "crs:PostCropVignetteAmount") ?? 0,
+      grain: numberProp(props, "crs:GrainAmount") ?? 0,
+      sharpening: numberProp(props, "crs:Sharpness") ?? 0,
+      noiseReduction: numberProp(props, "crs:LuminanceSmoothing") ?? 0,
+    }),
+  },
+};

--- a/lib/develop/plugins/effects.ts
+++ b/lib/develop/plugins/effects.ts
@@ -1,4 +1,4 @@
-import type { DevelopPlugin, EffectsSettings } from "@/lib/develop/types";
+import type { EffectsSettings } from "@/lib/develop/types";
 
 export const DEFAULT_EFFECTS_SETTINGS: EffectsSettings = {
   vignette: 0,
@@ -16,30 +16,29 @@ function numberProp(props: Record<string, string>, key: string): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
-function isDefault(settings: EffectsSettings): boolean {
+export function isDefaultEffects(settings: EffectsSettings): boolean {
   return Object.values(settings).every((value) => value === 0);
 }
 
-export const effectsPlugin: DevelopPlugin<"effects"> = {
-  id: "effects",
-  label: "Effects & Details",
-  defaults: DEFAULT_EFFECTS_SETTINGS,
-  isDefault,
-  xmp: {
-    write: (settings) => ({
-      "crs:PostCropVignetteAmount": String(Math.round(settings.vignette)),
-      "crs:GrainAmount": String(Math.round(settings.grain)),
-      "crs:Sharpness": String(Math.round(settings.sharpening)),
-      "crs:LuminanceSmoothing": String(Math.round(settings.noiseReduction)),
-      "crs:ColorNoiseReduction": String(
-        Math.round(settings.noiseReduction / 2),
-      ),
-    }),
-    read: (props) => ({
-      vignette: numberProp(props, "crs:PostCropVignetteAmount") ?? 0,
-      grain: numberProp(props, "crs:GrainAmount") ?? 0,
-      sharpening: numberProp(props, "crs:Sharpness") ?? 0,
-      noiseReduction: numberProp(props, "crs:LuminanceSmoothing") ?? 0,
-    }),
-  },
-};
+export function writeEffectsXmp(
+  settings: EffectsSettings,
+): Record<string, string> {
+  return {
+    "crs:PostCropVignetteAmount": String(Math.round(settings.vignette)),
+    "crs:GrainAmount": String(Math.round(settings.grain)),
+    "crs:Sharpness": String(Math.round(settings.sharpening)),
+    "crs:LuminanceSmoothing": String(Math.round(settings.noiseReduction)),
+    "crs:ColorNoiseReduction": String(Math.round(settings.noiseReduction / 2)),
+  };
+}
+
+export function readEffectsXmp(
+  props: Record<string, string>,
+): Partial<EffectsSettings> {
+  return {
+    vignette: numberProp(props, "crs:PostCropVignetteAmount") ?? 0,
+    grain: numberProp(props, "crs:GrainAmount") ?? 0,
+    sharpening: numberProp(props, "crs:Sharpness") ?? 0,
+    noiseReduction: numberProp(props, "crs:LuminanceSmoothing") ?? 0,
+  };
+}

--- a/lib/develop/plugins/mixer.ts
+++ b/lib/develop/plugins/mixer.ts
@@ -1,9 +1,4 @@
-import type {
-  DevelopPlugin,
-  MixerBandSettings,
-  MixerColor,
-  MixerSettings,
-} from "@/lib/develop/types";
+import type { MixerBandSettings, MixerColor, MixerSettings } from "@/lib/develop/types";
 
 export const MIXER_COLORS: MixerColor[] = [
   "red",
@@ -46,45 +41,38 @@ function numberProp(props: Record<string, string>, key: string): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
-function isDefault(settings: MixerSettings): boolean {
+export function isDefaultMixer(settings: MixerSettings): boolean {
   return MIXER_COLORS.every((color) =>
     Object.values(settings[color]).every((value) => value === 0),
   );
 }
 
-export const mixerPlugin: DevelopPlugin<"mixer"> = {
-  id: "mixer",
-  label: "Color Mixer",
-  defaults: DEFAULT_MIXER_SETTINGS,
-  isDefault,
-  xmp: {
-    write: (settings) => {
-      const props: Record<string, string> = {};
-      for (const color of MIXER_COLORS) {
-        const name = XMP_NAMES[color];
-        props[`crs:HueAdjustment${name}`] = String(
-          Math.round(settings[color].hue),
-        );
-        props[`crs:SaturationAdjustment${name}`] = String(
-          Math.round(settings[color].saturation),
-        );
-        props[`crs:LuminanceAdjustment${name}`] = String(
-          Math.round(settings[color].luminance),
-        );
-      }
-      return props;
-    },
-    read: (props) => {
-      const settings = structuredClone(DEFAULT_MIXER_SETTINGS);
-      for (const color of MIXER_COLORS) {
-        const name = XMP_NAMES[color];
-        settings[color] = {
-          hue: numberProp(props, `crs:HueAdjustment${name}`) ?? 0,
-          saturation: numberProp(props, `crs:SaturationAdjustment${name}`) ?? 0,
-          luminance: numberProp(props, `crs:LuminanceAdjustment${name}`) ?? 0,
-        };
-      }
-      return settings;
-    },
-  },
-};
+export function writeMixerXmp(settings: MixerSettings): Record<string, string> {
+  const props: Record<string, string> = {};
+  for (const color of MIXER_COLORS) {
+    const name = XMP_NAMES[color];
+    props[`crs:HueAdjustment${name}`] = String(Math.round(settings[color].hue));
+    props[`crs:SaturationAdjustment${name}`] = String(
+      Math.round(settings[color].saturation),
+    );
+    props[`crs:LuminanceAdjustment${name}`] = String(
+      Math.round(settings[color].luminance),
+    );
+  }
+  return props;
+}
+
+export function readMixerXmp(
+  props: Record<string, string>,
+): Partial<MixerSettings> {
+  const settings = structuredClone(DEFAULT_MIXER_SETTINGS);
+  for (const color of MIXER_COLORS) {
+    const name = XMP_NAMES[color];
+    settings[color] = {
+      hue: numberProp(props, `crs:HueAdjustment${name}`) ?? 0,
+      saturation: numberProp(props, `crs:SaturationAdjustment${name}`) ?? 0,
+      luminance: numberProp(props, `crs:LuminanceAdjustment${name}`) ?? 0,
+    };
+  }
+  return settings;
+}

--- a/lib/develop/plugins/mixer.ts
+++ b/lib/develop/plugins/mixer.ts
@@ -1,0 +1,90 @@
+import type {
+  DevelopPlugin,
+  MixerBandSettings,
+  MixerColor,
+  MixerSettings,
+} from "@/lib/develop/types";
+
+export const MIXER_COLORS: MixerColor[] = [
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "aqua",
+  "blue",
+  "purple",
+  "magenta",
+];
+
+const XMP_NAMES: Record<MixerColor, string> = {
+  red: "Red",
+  orange: "Orange",
+  yellow: "Yellow",
+  green: "Green",
+  aqua: "Aqua",
+  blue: "Blue",
+  purple: "Purple",
+  magenta: "Magenta",
+};
+
+const DEFAULT_BAND: MixerBandSettings = {
+  hue: 0,
+  saturation: 0,
+  luminance: 0,
+};
+
+export const DEFAULT_MIXER_SETTINGS = Object.fromEntries(
+  MIXER_COLORS.map((color) => [color, { ...DEFAULT_BAND }]),
+) as MixerSettings;
+
+function numberProp(props: Record<string, string>, key: string): number | null {
+  const raw = props[key];
+  if (raw === undefined) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function isDefault(settings: MixerSettings): boolean {
+  return MIXER_COLORS.every((color) =>
+    Object.values(settings[color]).every((value) => value === 0),
+  );
+}
+
+export const mixerPlugin: DevelopPlugin<"mixer"> = {
+  id: "mixer",
+  label: "Color Mixer",
+  defaults: DEFAULT_MIXER_SETTINGS,
+  isDefault,
+  xmp: {
+    write: (settings) => {
+      const props: Record<string, string> = {};
+      for (const color of MIXER_COLORS) {
+        const name = XMP_NAMES[color];
+        props[`crs:HueAdjustment${name}`] = String(
+          Math.round(settings[color].hue),
+        );
+        props[`crs:SaturationAdjustment${name}`] = String(
+          Math.round(settings[color].saturation),
+        );
+        props[`crs:LuminanceAdjustment${name}`] = String(
+          Math.round(settings[color].luminance),
+        );
+      }
+      return props;
+    },
+    read: (props) => {
+      const settings = structuredClone(DEFAULT_MIXER_SETTINGS);
+      for (const color of MIXER_COLORS) {
+        const name = XMP_NAMES[color];
+        settings[color] = {
+          hue: numberProp(props, `crs:HueAdjustment${name}`) ?? 0,
+          saturation: numberProp(props, `crs:SaturationAdjustment${name}`) ?? 0,
+          luminance: numberProp(props, `crs:LuminanceAdjustment${name}`) ?? 0,
+        };
+      }
+      return settings;
+    },
+  },
+};

--- a/lib/develop/registry.ts
+++ b/lib/develop/registry.ts
@@ -1,0 +1,57 @@
+import { basicPlugin } from "@/lib/develop/plugins/basic";
+import { cropPlugin } from "@/lib/develop/plugins/crop";
+import { curvePlugin } from "@/lib/develop/plugins/curve";
+import { effectsPlugin } from "@/lib/develop/plugins/effects";
+import { mixerPlugin } from "@/lib/develop/plugins/mixer";
+import type {
+  DevelopPlugin,
+  DevelopPluginId,
+  DevelopSettings,
+} from "@/lib/develop/types";
+
+export const DEVELOP_PLUGINS = [
+  cropPlugin,
+  basicPlugin,
+  curvePlugin,
+  mixerPlugin,
+  effectsPlugin,
+] as const satisfies readonly DevelopPlugin<DevelopPluginId>[];
+
+export const DEFAULT_DEVELOP_SETTINGS: DevelopSettings = composeDefaults();
+
+function composeDefaults(): DevelopSettings {
+  return DEVELOP_PLUGINS.reduce((settings, plugin) => {
+    return {
+      ...settings,
+      [plugin.id]: structuredClone(plugin.defaults),
+    };
+  }, {} as DevelopSettings);
+}
+
+export function createDevelopSettings(
+  patch: Partial<DevelopSettings> = {},
+): DevelopSettings {
+  const defaults = structuredClone(DEFAULT_DEVELOP_SETTINGS);
+  return {
+    ...defaults,
+    ...Object.fromEntries(
+      Object.entries(patch).map(([pluginId, pluginSettings]) => [
+        pluginId,
+        {
+          ...defaults[pluginId as DevelopPluginId],
+          ...(pluginSettings as object),
+        },
+      ]),
+    ),
+  };
+}
+
+export function isDefaultDevelopSettings(settings: DevelopSettings): boolean {
+  return DEVELOP_PLUGINS.every((plugin) =>
+    plugin.isDefault(settings[plugin.id] as never),
+  );
+}
+
+export function developSettingsHash(settings: DevelopSettings): string {
+  return JSON.stringify(settings);
+}

--- a/lib/develop/registry.ts
+++ b/lib/develop/registry.ts
@@ -1,57 +1,59 @@
-import { basicPlugin } from "@/lib/develop/plugins/basic";
-import { cropPlugin } from "@/lib/develop/plugins/crop";
-import { curvePlugin } from "@/lib/develop/plugins/curve";
-import { effectsPlugin } from "@/lib/develop/plugins/effects";
-import { mixerPlugin } from "@/lib/develop/plugins/mixer";
-import type {
-  DevelopPlugin,
-  DevelopPluginId,
-  DevelopSettings,
-} from "@/lib/develop/types";
+import {
+  DEFAULT_BASIC_SETTINGS,
+  isDefaultBasic,
+} from "@/lib/develop/plugins/basic";
+import {
+  DEFAULT_CROP_SETTINGS,
+  isDefaultCrop,
+} from "@/lib/develop/plugins/crop";
+import {
+  DEFAULT_CURVE_SETTINGS,
+  isDefaultCurve,
+} from "@/lib/develop/plugins/curve";
+import {
+  DEFAULT_EFFECTS_SETTINGS,
+  isDefaultEffects,
+} from "@/lib/develop/plugins/effects";
+import {
+  DEFAULT_MIXER_SETTINGS,
+  isDefaultMixer,
+} from "@/lib/develop/plugins/mixer";
+import type { DevelopSettings } from "@/lib/develop/types";
 
-export const DEVELOP_PLUGINS = [
-  cropPlugin,
-  basicPlugin,
-  curvePlugin,
-  mixerPlugin,
-  effectsPlugin,
-] as const satisfies readonly DevelopPlugin<DevelopPluginId>[];
+type DevelopSettingsPatch = {
+  [Plugin in keyof DevelopSettings]?: Partial<DevelopSettings[Plugin]>;
+};
 
-export const DEFAULT_DEVELOP_SETTINGS: DevelopSettings = composeDefaults();
-
-function composeDefaults(): DevelopSettings {
-  return DEVELOP_PLUGINS.reduce((settings, plugin) => {
-    return {
-      ...settings,
-      [plugin.id]: structuredClone(plugin.defaults),
-    };
-  }, {} as DevelopSettings);
-}
+export const DEFAULT_DEVELOP_SETTINGS: DevelopSettings = {
+  crop: DEFAULT_CROP_SETTINGS,
+  basic: DEFAULT_BASIC_SETTINGS,
+  curve: DEFAULT_CURVE_SETTINGS,
+  mixer: DEFAULT_MIXER_SETTINGS,
+  effects: DEFAULT_EFFECTS_SETTINGS,
+};
 
 export function createDevelopSettings(
-  patch: Partial<DevelopSettings> = {},
+  patch: DevelopSettingsPatch = {},
 ): DevelopSettings {
-  const defaults = structuredClone(DEFAULT_DEVELOP_SETTINGS);
   return {
-    ...defaults,
-    ...Object.fromEntries(
-      Object.entries(patch).map(([pluginId, pluginSettings]) => [
-        pluginId,
-        {
-          ...defaults[pluginId as DevelopPluginId],
-          ...(pluginSettings as object),
-        },
-      ]),
-    ),
+    crop: { ...DEFAULT_CROP_SETTINGS, ...patch.crop },
+    basic: { ...DEFAULT_BASIC_SETTINGS, ...patch.basic },
+    curve: { ...DEFAULT_CURVE_SETTINGS, ...patch.curve },
+    mixer: { ...DEFAULT_MIXER_SETTINGS, ...patch.mixer },
+    effects: { ...DEFAULT_EFFECTS_SETTINGS, ...patch.effects },
   };
-}
-
-export function isDefaultDevelopSettings(settings: DevelopSettings): boolean {
-  return DEVELOP_PLUGINS.every((plugin) =>
-    plugin.isDefault(settings[plugin.id] as never),
-  );
 }
 
 export function developSettingsHash(settings: DevelopSettings): string {
   return JSON.stringify(settings);
+}
+
+export function isDefaultDevelopSettings(settings: DevelopSettings): boolean {
+  return (
+    isDefaultCrop(settings.crop) &&
+    isDefaultBasic(settings.basic) &&
+    isDefaultCurve(settings.curve) &&
+    isDefaultMixer(settings.mixer) &&
+    isDefaultEffects(settings.effects)
+  );
 }

--- a/lib/develop/registry.ts
+++ b/lib/develop/registry.ts
@@ -5,6 +5,7 @@ import {
 import {
   DEFAULT_CROP_SETTINGS,
   isDefaultCrop,
+  normalizeCrop,
 } from "@/lib/develop/plugins/crop";
 import {
   DEFAULT_CURVE_SETTINGS,
@@ -36,7 +37,7 @@ export function createDevelopSettings(
   patch: DevelopSettingsPatch = {},
 ): DevelopSettings {
   return {
-    crop: { ...DEFAULT_CROP_SETTINGS, ...patch.crop },
+    crop: normalizeCrop({ ...DEFAULT_CROP_SETTINGS, ...patch.crop }),
     basic: { ...DEFAULT_BASIC_SETTINGS, ...patch.basic },
     curve: { ...DEFAULT_CURVE_SETTINGS, ...patch.curve },
     mixer: { ...DEFAULT_MIXER_SETTINGS, ...patch.mixer },

--- a/lib/develop/renderer.ts
+++ b/lib/develop/renderer.ts
@@ -1,0 +1,477 @@
+import type { DevelopImage } from "@/lib/cache/develop-image-cache";
+import type { DevelopSettings } from "@/lib/develop/types";
+import { MIXER_COLORS } from "@/lib/develop/plugins/mixer";
+
+const VERTEX_SHADER = `#version 300 es
+in vec2 a_position;
+out vec2 v_uv;
+
+void main() {
+  v_uv = (a_position + 1.0) * 0.5;
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}`;
+
+const FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+precision highp sampler2D;
+
+in vec2 v_uv;
+out vec4 out_color;
+
+uniform sampler2D u_image;
+uniform vec2 u_texel;
+uniform float u_show_original;
+
+uniform float u_crop_enabled;
+uniform vec4 u_crop;
+uniform float u_crop_angle;
+uniform float u_perspective_x;
+uniform float u_perspective_y;
+uniform float u_distortion;
+
+uniform float u_exposure;
+uniform float u_contrast;
+uniform float u_highlights;
+uniform float u_shadows;
+uniform float u_whites;
+uniform float u_blacks;
+uniform float u_temperature;
+uniform float u_tint;
+uniform float u_vibrance;
+uniform float u_saturation;
+
+uniform float u_curve_shadows;
+uniform float u_curve_midtones;
+uniform float u_curve_highlights;
+uniform float u_mixer[24];
+uniform float u_vignette;
+uniform float u_grain;
+uniform float u_sharpening;
+uniform float u_noise_reduction;
+
+float luma(vec3 color) {
+  return dot(color, vec3(0.2126, 0.7152, 0.0722));
+}
+
+vec2 transform_uv(vec2 uv) {
+  uv = vec2(uv.x, 1.0 - uv.y);
+
+  if (u_crop_enabled > 0.5) {
+    vec2 crop_center = u_crop.xy + u_crop.zw * 0.5;
+    vec2 p = uv - 0.5;
+    float angle = radians(-u_crop_angle);
+    mat2 rotation = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
+    p = rotation * p;
+    uv = crop_center + p * u_crop.zw;
+  }
+
+  vec2 centered = uv - 0.5;
+  uv += vec2(centered.y * u_perspective_x, centered.x * u_perspective_y) * 0.002;
+  uv += centered * dot(centered, centered) * u_distortion * 0.001;
+  return uv;
+}
+
+vec3 adjust_basic(vec3 color) {
+  color *= pow(2.0, u_exposure);
+  color *= vec3(
+    1.0 + u_temperature * 0.00008 + u_tint * 0.00002,
+    1.0 - abs(u_tint) * 0.00003,
+    1.0 - u_temperature * 0.00008 - u_tint * 0.00002
+  );
+
+  float lum = luma(color);
+  float shadow_mask = smoothstep(0.7, 0.0, lum);
+  float highlight_mask = smoothstep(0.35, 1.0, lum);
+  color += shadow_mask * u_shadows * 0.005;
+  color += highlight_mask * u_highlights * 0.004;
+  color += smoothstep(0.72, 1.0, lum) * u_whites * 0.004;
+  color += smoothstep(0.25, 0.0, lum) * u_blacks * 0.004;
+  color = (color - 0.5) * (1.0 + u_contrast * 0.01) + 0.5;
+
+  float average = (color.r + color.g + color.b) / 3.0;
+  float saturation = max(max(color.r, color.g), color.b) - min(min(color.r, color.g), color.b);
+  float vibrance = u_vibrance * 0.01 * (1.0 - saturation);
+  color = mix(vec3(average), color, 1.0 + u_saturation * 0.01 + vibrance);
+  return color;
+}
+
+vec3 adjust_curve(vec3 color) {
+  float lum = luma(color);
+  float lift =
+    (1.0 - smoothstep(0.0, 0.45, lum)) * u_curve_shadows +
+    (1.0 - abs(lum - 0.5) * 2.0) * u_curve_midtones +
+    smoothstep(0.55, 1.0, lum) * u_curve_highlights;
+  return color + lift * 0.004;
+}
+
+vec3 rgb_to_hsl(vec3 c) {
+  float maxc = max(max(c.r, c.g), c.b);
+  float minc = min(min(c.r, c.g), c.b);
+  float h = 0.0;
+  float s = 0.0;
+  float l = (maxc + minc) * 0.5;
+  float d = maxc - minc;
+  if (d > 0.0001) {
+    s = d / (1.0 - abs(2.0 * l - 1.0));
+    if (maxc == c.r) {
+      h = mod((c.g - c.b) / d, 6.0);
+    } else if (maxc == c.g) {
+      h = (c.b - c.r) / d + 2.0;
+    } else {
+      h = (c.r - c.g) / d + 4.0;
+    }
+    h /= 6.0;
+  }
+  return vec3(h, s, l);
+}
+
+float hue_to_rgb(float p, float q, float t) {
+  t = fract(t);
+  if (t < 1.0 / 6.0) return p + (q - p) * 6.0 * t;
+  if (t < 1.0 / 2.0) return q;
+  if (t < 2.0 / 3.0) return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+  return p;
+}
+
+vec3 hsl_to_rgb(vec3 hsl) {
+  if (hsl.y <= 0.0001) return vec3(hsl.z);
+  float q = hsl.z < 0.5 ? hsl.z * (1.0 + hsl.y) : hsl.z + hsl.y - hsl.z * hsl.y;
+  float p = 2.0 * hsl.z - q;
+  return vec3(
+    hue_to_rgb(p, q, hsl.x + 1.0 / 3.0),
+    hue_to_rgb(p, q, hsl.x),
+    hue_to_rgb(p, q, hsl.x - 1.0 / 3.0)
+  );
+}
+
+vec3 adjust_mixer(vec3 color) {
+  vec3 hsl = rgb_to_hsl(clamp(color, 0.0, 1.0));
+  for (int i = 0; i < 8; i++) {
+    float center = float(i) / 8.0;
+    float distance = min(abs(hsl.x - center), 1.0 - abs(hsl.x - center));
+    float weight = smoothstep(0.18, 0.0, distance);
+    int base = i * 3;
+    hsl.x = fract(hsl.x + u_mixer[base] * weight / 360.0);
+    hsl.y = clamp(hsl.y * (1.0 + u_mixer[base + 1] * weight * 0.01), 0.0, 1.0);
+    hsl.z = clamp(hsl.z + u_mixer[base + 2] * weight * 0.005, 0.0, 1.0);
+  }
+  return hsl_to_rgb(hsl);
+}
+
+float random(vec2 co) {
+  return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec3 adjust_effects(vec3 color, vec2 uv) {
+  vec2 centered = v_uv - 0.5;
+  float vignette = smoothstep(0.85, 0.15, length(centered));
+  color *= mix(1.0, vignette, max(0.0, -u_vignette) * 0.012);
+  color += (1.0 - vignette) * max(0.0, u_vignette) * 0.006;
+  color += (random(gl_FragCoord.xy) - 0.5) * u_grain * 0.004;
+  return color;
+}
+
+void main() {
+  vec2 uv = transform_uv(v_uv);
+  if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+    out_color = vec4(0.0, 0.0, 0.0, 1.0);
+    return;
+  }
+
+  vec3 center = texture(u_image, uv).rgb;
+  if (u_show_original > 0.5) {
+    out_color = vec4(center, 1.0);
+    return;
+  }
+
+  vec3 neighbors =
+    texture(u_image, uv + vec2(u_texel.x, 0.0)).rgb +
+    texture(u_image, uv - vec2(u_texel.x, 0.0)).rgb +
+    texture(u_image, uv + vec2(0.0, u_texel.y)).rgb +
+    texture(u_image, uv - vec2(0.0, u_texel.y)).rgb;
+  vec3 average = neighbors * 0.25;
+  center = mix(center, average, u_noise_reduction * 0.003);
+  center += (center - average) * u_sharpening * 0.015;
+
+  vec3 color = adjust_basic(center);
+  color = adjust_curve(color);
+  color = adjust_mixer(color);
+  color = adjust_effects(color, uv);
+  out_color = vec4(clamp(color, 0.0, 1.0), 1.0);
+}`;
+
+const QUAD = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]);
+
+function compileShader(
+  gl: WebGL2RenderingContext,
+  type: number,
+  source: string,
+): WebGLShader {
+  const shader = gl.createShader(type);
+  if (!shader) {
+    throw new Error("Could not create WebGL shader.");
+  }
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const message = gl.getShaderInfoLog(shader) ?? "Unknown shader error.";
+    gl.deleteShader(shader);
+    throw new Error(message);
+  }
+  return shader;
+}
+
+function createProgram(gl: WebGL2RenderingContext): WebGLProgram {
+  const vertex = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+  const fragment = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+  const program = gl.createProgram();
+  if (!program) {
+    throw new Error("Could not create WebGL program.");
+  }
+  gl.attachShader(program, vertex);
+  gl.attachShader(program, fragment);
+  gl.linkProgram(program);
+  gl.deleteShader(vertex);
+  gl.deleteShader(fragment);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const message = gl.getProgramInfoLog(program) ?? "Unknown WebGL link error.";
+    gl.deleteProgram(program);
+    throw new Error(message);
+  }
+  return program;
+}
+
+function toFloatRgba(image: DevelopImage): Float32Array {
+  const source =
+    image.rgb instanceof Uint16Array
+      ? image.rgb
+      : new Uint16Array(image.rgb.buffer);
+  const channels = Math.max(1, image.colors);
+  const maxValue = image.bits > 8 ? 65535 : 255;
+  const output = new Float32Array(image.width * image.height * 4);
+
+  for (let sourceIndex = 0, outputIndex = 0; outputIndex < output.length; sourceIndex += channels, outputIndex += 4) {
+    output[outputIndex] = source[sourceIndex] / maxValue;
+    output[outputIndex + 1] = source[sourceIndex + 1] / maxValue;
+    output[outputIndex + 2] = source[sourceIndex + 2] / maxValue;
+    output[outputIndex + 3] = 1;
+  }
+
+  return output;
+}
+
+export class DevelopRenderer {
+  private readonly canvas: HTMLCanvasElement;
+  private readonly gl: WebGL2RenderingContext;
+  private readonly program: WebGLProgram;
+  private texture: WebGLTexture | null = null;
+  private textureWidth = 1;
+  private textureHeight = 1;
+
+  constructor(canvas: HTMLCanvasElement) {
+    const gl = canvas.getContext("webgl2", { preserveDrawingBuffer: true });
+    if (!gl) {
+      throw new Error("WebGL2 is not available.");
+    }
+
+    this.canvas = canvas;
+    this.gl = gl;
+    this.program = createProgram(gl);
+    this.configureGeometry();
+  }
+
+  private configureGeometry(): void {
+    const gl = this.gl;
+    gl.useProgram(this.program);
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, QUAD, gl.STATIC_DRAW);
+    const location = gl.getAttribLocation(this.program, "a_position");
+    gl.enableVertexAttribArray(location);
+    gl.vertexAttribPointer(location, 2, gl.FLOAT, false, 0, 0);
+  }
+
+  async setImage(image: DevelopImage): Promise<void> {
+    const gl = this.gl;
+    const texture = gl.createTexture();
+    if (!texture) {
+      throw new Error("Could not create WebGL texture.");
+    }
+
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+
+    if (image.bits > 8 && image.rgb.length > 0) {
+      const floatLinear = gl.getExtension("OES_texture_float_linear");
+      if (!floatLinear) {
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      }
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA32F,
+        image.width,
+        image.height,
+        0,
+        gl.RGBA,
+        gl.FLOAT,
+        toFloatRgba(image),
+      );
+    } else {
+      const bitmap = await createImageBitmap(image.blob);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmap);
+      bitmap.close();
+    }
+
+    if (this.texture) {
+      gl.deleteTexture(this.texture);
+    }
+    this.texture = texture;
+    this.textureWidth = image.width;
+    this.textureHeight = image.height;
+  }
+
+  resize(width: number, height: number): void {
+    const nextWidth = Math.max(1, Math.floor(width));
+    const nextHeight = Math.max(1, Math.floor(height));
+    if (this.canvas.width !== nextWidth || this.canvas.height !== nextHeight) {
+      this.canvas.width = nextWidth;
+      this.canvas.height = nextHeight;
+    }
+  }
+
+  render(settings: DevelopSettings, showOriginal: boolean): void {
+    const gl = this.gl;
+    if (!this.texture) {
+      return;
+    }
+
+    gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    this.applyContainViewport();
+    gl.useProgram(this.program);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.texture);
+    this.uniform1i("u_image", 0);
+    this.uniform2f("u_texel", 1 / this.textureWidth, 1 / this.textureHeight);
+    this.uniform1f("u_show_original", showOriginal ? 1 : 0);
+
+    this.uniform1f("u_crop_enabled", settings.crop.enabled ? 1 : 0);
+    this.uniform4f(
+      "u_crop",
+      settings.crop.x,
+      settings.crop.y,
+      settings.crop.width,
+      settings.crop.height,
+    );
+    this.uniform1f("u_crop_angle", settings.crop.angle);
+    this.uniform1f("u_perspective_x", settings.crop.perspectiveX);
+    this.uniform1f("u_perspective_y", settings.crop.perspectiveY);
+    this.uniform1f("u_distortion", settings.crop.distortion);
+
+    this.uniform1f("u_exposure", settings.basic.exposure);
+    this.uniform1f("u_contrast", settings.basic.contrast);
+    this.uniform1f("u_highlights", settings.basic.highlights);
+    this.uniform1f("u_shadows", settings.basic.shadows);
+    this.uniform1f("u_whites", settings.basic.whites);
+    this.uniform1f("u_blacks", settings.basic.blacks);
+    this.uniform1f("u_temperature", settings.basic.temperature);
+    this.uniform1f("u_tint", settings.basic.tint);
+    this.uniform1f("u_vibrance", settings.basic.vibrance);
+    this.uniform1f("u_saturation", settings.basic.saturation);
+
+    this.uniform1f("u_curve_shadows", settings.curve.shadows);
+    this.uniform1f("u_curve_midtones", settings.curve.midtones);
+    this.uniform1f("u_curve_highlights", settings.curve.highlights);
+    this.uniformMixer(settings);
+    this.uniform1f("u_vignette", settings.effects.vignette);
+    this.uniform1f("u_grain", settings.effects.grain);
+    this.uniform1f("u_sharpening", settings.effects.sharpening);
+    this.uniform1f("u_noise_reduction", settings.effects.noiseReduction);
+
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+  }
+
+  private applyContainViewport(): void {
+    const canvasRatio = this.canvas.width / this.canvas.height;
+    const imageRatio = this.textureWidth / this.textureHeight;
+    let width = this.canvas.width;
+    let height = this.canvas.height;
+
+    if (imageRatio > canvasRatio) {
+      height = width / imageRatio;
+    } else {
+      width = height * imageRatio;
+    }
+
+    this.gl.viewport(
+      Math.round((this.canvas.width - width) / 2),
+      Math.round((this.canvas.height - height) / 2),
+      Math.round(width),
+      Math.round(height),
+    );
+  }
+
+  dispose(): void {
+    if (this.texture) {
+      this.gl.deleteTexture(this.texture);
+      this.texture = null;
+    }
+    this.gl.deleteProgram(this.program);
+  }
+
+  toBlob(type = "image/jpeg", quality = 0.92): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      this.canvas.toBlob(
+        (blob) => {
+          if (!blob) {
+            reject(new Error("Could not export edited image."));
+            return;
+          }
+          resolve(blob);
+        },
+        type,
+        quality,
+      );
+    });
+  }
+
+  private uniformMixer(settings: DevelopSettings): void {
+    const values = new Float32Array(24);
+    for (const [index, color] of MIXER_COLORS.entries()) {
+      const base = index * 3;
+      values[base] = settings.mixer[color].hue;
+      values[base + 1] = settings.mixer[color].saturation;
+      values[base + 2] = settings.mixer[color].luminance;
+    }
+    const location = this.gl.getUniformLocation(this.program, "u_mixer");
+    this.gl.uniform1fv(location, values);
+  }
+
+  private uniform1i(name: string, value: number): void {
+    this.gl.uniform1i(this.gl.getUniformLocation(this.program, name), value);
+  }
+
+  private uniform1f(name: string, value: number): void {
+    this.gl.uniform1f(this.gl.getUniformLocation(this.program, name), value);
+  }
+
+  private uniform2f(name: string, x: number, y: number): void {
+    this.gl.uniform2f(this.gl.getUniformLocation(this.program, name), x, y);
+  }
+
+  private uniform4f(
+    name: string,
+    x: number,
+    y: number,
+    z: number,
+    w: number,
+  ): void {
+    this.gl.uniform4f(this.gl.getUniformLocation(this.program, name), x, y, z, w);
+  }
+}

--- a/lib/develop/renderer.ts
+++ b/lib/develop/renderer.ts
@@ -291,6 +291,33 @@ function toFloatRgba(
   return output;
 }
 
+function toUint8Rgba(image: DevelopImage): Uint8Array {
+  const source =
+    image.rgb instanceof Uint16Array
+      ? image.rgb
+      : new Uint16Array(
+          image.rgb.buffer,
+          image.rgb.byteOffset,
+          Math.floor(image.rgb.byteLength / Uint16Array.BYTES_PER_ELEMENT),
+        );
+  const channels = Math.max(1, image.colors);
+  const output = new Uint8Array(image.width * image.height * 4);
+
+  for (
+    let pixel = 0, outputIndex = 0;
+    outputIndex < output.length;
+    pixel += 1, outputIndex += 4
+  ) {
+    const sourceIndex = pixel * channels;
+    output[outputIndex] = Math.round((source[sourceIndex] / 65535) * 255);
+    output[outputIndex + 1] = Math.round((source[sourceIndex + 1] / 65535) * 255);
+    output[outputIndex + 2] = Math.round((source[sourceIndex + 2] / 65535) * 255);
+    output[outputIndex + 3] = 255;
+  }
+
+  return output;
+}
+
 export class DevelopRenderer {
   private readonly canvas: HTMLCanvasElement;
   private readonly gl: WebGL2RenderingContext;
@@ -328,7 +355,10 @@ export class DevelopRenderer {
 
   async setImage(
     image: DevelopImage,
-    { useRawPixels = true }: { useRawPixels?: boolean } = {},
+    {
+      useRawPixels = true,
+      exportRawPixels = false,
+    }: { useRawPixels?: boolean; exportRawPixels?: boolean } = {},
   ): Promise<void> {
     const gl = this.gl;
     const texture = gl.createTexture();
@@ -344,25 +374,45 @@ export class DevelopRenderer {
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
       if (useRawPixels && image.bits > 8 && image.rgb.length > 0) {
-        const size = previewSize(image, gl.getParameter(gl.MAX_TEXTURE_SIZE));
-        const floatLinear = gl.getExtension("OES_texture_float_linear");
-        if (!floatLinear) {
-          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        if (exportRawPixels) {
+          const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+          if (image.width > maxTextureSize || image.height > maxTextureSize) {
+            throw new Error("Image exceeds this GPU's maximum export texture size.");
+          }
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA,
+            image.width,
+            image.height,
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            toUint8Rgba(image),
+          );
+          this.textureWidth = image.width;
+          this.textureHeight = image.height;
+        } else {
+          const size = previewSize(image, gl.getParameter(gl.MAX_TEXTURE_SIZE));
+          const floatLinear = gl.getExtension("OES_texture_float_linear");
+          if (!floatLinear) {
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+          }
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA32F,
+            size.width,
+            size.height,
+            0,
+            gl.RGBA,
+            gl.FLOAT,
+            toFloatRgba(image, size.width, size.height),
+          );
+          this.textureWidth = size.width;
+          this.textureHeight = size.height;
         }
-        gl.texImage2D(
-          gl.TEXTURE_2D,
-          0,
-          gl.RGBA32F,
-          size.width,
-          size.height,
-          0,
-          gl.RGBA,
-          gl.FLOAT,
-          toFloatRgba(image, size.width, size.height),
-        );
-        this.textureWidth = size.width;
-        this.textureHeight = size.height;
       } else {
         const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
         if (image.width > maxTextureSize || image.height > maxTextureSize) {
@@ -513,7 +563,7 @@ export class DevelopRenderer {
     canvas.height = image.height;
     const renderer = new DevelopRenderer(canvas, { preserveDrawingBuffer: true });
     try {
-      await renderer.setImage(image, { useRawPixels: false });
+      await renderer.setImage(image, { exportRawPixels: true });
       renderer.render(settings, false, false);
       renderer.gl.finish();
       return await renderer.toBlob();

--- a/lib/develop/renderer.ts
+++ b/lib/develop/renderer.ts
@@ -162,7 +162,7 @@ float random(vec2 co) {
   return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
 }
 
-vec3 adjust_effects(vec3 color, vec2 uv) {
+vec3 adjust_effects(vec3 color) {
   vec2 centered = v_uv - 0.5;
   float vignette = smoothstep(0.85, 0.15, length(centered));
   color *= mix(1.0, vignette, max(0.0, -u_vignette) * 0.012);
@@ -196,11 +196,13 @@ void main() {
   vec3 color = adjust_basic(center);
   color = adjust_curve(color);
   color = adjust_mixer(color);
-  color = adjust_effects(color, uv);
+  color = adjust_effects(color);
   out_color = vec4(clamp(color, 0.0, 1.0), 1.0);
 }`;
 
 const QUAD = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]);
+const MAX_PREVIEW_PIXELS = 4_000_000;
+const MAX_EXPORT_PIXELS = 40_000_000;
 
 function compileShader(
   gl: WebGL2RenderingContext,
@@ -241,20 +243,49 @@ function createProgram(gl: WebGL2RenderingContext): WebGLProgram {
   return program;
 }
 
-function toFloatRgba(image: DevelopImage): Float32Array {
+function previewSize(
+  image: DevelopImage,
+  maxTextureSize: number,
+): { width: number; height: number } {
+  const scale = Math.min(
+    1,
+    Math.sqrt(MAX_PREVIEW_PIXELS / (image.width * image.height)),
+    maxTextureSize / Math.max(image.width, image.height),
+  );
+  return {
+    width: Math.max(1, Math.floor(image.width * scale)),
+    height: Math.max(1, Math.floor(image.height * scale)),
+  };
+}
+
+function toFloatRgba(
+  image: DevelopImage,
+  width: number,
+  height: number,
+): Float32Array {
   const source =
     image.rgb instanceof Uint16Array
       ? image.rgb
-      : new Uint16Array(image.rgb.buffer);
+      : new Uint16Array(
+          image.rgb.buffer,
+          image.rgb.byteOffset,
+          Math.floor(image.rgb.byteLength / Uint16Array.BYTES_PER_ELEMENT),
+        );
   const channels = Math.max(1, image.colors);
   const maxValue = image.bits > 8 ? 65535 : 255;
-  const output = new Float32Array(image.width * image.height * 4);
+  const output = new Float32Array(width * height * 4);
 
-  for (let sourceIndex = 0, outputIndex = 0; outputIndex < output.length; sourceIndex += channels, outputIndex += 4) {
-    output[outputIndex] = source[sourceIndex] / maxValue;
-    output[outputIndex + 1] = source[sourceIndex + 1] / maxValue;
-    output[outputIndex + 2] = source[sourceIndex + 2] / maxValue;
-    output[outputIndex + 3] = 1;
+  for (let y = 0; y < height; y += 1) {
+    const sourceY = Math.min(image.height - 1, Math.floor((y * image.height) / height));
+    for (let x = 0; x < width; x += 1) {
+      const sourceX = Math.min(image.width - 1, Math.floor((x * image.width) / width));
+      const sourceIndex = (sourceY * image.width + sourceX) * channels;
+      const outputIndex = (y * width + x) * 4;
+      output[outputIndex] = source[sourceIndex] / maxValue;
+      output[outputIndex + 1] = source[sourceIndex + 1] / maxValue;
+      output[outputIndex + 2] = source[sourceIndex + 2] / maxValue;
+      output[outputIndex + 3] = 1;
+    }
   }
 
   return output;
@@ -267,9 +298,13 @@ export class DevelopRenderer {
   private texture: WebGLTexture | null = null;
   private textureWidth = 1;
   private textureHeight = 1;
+  private readonly uniformLocations = new Map<string, WebGLUniformLocation | null>();
 
-  constructor(canvas: HTMLCanvasElement) {
-    const gl = canvas.getContext("webgl2", { preserveDrawingBuffer: true });
+  constructor(
+    canvas: HTMLCanvasElement,
+    { preserveDrawingBuffer = false }: { preserveDrawingBuffer?: boolean } = {},
+  ) {
+    const gl = canvas.getContext("webgl2", { preserveDrawingBuffer });
     if (!gl) {
       throw new Error("WebGL2 is not available.");
     }
@@ -291,48 +326,66 @@ export class DevelopRenderer {
     gl.vertexAttribPointer(location, 2, gl.FLOAT, false, 0, 0);
   }
 
-  async setImage(image: DevelopImage): Promise<void> {
+  async setImage(
+    image: DevelopImage,
+    { useRawPixels = true }: { useRawPixels?: boolean } = {},
+  ): Promise<void> {
     const gl = this.gl;
     const texture = gl.createTexture();
     if (!texture) {
       throw new Error("Could not create WebGL texture.");
     }
 
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    try {
+      gl.bindTexture(gl.TEXTURE_2D, texture);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
-    if (image.bits > 8 && image.rgb.length > 0) {
-      const floatLinear = gl.getExtension("OES_texture_float_linear");
-      if (!floatLinear) {
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      if (useRawPixels && image.bits > 8 && image.rgb.length > 0) {
+        const size = previewSize(image, gl.getParameter(gl.MAX_TEXTURE_SIZE));
+        const floatLinear = gl.getExtension("OES_texture_float_linear");
+        if (!floatLinear) {
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        }
+        gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA32F,
+          size.width,
+          size.height,
+          0,
+          gl.RGBA,
+          gl.FLOAT,
+          toFloatRgba(image, size.width, size.height),
+        );
+        this.textureWidth = size.width;
+        this.textureHeight = size.height;
+      } else {
+        const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+        if (image.width > maxTextureSize || image.height > maxTextureSize) {
+          throw new Error("Image exceeds this GPU's maximum export texture size.");
+        }
+        const bitmap = await createImageBitmap(image.blob);
+        try {
+          gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmap);
+        } finally {
+          bitmap.close();
+        }
+        this.textureWidth = image.width;
+        this.textureHeight = image.height;
       }
-      gl.texImage2D(
-        gl.TEXTURE_2D,
-        0,
-        gl.RGBA32F,
-        image.width,
-        image.height,
-        0,
-        gl.RGBA,
-        gl.FLOAT,
-        toFloatRgba(image),
-      );
-    } else {
-      const bitmap = await createImageBitmap(image.blob);
-      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmap);
-      bitmap.close();
+    } catch (error) {
+      gl.deleteTexture(texture);
+      throw error;
     }
 
     if (this.texture) {
       gl.deleteTexture(this.texture);
     }
     this.texture = texture;
-    this.textureWidth = image.width;
-    this.textureHeight = image.height;
   }
 
   resize(width: number, height: number): void {
@@ -344,7 +397,11 @@ export class DevelopRenderer {
     }
   }
 
-  render(settings: DevelopSettings, showOriginal: boolean): void {
+  render(
+    settings: DevelopSettings,
+    showOriginal: boolean,
+    contain = true,
+  ): void {
     const gl = this.gl;
     if (!this.texture) {
       return;
@@ -353,7 +410,9 @@ export class DevelopRenderer {
     gl.viewport(0, 0, this.canvas.width, this.canvas.height);
     gl.clearColor(0, 0, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    this.applyContainViewport();
+    if (contain) {
+      this.applyContainViewport();
+    }
     gl.useProgram(this.program);
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
@@ -441,6 +500,28 @@ export class DevelopRenderer {
     });
   }
 
+  async exportJpeg(
+    image: DevelopImage,
+    settings: DevelopSettings,
+  ): Promise<Blob> {
+    if (image.width * image.height > MAX_EXPORT_PIXELS) {
+      throw new Error("Image is too large to export safely on this device.");
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const renderer = new DevelopRenderer(canvas, { preserveDrawingBuffer: true });
+    try {
+      await renderer.setImage(image, { useRawPixels: false });
+      renderer.render(settings, false, false);
+      renderer.gl.finish();
+      return await renderer.toBlob();
+    } finally {
+      renderer.dispose();
+    }
+  }
+
   private uniformMixer(settings: DevelopSettings): void {
     const values = new Float32Array(24);
     for (const [index, color] of MIXER_COLORS.entries()) {
@@ -449,20 +530,19 @@ export class DevelopRenderer {
       values[base + 1] = settings.mixer[color].saturation;
       values[base + 2] = settings.mixer[color].luminance;
     }
-    const location = this.gl.getUniformLocation(this.program, "u_mixer");
-    this.gl.uniform1fv(location, values);
+    this.gl.uniform1fv(this.uniformLocation("u_mixer"), values);
   }
 
   private uniform1i(name: string, value: number): void {
-    this.gl.uniform1i(this.gl.getUniformLocation(this.program, name), value);
+    this.gl.uniform1i(this.uniformLocation(name), value);
   }
 
   private uniform1f(name: string, value: number): void {
-    this.gl.uniform1f(this.gl.getUniformLocation(this.program, name), value);
+    this.gl.uniform1f(this.uniformLocation(name), value);
   }
 
   private uniform2f(name: string, x: number, y: number): void {
-    this.gl.uniform2f(this.gl.getUniformLocation(this.program, name), x, y);
+    this.gl.uniform2f(this.uniformLocation(name), x, y);
   }
 
   private uniform4f(
@@ -472,6 +552,13 @@ export class DevelopRenderer {
     z: number,
     w: number,
   ): void {
-    this.gl.uniform4f(this.gl.getUniformLocation(this.program, name), x, y, z, w);
+    this.gl.uniform4f(this.uniformLocation(name), x, y, z, w);
+  }
+
+  private uniformLocation(name: string): WebGLUniformLocation | null {
+    if (!this.uniformLocations.has(name)) {
+      this.uniformLocations.set(name, this.gl.getUniformLocation(this.program, name));
+    }
+    return this.uniformLocations.get(name) ?? null;
   }
 }

--- a/lib/develop/sidecar.ts
+++ b/lib/develop/sidecar.ts
@@ -1,6 +1,5 @@
 import type { EntryMetadata } from "@/lib/catalog/types";
 import { getDarkroomAPI } from "@/lib/fs/platform";
-import { isDefaultDevelopSettings } from "@/lib/develop/registry";
 import type { DevelopSettings } from "@/lib/develop/types";
 import { parseDevelopXmp, serializeDevelopXmp } from "@/lib/develop/xmp";
 
@@ -32,8 +31,11 @@ export async function writeDevelopSidecar(
   settings: DevelopSettings,
   metadata: Pick<EntryMetadata, "rating" | "colorLabel">,
 ): Promise<void> {
-  const contents = isDefaultDevelopSettings(settings)
-    ? null
-    : serializeDevelopXmp(settings, metadata);
-  await getDarkroomAPI().writeSidecar(rootPath, relativePath, contents);
+  const api = getDarkroomAPI();
+  const existing = await api.readSidecar(rootPath, relativePath);
+  const contents = serializeDevelopXmp(settings, metadata, existing?.contents);
+
+  if (contents && contents !== existing?.contents) {
+    await api.writeSidecar(rootPath, relativePath, contents);
+  }
 }

--- a/lib/develop/sidecar.ts
+++ b/lib/develop/sidecar.ts
@@ -1,0 +1,39 @@
+import type { EntryMetadata } from "@/lib/catalog/types";
+import { getDarkroomAPI } from "@/lib/fs/platform";
+import { isDefaultDevelopSettings } from "@/lib/develop/registry";
+import type { DevelopSettings } from "@/lib/develop/types";
+import { parseDevelopXmp, serializeDevelopXmp } from "@/lib/develop/xmp";
+
+export interface DevelopSidecar {
+  settings: DevelopSettings;
+  lastModified: number;
+  rating?: EntryMetadata["rating"];
+  colorLabel?: EntryMetadata["colorLabel"];
+}
+
+export async function readDevelopSidecar(
+  rootPath: string,
+  relativePath: string,
+): Promise<DevelopSidecar | null> {
+  const sidecar = await getDarkroomAPI().readSidecar(rootPath, relativePath);
+  if (!sidecar) {
+    return null;
+  }
+
+  return {
+    ...parseDevelopXmp(sidecar.contents),
+    lastModified: sidecar.lastModified,
+  };
+}
+
+export async function writeDevelopSidecar(
+  rootPath: string,
+  relativePath: string,
+  settings: DevelopSettings,
+  metadata: Pick<EntryMetadata, "rating" | "colorLabel">,
+): Promise<void> {
+  const contents = isDefaultDevelopSettings(settings)
+    ? null
+    : serializeDevelopXmp(settings, metadata);
+  await getDarkroomAPI().writeSidecar(rootPath, relativePath, contents);
+}

--- a/lib/develop/types.ts
+++ b/lib/develop/types.ts
@@ -63,19 +63,3 @@ export interface DevelopSettings {
 }
 
 export type DevelopPluginId = keyof DevelopSettings;
-
-export type DevelopPluginSettings<T extends DevelopPluginId> =
-  DevelopSettings[T];
-
-export interface XmpPluginAdapter<T extends DevelopPluginId> {
-  write(settings: DevelopSettings[T]): Record<string, string>;
-  read(props: Record<string, string>): Partial<DevelopSettings[T]>;
-}
-
-export interface DevelopPlugin<T extends DevelopPluginId> {
-  id: T;
-  label: string;
-  defaults: DevelopSettings[T];
-  isDefault(settings: DevelopSettings[T]): boolean;
-  xmp: XmpPluginAdapter<T>;
-}

--- a/lib/develop/types.ts
+++ b/lib/develop/types.ts
@@ -1,0 +1,81 @@
+export interface BasicSettings {
+  exposure: number;
+  contrast: number;
+  highlights: number;
+  shadows: number;
+  whites: number;
+  blacks: number;
+  temperature: number;
+  tint: number;
+  vibrance: number;
+  saturation: number;
+}
+
+export interface CropSettings {
+  enabled: boolean;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  angle: number;
+  perspectiveX: number;
+  perspectiveY: number;
+  distortion: number;
+}
+
+export interface CurveSettings {
+  shadows: number;
+  midtones: number;
+  highlights: number;
+}
+
+export type MixerColor =
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "aqua"
+  | "blue"
+  | "purple"
+  | "magenta";
+
+export interface MixerBandSettings {
+  hue: number;
+  saturation: number;
+  luminance: number;
+}
+
+export type MixerSettings = Record<MixerColor, MixerBandSettings>;
+
+export interface EffectsSettings {
+  vignette: number;
+  grain: number;
+  sharpening: number;
+  noiseReduction: number;
+}
+
+export interface DevelopSettings {
+  basic: BasicSettings;
+  crop: CropSettings;
+  curve: CurveSettings;
+  mixer: MixerSettings;
+  effects: EffectsSettings;
+}
+
+export type DevelopPluginId = keyof DevelopSettings;
+
+export type DevelopPluginSettings<T extends DevelopPluginId> =
+  DevelopSettings[T];
+
+export interface XmpPluginAdapter<T extends DevelopPluginId> {
+  write(settings: DevelopSettings[T]): Record<string, string>;
+  read(props: Record<string, string>): Partial<DevelopSettings[T]>;
+}
+
+export interface DevelopPlugin<T extends DevelopPluginId> {
+  id: T;
+  label: string;
+  defaults: DevelopSettings[T];
+  isDefault(settings: DevelopSettings[T]): boolean;
+  xmp: XmpPluginAdapter<T>;
+}

--- a/lib/develop/xmp.ts
+++ b/lib/develop/xmp.ts
@@ -1,0 +1,118 @@
+import type { EntryMetadata } from "@/lib/catalog/types";
+import { COLOR_LABELS } from "@/lib/catalog/types";
+import { DEVELOP_PLUGINS, createDevelopSettings } from "@/lib/develop/registry";
+import type { DevelopSettings } from "@/lib/develop/types";
+
+export interface ParsedDevelopXmp {
+  settings: DevelopSettings;
+  rating?: EntryMetadata["rating"];
+  colorLabel?: EntryMetadata["colorLabel"];
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function collectDevelopProps(settings: DevelopSettings): Record<string, string> {
+  const props: Record<string, string> = {};
+  for (const plugin of DEVELOP_PLUGINS) {
+    Object.assign(props, plugin.xmp.write(settings[plugin.id] as never));
+  }
+  return props;
+}
+
+export function serializeDevelopXmp(
+  settings: DevelopSettings,
+  metadata?: Pick<EntryMetadata, "rating" | "colorLabel">,
+): string {
+  const props: Record<string, string> = {
+    ...collectDevelopProps(settings),
+  };
+
+  if (metadata?.rating) {
+    props["xmp:Rating"] = String(metadata.rating);
+  }
+  if (metadata?.colorLabel) {
+    props["xmp:Label"] = metadata.colorLabel;
+  }
+
+  const attributes = Object.entries(props)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `   ${key}="${escapeXml(value)}"`)
+    .join("\n");
+
+  return `<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description
+   xmlns:crs="http://ns.adobe.com/camera-raw-settings/1.0/"
+   xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+${attributes}
+  />
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>`;
+}
+
+function extractAttributes(xml: string): Record<string, string> {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, "application/xml");
+  if (doc.querySelector("parsererror")) {
+    throw new Error("Could not parse XMP sidecar.");
+  }
+
+  const description = doc.querySelector("Description");
+  if (!description) {
+    return {};
+  }
+
+  return Array.from(description.attributes).reduce<Record<string, string>>(
+    (props, attribute) => {
+      if (attribute.name.startsWith("crs:") || attribute.name.startsWith("xmp:")) {
+        props[attribute.name] = attribute.value;
+      }
+      return props;
+    },
+    {},
+  );
+}
+
+function parseRating(value: string | undefined): EntryMetadata["rating"] | undefined {
+  const rating = Number(value);
+  if (Number.isInteger(rating) && rating >= 0 && rating <= 5) {
+    return rating as EntryMetadata["rating"];
+  }
+  return undefined;
+}
+
+function parseColorLabel(
+  value: string | undefined,
+): EntryMetadata["colorLabel"] | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value.toLowerCase();
+  if (COLOR_LABELS.includes(normalized as Exclude<EntryMetadata["colorLabel"], null>)) {
+    return normalized as EntryMetadata["colorLabel"];
+  }
+  return undefined;
+}
+
+export function parseDevelopXmp(xml: string): ParsedDevelopXmp {
+  const props = extractAttributes(xml);
+  const patch: Partial<DevelopSettings> = {};
+
+  for (const plugin of DEVELOP_PLUGINS) {
+    patch[plugin.id] = plugin.xmp.read(props) as never;
+  }
+
+  return {
+    settings: createDevelopSettings(patch),
+    rating: parseRating(props["xmp:Rating"]),
+    colorLabel: parseColorLabel(props["xmp:Label"]),
+  };
+}

--- a/lib/develop/xmp.ts
+++ b/lib/develop/xmp.ts
@@ -1,7 +1,71 @@
-import type { EntryMetadata } from "@/lib/catalog/types";
-import { COLOR_LABELS } from "@/lib/catalog/types";
-import { DEVELOP_PLUGINS, createDevelopSettings } from "@/lib/develop/registry";
+import { COLOR_LABELS, type EntryMetadata } from "@/lib/catalog/types";
+import {
+  readBasicXmp,
+  writeBasicXmp,
+} from "@/lib/develop/plugins/basic";
+import {
+  readCropXmp,
+  writeCropXmp,
+} from "@/lib/develop/plugins/crop";
+import {
+  readCurveXmp,
+  writeCurveXmp,
+} from "@/lib/develop/plugins/curve";
+import {
+  readEffectsXmp,
+  writeEffectsXmp,
+} from "@/lib/develop/plugins/effects";
+import {
+  readMixerXmp,
+  writeMixerXmp,
+} from "@/lib/develop/plugins/mixer";
+import {
+  createDevelopSettings,
+  isDefaultDevelopSettings,
+} from "@/lib/develop/registry";
 import type { DevelopSettings } from "@/lib/develop/types";
+
+const CRS_NAMESPACE = "http://ns.adobe.com/camera-raw-settings/1.0/";
+const RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+const XMP_NAMESPACE = "http://ns.adobe.com/xap/1.0/";
+
+const DEVELOP_XMP_PROPERTIES = [
+  "crs:ProcessVersion",
+  "crs:Exposure2012",
+  "crs:Contrast2012",
+  "crs:Highlights2012",
+  "crs:Shadows2012",
+  "crs:Whites2012",
+  "crs:Blacks2012",
+  "crs:Temperature",
+  "crs:Tint",
+  "crs:Vibrance",
+  "crs:Saturation",
+  "crs:HasCrop",
+  "crs:CropLeft",
+  "crs:CropTop",
+  "crs:CropRight",
+  "crs:CropBottom",
+  "crs:CropAngle",
+  "crs:PerspectiveHorizontal",
+  "crs:PerspectiveVertical",
+  "crs:LensManualDistortionAmount",
+  "crs:ToneCurvePV2012",
+  "crs:PostCropVignetteAmount",
+  "crs:GrainAmount",
+  "crs:Sharpness",
+  "crs:LuminanceSmoothing",
+  "crs:ColorNoiseReduction",
+  ...["Red", "Orange", "Yellow", "Green", "Aqua", "Blue", "Purple", "Magenta"].flatMap(
+    (color) => [
+      `crs:HueAdjustment${color}`,
+      `crs:SaturationAdjustment${color}`,
+      `crs:LuminanceAdjustment${color}`,
+    ],
+  ),
+  "xmp:Rating",
+  "xmp:Label",
+] as const;
 
 export interface ParsedDevelopXmp {
   settings: DevelopSettings;
@@ -18,28 +82,67 @@ function escapeXml(value: string): string {
 }
 
 function collectDevelopProps(settings: DevelopSettings): Record<string, string> {
-  const props: Record<string, string> = {};
-  for (const plugin of DEVELOP_PLUGINS) {
-    Object.assign(props, plugin.xmp.write(settings[plugin.id] as never));
+  if (isDefaultDevelopSettings(settings)) {
+    return {};
   }
-  return props;
+
+  return {
+    ...writeCropXmp(settings.crop),
+    ...writeBasicXmp(settings.basic),
+    ...writeCurveXmp(settings.curve),
+    ...writeMixerXmp(settings.mixer),
+    ...writeEffectsXmp(settings.effects),
+  };
 }
 
-export function serializeDevelopXmp(
+function collectProps(
   settings: DevelopSettings,
   metadata?: Pick<EntryMetadata, "rating" | "colorLabel">,
-): string {
-  const props: Record<string, string> = {
-    ...collectDevelopProps(settings),
-  };
-
+): Record<string, string> {
+  const props = collectDevelopProps(settings);
   if (metadata?.rating) {
     props["xmp:Rating"] = String(metadata.rating);
   }
   if (metadata?.colorLabel) {
     props["xmp:Label"] = metadata.colorLabel;
   }
+  return props;
+}
 
+function parseXml(xml: string): XMLDocument {
+  const doc = new DOMParser().parseFromString(xml, "application/xml");
+  if (doc.querySelector("parsererror")) {
+    throw new Error("Could not parse XMP sidecar.");
+  }
+  return doc;
+}
+
+function getDescription(doc: XMLDocument): Element | null {
+  return doc.getElementsByTagNameNS(RDF_NAMESPACE, "Description").item(0);
+}
+
+function propertyNamespace(property: string): string {
+  return property.startsWith("xmp:") ? XMP_NAMESPACE : CRS_NAMESPACE;
+}
+
+function propertyLocalName(property: string): string {
+  return property.slice(property.indexOf(":") + 1);
+}
+
+function applyProps(description: Element, props: Record<string, string>): void {
+  for (const property of DEVELOP_XMP_PROPERTIES) {
+    description.removeAttributeNS(
+      propertyNamespace(property),
+      propertyLocalName(property),
+    );
+  }
+
+  for (const [property, value] of Object.entries(props)) {
+    description.setAttributeNS(propertyNamespace(property), property, value);
+  }
+}
+
+function createXmp(props: Record<string, string>): string {
   const attributes = Object.entries(props)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => `   ${key}="${escapeXml(value)}"`)
@@ -58,14 +161,27 @@ ${attributes}
 <?xpacket end="w"?>`;
 }
 
-function extractAttributes(xml: string): Record<string, string> {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(xml, "application/xml");
-  if (doc.querySelector("parsererror")) {
-    throw new Error("Could not parse XMP sidecar.");
+export function serializeDevelopXmp(
+  settings: DevelopSettings,
+  metadata?: Pick<EntryMetadata, "rating" | "colorLabel">,
+  existingXml?: string,
+): string | null {
+  const props = collectProps(settings, metadata);
+  if (!existingXml) {
+    return Object.keys(props).length > 0 ? createXmp(props) : null;
   }
 
-  const description = doc.querySelector("Description");
+  const doc = parseXml(existingXml);
+  const description = getDescription(doc);
+  if (!description) {
+    throw new Error("XMP sidecar does not contain an rdf:Description element.");
+  }
+  applyProps(description, props);
+  return new XMLSerializer().serializeToString(doc);
+}
+
+function extractAttributes(xml: string): Record<string, string> {
+  const description = getDescription(parseXml(xml));
   if (!description) {
     return {};
   }
@@ -104,14 +220,14 @@ function parseColorLabel(
 
 export function parseDevelopXmp(xml: string): ParsedDevelopXmp {
   const props = extractAttributes(xml);
-  const patch: Partial<DevelopSettings> = {};
-
-  for (const plugin of DEVELOP_PLUGINS) {
-    patch[plugin.id] = plugin.xmp.read(props) as never;
-  }
-
   return {
-    settings: createDevelopSettings(patch),
+    settings: createDevelopSettings({
+      crop: readCropXmp(props),
+      basic: readBasicXmp(props),
+      curve: readCurveXmp(props),
+      mixer: readMixerXmp(props),
+      effects: readEffectsXmp(props),
+    }),
     rating: parseRating(props["xmp:Rating"]),
     colorLabel: parseColorLabel(props["xmp:Label"]),
   };

--- a/lib/raw/libraw-client.ts
+++ b/lib/raw/libraw-client.ts
@@ -43,7 +43,7 @@ function buildSettings(
 ): LibRawSettings {
   return {
     halfSize,
-    outputBps: 8,
+    outputBps: options.thumbnail ? 8 : 16,
     useCameraWb: true,
     userQual: options.thumbnail ? 0 : halfSize ? 1 : 2,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.3",
         "libraw-wasm": "^1.4.0",
-        "next": "16.2.9",
+        "next": "16.2.10",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "zustand": "^5.0.14"
@@ -23,7 +23,7 @@
         "@types/react-dom": "^19",
         "concurrently": "^9.2.1",
         "cross-env": "^10.1.0",
-        "electron": "^35.7.5",
+        "electron": "^43.1.0",
         "electron-builder": "^26.0.12",
         "esbuild": "^0.25.9",
         "eslint": "^9",
@@ -287,6 +287,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -391,25 +401,61 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -1641,9 +1687,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1659,9 +1702,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1679,9 +1719,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1697,9 +1734,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1717,9 +1751,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1735,9 +1766,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1755,9 +1783,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1774,9 +1799,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1792,9 +1814,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1818,9 +1837,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1842,9 +1858,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1868,9 +1881,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1892,9 +1902,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1918,9 +1925,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1943,9 +1947,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1967,9 +1968,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2223,9 +2221,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2239,9 +2237,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
@@ -2255,9 +2253,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
@@ -2271,14 +2269,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2290,14 +2285,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2309,14 +2301,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2328,14 +2317,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2347,9 +2333,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
@@ -2363,9 +2349,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
@@ -2673,9 +2659,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2693,9 +2676,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2713,9 +2693,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2733,9 +2710,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2975,17 +2949,6 @@
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3352,9 +3315,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3369,9 +3329,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3386,9 +3343,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3403,9 +3357,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3420,9 +3371,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3437,9 +3385,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3454,9 +3399,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3471,9 +3413,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3488,9 +3427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3505,9 +3441,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4338,16 +4271,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5163,22 +5086,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "35.7.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
-      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.0.tgz",
+      "integrity": "sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -5360,14 +5283,21 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -6249,27 +6179,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6346,16 +6255,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -6514,21 +6413,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -7996,9 +7880,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8020,9 +7901,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8044,9 +7922,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8068,9 +7943,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8405,12 +8277,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -8424,14 +8296,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -8455,34 +8327,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-abi": {
@@ -8939,13 +8783,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9054,10 +8891,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11102,17 +10938,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.3",
     "libraw-wasm": "^1.4.0",
-    "next": "16.2.9",
+    "next": "16.2.10",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "zustand": "^5.0.14"
@@ -29,7 +29,7 @@
     "@types/react-dom": "^19",
     "concurrently": "^9.2.1",
     "cross-env": "^10.1.0",
-    "electron": "^35.7.5",
+    "electron": "^43.1.0",
     "electron-builder": "^26.0.12",
     "esbuild": "^0.25.9",
     "eslint": "^9",
@@ -38,6 +38,9 @@
     "tailwindcss": "^4",
     "typescript": "^5",
     "wait-on": "^8.0.5"
+  },
+  "overrides": {
+    "postcss": "8.5.16"
   },
   "build": {
     "appId": "com.darkroom.app",

--- a/stores/develop-store.ts
+++ b/stores/develop-store.ts
@@ -1,0 +1,77 @@
+import { create } from "zustand";
+import {
+  DEFAULT_DEVELOP_SETTINGS,
+  createDevelopSettings,
+} from "@/lib/develop/registry";
+import type {
+  DevelopPluginId,
+  DevelopSettings,
+} from "@/lib/develop/types";
+
+export type SidecarStatus = "idle" | "loading" | "saving" | "saved" | "error";
+
+interface DevelopStore {
+  activeEntryId: string | null;
+  settings: DevelopSettings;
+  showOriginal: boolean;
+  sidecarStatus: SidecarStatus;
+  sidecarError: string | null;
+  setActiveEntry: (
+    entryId: string,
+    settings?: Partial<DevelopSettings>,
+  ) => void;
+  updatePlugin: <T extends DevelopPluginId>(
+    pluginId: T,
+    patch: Partial<DevelopSettings[T]>,
+  ) => void;
+  resetPlugin: (pluginId: DevelopPluginId) => void;
+  resetAll: () => void;
+  setShowOriginal: (showOriginal: boolean) => void;
+  setSidecarStatus: (status: SidecarStatus, error?: string | null) => void;
+}
+
+export const useDevelopStore = create<DevelopStore>((set) => ({
+  activeEntryId: null,
+  settings: DEFAULT_DEVELOP_SETTINGS,
+  showOriginal: false,
+  sidecarStatus: "idle",
+  sidecarError: null,
+
+  setActiveEntry: (entryId, settings) =>
+    set({
+      activeEntryId: entryId,
+      settings: createDevelopSettings(settings),
+      showOriginal: false,
+      sidecarStatus: "idle",
+      sidecarError: null,
+    }),
+
+  updatePlugin: (pluginId, patch) =>
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        [pluginId]: {
+          ...state.settings[pluginId],
+          ...patch,
+        },
+      },
+    })),
+
+  resetPlugin: (pluginId) =>
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        [pluginId]: structuredClone(DEFAULT_DEVELOP_SETTINGS[pluginId]),
+      },
+    })),
+
+  resetAll: () =>
+    set({
+      settings: structuredClone(DEFAULT_DEVELOP_SETTINGS),
+    }),
+
+  setShowOriginal: (showOriginal) => set({ showOriginal }),
+
+  setSidecarStatus: (sidecarStatus, sidecarError = null) =>
+    set({ sidecarStatus, sidecarError }),
+}));

--- a/stores/develop-store.ts
+++ b/stores/develop-store.ts
@@ -48,13 +48,19 @@ export const useDevelopStore = create<DevelopStore>((set) => ({
 
   updatePlugin: (pluginId, patch) =>
     set((state) => ({
-      settings: {
-        ...state.settings,
-        [pluginId]: {
-          ...state.settings[pluginId],
-          ...patch,
-        },
-      },
+      settings:
+        pluginId === "crop"
+          ? createDevelopSettings({
+              ...state.settings,
+              crop: { ...state.settings.crop, ...patch },
+            })
+          : {
+              ...state.settings,
+              [pluginId]: {
+                ...state.settings[pluginId],
+                ...patch,
+              },
+            },
     })),
 
   resetPlugin: (pluginId) =>

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -30,7 +30,7 @@ export interface DarkroomAPI {
   writeSidecar(
     rootPath: string,
     relativePath: string,
-    contents: string | null,
+    contents: string,
   ): Promise<void>;
   saveExport(suggestedName: string, data: ArrayBuffer): Promise<string | null>;
 }

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -23,6 +23,16 @@ export interface DarkroomAPI {
   writeCatalog(catalog: PhotoCatalog): Promise<void>;
   deleteCatalog(rootPath: string): Promise<void>;
   deleteFiles(absolutePaths: string[]): Promise<void>;
+  readSidecar(
+    rootPath: string,
+    relativePath: string,
+  ): Promise<{ contents: string; lastModified: number } | null>;
+  writeSidecar(
+    rootPath: string,
+    relativePath: string,
+    contents: string | null,
+  ): Promise<void>;
+  saveExport(suggestedName: string, data: ArrayBuffer): Promise<string | null>;
 }
 
 declare global {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds a plugin-structured Develop editing system for crop/transform, basic tone/color, tone curve, color mixer, and effects/details.
- Replaces the static Develop preview with a WebGL2 editing canvas that uses 16-bit RAW decode output where available.
- Persists non-destructive edit settings in the catalog and writes Lightroom-style XMP sidecars beside source files.
- Adds edited JPEG export through Electron's native save dialog.

### Walkthrough
[plugin_raw_editing_fixed_walkthrough.mp4](https://cursor.com/agents/bc-2331680e-f69d-4db7-9d36-3531907a6c0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplugin_raw_editing_fixed_walkthrough.mp4)

### Testing
- `npm run build` passes. Next.js emits existing libraw/webpack circular dependency warnings.
- Scoped ESLint on changed source files passes.
- Full `npm run lint` still fails on documented pre-existing repo lint issues outside this change.
- Manual Electron verification passed on `DISPLAY=:1` with `/workspace/public/demo`: exposure, Reset All, crop overlay/crop adjustment, vignette, and XMP sidecar generation were verified.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2331680e-f69d-4db7-9d36-3531907a6c0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2331680e-f69d-4db7-9d36-3531907a6c0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

