### PR TITLE
Add develop panel sidebar for edit and info panels

### DIFF
--- a/components/develop/CropPanel.tsx
+++ b/components/develop/CropPanel.tsx
@@ -2,11 +2,18 @@
 
 import { useDevelopStore } from "@/stores/develop-store";
 import { SliderRow } from "@/components/develop/SliderRow";
+import { DEFAULT_CROP_SETTINGS } from "@/lib/develop/plugins/crop";
 
 export function CropPanel() {
   const crop = useDevelopStore((state) => state.settings.crop);
   const updatePlugin = useDevelopStore((state) => state.updatePlugin);
   const resetPlugin = useDevelopStore((state) => state.resetPlugin);
+  const updateCrop = (patch: Partial<typeof crop>) => {
+    const next = { ...crop, ...patch };
+    const width = Math.min(next.width, 1 - next.x);
+    const height = Math.min(next.height, 1 - next.y);
+    updatePlugin("crop", { ...patch, width, height });
+  };
 
   return (
     <aside className="flex w-80 shrink-0 flex-col border-l border-lr-border-subtle bg-lr-panel">
@@ -29,19 +36,21 @@ export function CropPanel() {
             type="checkbox"
             checked={crop.enabled}
             onChange={(event) =>
-              updatePlugin("crop", { enabled: event.target.checked })
+              event.target.checked
+                ? updatePlugin("crop", { enabled: true })
+                : updatePlugin("crop", DEFAULT_CROP_SETTINGS)
             }
           />
           Enable crop
         </label>
-        <SliderRow label="Left" value={crop.x} min={0} max={0.95} step={0.01} onChange={(x) => updatePlugin("crop", { x })} />
-        <SliderRow label="Top" value={crop.y} min={0} max={0.95} step={0.01} onChange={(y) => updatePlugin("crop", { y })} />
-        <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} onChange={(width) => updatePlugin("crop", { width })} />
-        <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} onChange={(height) => updatePlugin("crop", { height })} />
-        <SliderRow label="Straighten" value={crop.angle} min={-45} max={45} step={0.1} suffix="deg" onChange={(angle) => updatePlugin("crop", { angle })} />
-        <SliderRow label="Perspective X" value={crop.perspectiveX} min={-100} max={100} onChange={(perspectiveX) => updatePlugin("crop", { perspectiveX })} />
-        <SliderRow label="Perspective Y" value={crop.perspectiveY} min={-100} max={100} onChange={(perspectiveY) => updatePlugin("crop", { perspectiveY })} />
-        <SliderRow label="Distortion" value={crop.distortion} min={-100} max={100} onChange={(distortion) => updatePlugin("crop", { distortion })} />
+        <SliderRow label="Left" value={crop.x} min={0} max={0.95} step={0.01} disabled={!crop.enabled} onChange={(x) => updateCrop({ x })} />
+        <SliderRow label="Top" value={crop.y} min={0} max={0.95} step={0.01} disabled={!crop.enabled} onChange={(y) => updateCrop({ y })} />
+        <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} disabled={!crop.enabled} onChange={(width) => updateCrop({ width })} />
+        <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} disabled={!crop.enabled} onChange={(height) => updateCrop({ height })} />
+        <SliderRow label="Straighten" value={crop.angle} min={-45} max={45} step={0.1} suffix="deg" disabled={!crop.enabled} onChange={(angle) => updatePlugin("crop", { angle })} />
+        <SliderRow label="Perspective X" value={crop.perspectiveX} min={-100} max={100} disabled={!crop.enabled} onChange={(perspectiveX) => updatePlugin("crop", { perspectiveX })} />
+        <SliderRow label="Perspective Y" value={crop.perspectiveY} min={-100} max={100} disabled={!crop.enabled} onChange={(perspectiveY) => updatePlugin("crop", { perspectiveY })} />
+        <SliderRow label="Distortion" value={crop.distortion} min={-100} max={100} disabled={!crop.enabled} onChange={(distortion) => updatePlugin("crop", { distortion })} />
       </div>
     </aside>
   );

--- a/components/develop/CropPanel.tsx
+++ b/components/develop/CropPanel.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useDevelopStore } from "@/stores/develop-store";
+import { SliderRow } from "@/components/develop/SliderRow";
+
+export function CropPanel() {
+  const crop = useDevelopStore((state) => state.settings.crop);
+  const updatePlugin = useDevelopStore((state) => state.updatePlugin);
+  const resetPlugin = useDevelopStore((state) => state.resetPlugin);
+
+  return (
+    <aside className="flex w-80 shrink-0 flex-col border-l border-lr-border-subtle bg-lr-panel">
+      <div className="flex items-center justify-between border-b border-lr-border-subtle px-3 py-2">
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-lr-text-muted">
+          Crop
+        </h2>
+        <button
+          type="button"
+          onClick={() => resetPlugin("crop")}
+          className="rounded border border-lr-border-subtle px-2 py-1 text-[11px] text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-auto px-3 py-3">
+        <label className="mb-3 flex items-center gap-2 text-xs text-lr-text-muted">
+          <input
+            type="checkbox"
+            checked={crop.enabled}
+            onChange={(event) =>
+              updatePlugin("crop", { enabled: event.target.checked })
+            }
+          />
+          Enable crop
+        </label>
+        <SliderRow label="Left" value={crop.x} min={0} max={0.95} step={0.01} onChange={(x) => updatePlugin("crop", { x })} />
+        <SliderRow label="Top" value={crop.y} min={0} max={0.95} step={0.01} onChange={(y) => updatePlugin("crop", { y })} />
+        <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} onChange={(width) => updatePlugin("crop", { width })} />
+        <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} onChange={(height) => updatePlugin("crop", { height })} />
+        <SliderRow label="Straighten" value={crop.angle} min={-45} max={45} step={0.1} suffix="deg" onChange={(angle) => updatePlugin("crop", { angle })} />
+        <SliderRow label="Perspective X" value={crop.perspectiveX} min={-100} max={100} onChange={(perspectiveX) => updatePlugin("crop", { perspectiveX })} />
+        <SliderRow label="Perspective Y" value={crop.perspectiveY} min={-100} max={100} onChange={(perspectiveY) => updatePlugin("crop", { perspectiveY })} />
+        <SliderRow label="Distortion" value={crop.distortion} min={-100} max={100} onChange={(distortion) => updatePlugin("crop", { distortion })} />
+      </div>
+    </aside>
+  );
+}

--- a/components/develop/CropPanel.tsx
+++ b/components/develop/CropPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   ASPECT_RATIO_PRESETS,
   fitCropToAspectRatio,
@@ -20,16 +20,6 @@ export function CropPanel({ imageWidth, imageHeight }: CropPanelProps) {
   const crop = useDevelopStore((state) => state.settings.crop);
   const updatePlugin = useDevelopStore((state) => state.updatePlugin);
   const resetPlugin = useDevelopStore((state) => state.resetPlugin);
-  const [customWidth, setCustomWidth] = useState(String(crop.customAspectWidth));
-  const [customHeight, setCustomHeight] = useState(
-    String(crop.customAspectHeight),
-  );
-
-  useEffect(() => {
-    setCustomWidth(String(crop.customAspectWidth));
-    setCustomHeight(String(crop.customAspectHeight));
-  }, [crop.customAspectWidth, crop.customAspectHeight]);
-
   function selectAspectPreset(presetId: AspectRatioPresetId) {
     const ratio = resolveAspectRatio(
       presetId,
@@ -45,13 +35,9 @@ export function CropPanel({ imageWidth, imageHeight }: CropPanelProps) {
     updatePlugin("crop", patch);
   }
 
-  function commitCustomAspect() {
-    const width = Number(customWidth);
-    const height = Number(customHeight);
-    const ratio = parseAspectRatioInput(customWidth, customHeight);
+  function commitCustomAspect(width: number, height: number) {
+    const ratio = parseAspectRatioInput(String(width), String(height));
     if (!ratio) {
-      setCustomWidth(String(crop.customAspectWidth));
-      setCustomHeight(String(crop.customAspectHeight));
       return;
     }
     const patch = {
@@ -111,43 +97,12 @@ export function CropPanel({ imageWidth, imageHeight }: CropPanelProps) {
         </div>
 
         {crop.aspectPreset === "custom" ? (
-          <div className="mb-3 flex items-center gap-2">
-            <label className="flex flex-1 items-center gap-1 text-xs text-lr-text-muted">
-              <span className="text-lr-text-dim">W</span>
-              <input
-                type="number"
-                min={1}
-                step={1}
-                value={customWidth}
-                onChange={(event) => setCustomWidth(event.target.value)}
-                onBlur={commitCustomAspect}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    commitCustomAspect();
-                  }
-                }}
-                className="w-full rounded border border-lr-border-subtle bg-lr-panel-raised px-2 py-1 font-mono text-[11px] text-lr-text"
-              />
-            </label>
-            <span className="text-xs text-lr-text-dim">:</span>
-            <label className="flex flex-1 items-center gap-1 text-xs text-lr-text-muted">
-              <span className="text-lr-text-dim">H</span>
-              <input
-                type="number"
-                min={1}
-                step={1}
-                value={customHeight}
-                onChange={(event) => setCustomHeight(event.target.value)}
-                onBlur={commitCustomAspect}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    commitCustomAspect();
-                  }
-                }}
-                className="w-full rounded border border-lr-border-subtle bg-lr-panel-raised px-2 py-1 font-mono text-[11px] text-lr-text"
-              />
-            </label>
-          </div>
+          <CustomAspectInputs
+            key={`${crop.customAspectWidth}:${crop.customAspectHeight}`}
+            width={crop.customAspectWidth}
+            height={crop.customAspectHeight}
+            onCommit={commitCustomAspect}
+          />
         ) : null}
 
         <p className="mb-1 mt-2 text-[11px] text-lr-text-dim">
@@ -165,5 +120,69 @@ export function CropPanel({ imageWidth, imageHeight }: CropPanelProps) {
         />
       </div>
     </aside>
+  );
+}
+
+function CustomAspectInputs({
+  width,
+  height,
+  onCommit,
+}: {
+  width: number;
+  height: number;
+  onCommit: (width: number, height: number) => void;
+}) {
+  const [customWidth, setCustomWidth] = useState(String(width));
+  const [customHeight, setCustomHeight] = useState(String(height));
+
+  function commit() {
+    const nextWidth = Number(customWidth);
+    const nextHeight = Number(customHeight);
+    if (!parseAspectRatioInput(customWidth, customHeight)) {
+      setCustomWidth(String(width));
+      setCustomHeight(String(height));
+      return;
+    }
+    onCommit(nextWidth, nextHeight);
+  }
+
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      <AspectInput label="W" value={customWidth} onChange={setCustomWidth} onCommit={commit} />
+      <span className="text-xs text-lr-text-dim">:</span>
+      <AspectInput label="H" value={customHeight} onChange={setCustomHeight} onCommit={commit} />
+    </div>
+  );
+}
+
+function AspectInput({
+  label,
+  value,
+  onChange,
+  onCommit,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  onCommit: () => void;
+}) {
+  return (
+    <label className="flex flex-1 items-center gap-1 text-xs text-lr-text-muted">
+      <span className="text-lr-text-dim">{label}</span>
+      <input
+        type="number"
+        min={1}
+        step={1}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={onCommit}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            onCommit();
+          }
+        }}
+        className="w-full rounded border border-lr-border-subtle bg-lr-panel-raised px-2 py-1 font-mono text-[11px] text-lr-text"
+      />
+    </label>
   );
 }

--- a/components/develop/CropPanel.tsx
+++ b/components/develop/CropPanel.tsx
@@ -1,12 +1,67 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import {
+  ASPECT_RATIO_PRESETS,
+  fitCropToAspectRatio,
+  parseAspectRatioInput,
+  resolveAspectRatio,
+  type AspectRatioPresetId,
+} from "@/lib/develop/crop-geometry";
 import { useDevelopStore } from "@/stores/develop-store";
 import { SliderRow } from "@/components/develop/SliderRow";
 
-export function CropPanel() {
+interface CropPanelProps {
+  imageWidth: number;
+  imageHeight: number;
+}
+
+export function CropPanel({ imageWidth, imageHeight }: CropPanelProps) {
   const crop = useDevelopStore((state) => state.settings.crop);
   const updatePlugin = useDevelopStore((state) => state.updatePlugin);
   const resetPlugin = useDevelopStore((state) => state.resetPlugin);
+  const [customWidth, setCustomWidth] = useState(String(crop.customAspectWidth));
+  const [customHeight, setCustomHeight] = useState(
+    String(crop.customAspectHeight),
+  );
+
+  useEffect(() => {
+    setCustomWidth(String(crop.customAspectWidth));
+    setCustomHeight(String(crop.customAspectHeight));
+  }, [crop.customAspectWidth, crop.customAspectHeight]);
+
+  function selectAspectPreset(presetId: AspectRatioPresetId) {
+    const ratio = resolveAspectRatio(
+      presetId,
+      imageWidth,
+      imageHeight,
+      crop.customAspectWidth,
+      crop.customAspectHeight,
+    );
+    const patch = {
+      aspectPreset: presetId,
+      ...(ratio && crop.enabled ? fitCropToAspectRatio(crop, ratio) : {}),
+    };
+    updatePlugin("crop", patch);
+  }
+
+  function commitCustomAspect() {
+    const width = Number(customWidth);
+    const height = Number(customHeight);
+    const ratio = parseAspectRatioInput(customWidth, customHeight);
+    if (!ratio) {
+      setCustomWidth(String(crop.customAspectWidth));
+      setCustomHeight(String(crop.customAspectHeight));
+      return;
+    }
+    const patch = {
+      aspectPreset: "custom" as const,
+      customAspectWidth: width,
+      customAspectHeight: height,
+      ...(crop.enabled ? fitCropToAspectRatio(crop, ratio) : {}),
+    };
+    updatePlugin("crop", patch);
+  }
 
   return (
     <aside className="flex w-80 shrink-0 flex-col border-l border-lr-border-subtle bg-lr-panel">
@@ -34,14 +89,80 @@ export function CropPanel() {
           />
           Enable crop
         </label>
-        <SliderRow label="Left" value={crop.x} min={0} max={0.95} step={0.01} onChange={(x) => updatePlugin("crop", { x })} />
-        <SliderRow label="Top" value={crop.y} min={0} max={0.95} step={0.01} onChange={(y) => updatePlugin("crop", { y })} />
-        <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} onChange={(width) => updatePlugin("crop", { width })} />
-        <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} onChange={(height) => updatePlugin("crop", { height })} />
-        <SliderRow label="Straighten" value={crop.angle} min={-45} max={45} step={0.1} suffix="deg" onChange={(angle) => updatePlugin("crop", { angle })} />
-        <SliderRow label="Perspective X" value={crop.perspectiveX} min={-100} max={100} onChange={(perspectiveX) => updatePlugin("crop", { perspectiveX })} />
-        <SliderRow label="Perspective Y" value={crop.perspectiveY} min={-100} max={100} onChange={(perspectiveY) => updatePlugin("crop", { perspectiveY })} />
-        <SliderRow label="Distortion" value={crop.distortion} min={-100} max={100} onChange={(distortion) => updatePlugin("crop", { distortion })} />
+
+        <p className="mb-1 text-[11px] uppercase tracking-wider text-lr-text-dim">
+          Aspect ratio
+        </p>
+        <div className="mb-3 grid grid-cols-2 gap-1">
+          {ASPECT_RATIO_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => selectAspectPreset(preset.id)}
+              className={`rounded border px-2 py-1.5 text-left text-[11px] ${
+                crop.aspectPreset === preset.id
+                  ? "border-lr-accent bg-lr-panel-raised text-lr-text"
+                  : "border-lr-border-subtle text-lr-text-muted hover:bg-lr-panel-raised hover:text-lr-text"
+              }`}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+
+        {crop.aspectPreset === "custom" ? (
+          <div className="mb-3 flex items-center gap-2">
+            <label className="flex flex-1 items-center gap-1 text-xs text-lr-text-muted">
+              <span className="text-lr-text-dim">W</span>
+              <input
+                type="number"
+                min={1}
+                step={1}
+                value={customWidth}
+                onChange={(event) => setCustomWidth(event.target.value)}
+                onBlur={commitCustomAspect}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    commitCustomAspect();
+                  }
+                }}
+                className="w-full rounded border border-lr-border-subtle bg-lr-panel-raised px-2 py-1 font-mono text-[11px] text-lr-text"
+              />
+            </label>
+            <span className="text-xs text-lr-text-dim">:</span>
+            <label className="flex flex-1 items-center gap-1 text-xs text-lr-text-muted">
+              <span className="text-lr-text-dim">H</span>
+              <input
+                type="number"
+                min={1}
+                step={1}
+                value={customHeight}
+                onChange={(event) => setCustomHeight(event.target.value)}
+                onBlur={commitCustomAspect}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    commitCustomAspect();
+                  }
+                }}
+                className="w-full rounded border border-lr-border-subtle bg-lr-panel-raised px-2 py-1 font-mono text-[11px] text-lr-text"
+              />
+            </label>
+          </div>
+        ) : null}
+
+        <p className="mb-1 mt-2 text-[11px] text-lr-text-dim">
+          Drag inside the image to move or resize the crop.
+        </p>
+
+        <SliderRow
+          label="Straighten"
+          value={crop.angle}
+          min={-45}
+          max={45}
+          step={0.1}
+          suffix="°"
+          onChange={(angle) => updatePlugin("crop", { angle })}
+        />
       </div>
     </aside>
   );

--- a/components/develop/DevelopCanvas.tsx
+++ b/components/develop/DevelopCanvas.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useRef, useState } from "react";
 import type { DevelopImage } from "@/lib/cache/develop-image-cache";
 import { DevelopRenderer } from "@/lib/develop/renderer";
 import { useDevelopStore } from "@/stores/develop-store";
@@ -18,12 +12,7 @@ interface DevelopCanvasProps {
   alt: string;
 }
 
-export interface DevelopCanvasHandle {
-  exportJpeg(): Promise<Blob>;
-}
-
-export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>(
-  function DevelopCanvas({ image, alt }, ref) {
+export function DevelopCanvas({ image, alt }: DevelopCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const rendererRef = useRef<DevelopRenderer | null>(null);
   const settings = useDevelopStore((state) => state.settings);
@@ -31,16 +20,6 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
   const setShowOriginal = useDevelopStore((state) => state.setShowOriginal);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useImperativeHandle(ref, () => ({
-    async exportJpeg() {
-      const renderer = rendererRef.current;
-      if (!renderer || !ready) {
-        throw new Error("Editor preview is not ready to export.");
-      }
-      return renderer.toBlob();
-    },
-  }), [ready]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -169,4 +148,4 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
       ) : null}
     </div>
   );
-});
+}

--- a/components/develop/DevelopCanvas.tsx
+++ b/components/develop/DevelopCanvas.tsx
@@ -11,6 +11,7 @@ import {
 import type { DevelopImage } from "@/lib/cache/develop-image-cache";
 import { DevelopRenderer } from "@/lib/develop/renderer";
 import { useDevelopStore } from "@/stores/develop-store";
+import { InteractiveCropOverlay } from "@/components/develop/InteractiveCropOverlay";
 
 interface DevelopCanvasProps {
   image: DevelopImage;
@@ -157,7 +158,10 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
           Preparing editor...
         </div>
       ) : null}
-      <CropOverlay />
+      <InteractiveCropOverlay
+        imageWidth={image.width}
+        imageHeight={image.height}
+      />
       {showOriginal ? (
         <div className="absolute left-3 top-3 rounded bg-lr-panel/90 px-2 py-1 text-[11px] uppercase tracking-wider text-lr-text-muted">
           Before
@@ -166,29 +170,3 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
     </div>
   );
 });
-
-function CropOverlay() {
-  const crop = useDevelopStore((state) => state.settings.crop);
-  if (!crop.enabled) {
-    return null;
-  }
-
-  return (
-    <div
-      className="pointer-events-none absolute border border-white/80 shadow-[0_0_0_9999px_rgba(0,0,0,0.32)]"
-      style={{
-        left: `${crop.x * 100}%`,
-        top: `${crop.y * 100}%`,
-        width: `${crop.width * 100}%`,
-        height: `${crop.height * 100}%`,
-        transform: `rotate(${crop.angle}deg)`,
-      }}
-    >
-      <div className="grid h-full w-full grid-cols-3 grid-rows-3">
-        {Array.from({ length: 9 }, (_, index) => (
-          <div key={index} className="border border-white/20" />
-        ))}
-      </div>
-    </div>
-  );
-}

--- a/components/develop/DevelopCanvas.tsx
+++ b/components/develop/DevelopCanvas.tsx
@@ -18,7 +18,7 @@ interface DevelopCanvasProps {
 }
 
 export interface DevelopCanvasHandle {
-  exportJpeg(): Promise<Blob>;
+  exportJpeg(image: DevelopImage): Promise<Blob>;
 }
 
 export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>(
@@ -32,14 +32,14 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
   const [error, setError] = useState<string | null>(null);
 
   useImperativeHandle(ref, () => ({
-    async exportJpeg() {
+    async exportJpeg(exportImage) {
       const renderer = rendererRef.current;
       if (!renderer || !ready) {
         throw new Error("Editor preview is not ready to export.");
       }
-      return renderer.toBlob();
+      return renderer.exportJpeg(exportImage, settings);
     },
-  }), [ready]);
+  }), [ready, settings]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -99,8 +99,8 @@ export const DevelopCanvas = forwardRef<DevelopCanvasHandle, DevelopCanvasProps>
         return;
       }
       currentRenderer.resize(
-        currentContainer.clientWidth,
-        currentContainer.clientHeight,
+        currentContainer.clientWidth * window.devicePixelRatio,
+        currentContainer.clientHeight * window.devicePixelRatio,
       );
       currentRenderer.render(settings, showOriginal);
     }

--- a/components/develop/DevelopPanelRail.tsx
+++ b/components/develop/DevelopPanelRail.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { IconInfo, IconSliders } from "@/components/shell/icons";
+
+export type DevelopPanelId = "edit" | "info";
+
+interface DevelopPanelRailProps {
+  activePanel: DevelopPanelId | null;
+  onSelect: (panel: DevelopPanelId) => void;
+}
+
+const PANELS: Array<{ id: DevelopPanelId; label: string; icon: typeof IconSliders }> = [
+  { id: "edit", label: "Edit", icon: IconSliders },
+  { id: "info", label: "Info", icon: IconInfo },
+];
+
+export function DevelopPanelRail({ activePanel, onSelect }: DevelopPanelRailProps) {
+  return (
+    <nav
+      className="flex w-11 shrink-0 flex-col items-center gap-1 border-l border-lr-border-subtle bg-lr-panel py-2"
+      aria-label="Develop panels"
+    >
+      {PANELS.map(({ id, label, icon: Icon }) => {
+        const isActive = activePanel === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            title={label}
+            aria-label={label}
+            aria-pressed={isActive}
+            onClick={() => onSelect(id)}
+            className={[
+              "flex h-9 w-9 items-center justify-center rounded transition",
+              isActive
+                ? "bg-lr-panel-raised text-lr-text"
+                : "text-lr-text-dim hover:bg-lr-panel-raised hover:text-lr-text-muted",
+            ].join(" ")}
+          >
+            <Icon className="h-4 w-4" />
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/develop/DevelopPanelRail.tsx
+++ b/components/develop/DevelopPanelRail.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { IconInfo, IconSliders } from "@/components/shell/icons";
+import { IconCrop, IconInfo, IconSliders } from "@/components/shell/icons";
 
-export type DevelopPanelId = "edit" | "info";
+export type DevelopPanelId = "crop" | "edit" | "info";
 
 interface DevelopPanelRailProps {
   activePanel: DevelopPanelId | null;
@@ -10,6 +10,7 @@ interface DevelopPanelRailProps {
 }
 
 const PANELS: Array<{ id: DevelopPanelId; label: string; icon: typeof IconSliders }> = [
+  { id: "crop", label: "Crop", icon: IconCrop },
   { id: "edit", label: "Edit", icon: IconSliders },
   { id: "info", label: "Info", icon: IconInfo },
 ];

--- a/components/develop/DevelopSidePanels.tsx
+++ b/components/develop/DevelopSidePanels.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import type { LibraryEntry } from "@/lib/fs/types";
+import type { DevelopImage } from "@/lib/cache/develop-image-cache";
+import { EditPanel } from "@/components/develop/EditPanel";
+import {
+  DevelopPanelRail,
+  type DevelopPanelId,
+} from "@/components/develop/DevelopPanelRail";
+import { MetadataPanel } from "@/components/viewer/MetadataPanel";
+
+interface DevelopSidePanelsProps {
+  decoded: DevelopImage;
+  entry: LibraryEntry;
+}
+
+export function DevelopSidePanels({ decoded, entry }: DevelopSidePanelsProps) {
+  const [activePanel, setActivePanel] = useState<DevelopPanelId | null>("edit");
+
+  function selectPanel(panel: DevelopPanelId) {
+    setActivePanel((current) => (current === panel ? null : panel));
+  }
+
+  return (
+    <>
+      {activePanel === "edit" ? <EditPanel /> : null}
+      {activePanel === "info" ? (
+        <MetadataPanel
+          metadata={decoded.metadata}
+          fileName={entry.name}
+          profileId={entry.profileId}
+        />
+      ) : null}
+      <DevelopPanelRail activePanel={activePanel} onSelect={selectPanel} />
+    </>
+  );
+}

--- a/components/develop/DevelopSidePanels.tsx
+++ b/components/develop/DevelopSidePanels.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
 import type { DevelopImage } from "@/lib/cache/develop-image-cache";
+import { CropPanel } from "@/components/develop/CropPanel";
 import { EditPanel } from "@/components/develop/EditPanel";
 import {
   DevelopPanelRail,
@@ -24,6 +25,7 @@ export function DevelopSidePanels({ decoded, entry }: DevelopSidePanelsProps) {
 
   return (
     <>
+      {activePanel === "crop" ? <CropPanel /> : null}
       {activePanel === "edit" ? <EditPanel /> : null}
       {activePanel === "info" ? (
         <MetadataPanel

--- a/components/develop/DevelopSidePanels.tsx
+++ b/components/develop/DevelopSidePanels.tsx
@@ -25,7 +25,12 @@ export function DevelopSidePanels({ decoded, entry }: DevelopSidePanelsProps) {
 
   return (
     <>
-      {activePanel === "crop" ? <CropPanel /> : null}
+      {activePanel === "crop" ? (
+        <CropPanel
+          imageWidth={decoded.width}
+          imageHeight={decoded.height}
+        />
+      ) : null}
       {activePanel === "edit" ? <EditPanel /> : null}
       {activePanel === "info" ? (
         <MetadataPanel

--- a/components/develop/EditPanel.tsx
+++ b/components/develop/EditPanel.tsx
@@ -6,6 +6,8 @@ import type { DevelopPluginId, MixerColor } from "@/lib/develop/types";
 import { useDevelopStore } from "@/stores/develop-store";
 import { SliderRow } from "@/components/develop/SliderRow";
 
+const EDIT_PLUGINS = DEVELOP_PLUGINS.filter((plugin) => plugin.id !== "crop");
+
 const MIXER_LABELS: Record<MixerColor, string> = {
   red: "Red",
   orange: "Orange",
@@ -44,7 +46,7 @@ export function EditPanel() {
       </div>
 
       <div className="flex-1 overflow-auto">
-        {DEVELOP_PLUGINS.map((plugin) => (
+        {EDIT_PLUGINS.map((plugin) => (
           <PluginSection key={plugin.id} id={plugin.id} label={plugin.label} />
         ))}
       </div>
@@ -67,7 +69,6 @@ function PluginSection({
         {label}
       </summary>
       <div className="px-3 pb-3">
-        {id === "crop" ? <CropControls /> : null}
         {id === "basic" ? <BasicControls /> : null}
         {id === "curve" ? <CurveControls /> : null}
         {id === "mixer" ? <MixerControls /> : null}
@@ -81,34 +82,6 @@ function PluginSection({
         </button>
       </div>
     </details>
-  );
-}
-
-function CropControls() {
-  const crop = useDevelopStore((state) => state.settings.crop);
-  const updatePlugin = useDevelopStore((state) => state.updatePlugin);
-
-  return (
-    <div>
-      <label className="mb-2 flex items-center gap-2 text-xs text-lr-text-muted">
-        <input
-          type="checkbox"
-          checked={crop.enabled}
-          onChange={(event) =>
-            updatePlugin("crop", { enabled: event.target.checked })
-          }
-        />
-        Enable crop
-      </label>
-      <SliderRow label="Left" value={crop.x} min={0} max={0.95} step={0.01} onChange={(x) => updatePlugin("crop", { x })} />
-      <SliderRow label="Top" value={crop.y} min={0} max={0.95} step={0.01} onChange={(y) => updatePlugin("crop", { y })} />
-      <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} onChange={(width) => updatePlugin("crop", { width })} />
-      <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} onChange={(height) => updatePlugin("crop", { height })} />
-      <SliderRow label="Straighten" value={crop.angle} min={-45} max={45} step={0.1} suffix="deg" onChange={(angle) => updatePlugin("crop", { angle })} />
-      <SliderRow label="Perspective X" value={crop.perspectiveX} min={-100} max={100} onChange={(perspectiveX) => updatePlugin("crop", { perspectiveX })} />
-      <SliderRow label="Perspective Y" value={crop.perspectiveY} min={-100} max={100} onChange={(perspectiveY) => updatePlugin("crop", { perspectiveY })} />
-      <SliderRow label="Distortion" value={crop.distortion} min={-100} max={100} onChange={(distortion) => updatePlugin("crop", { distortion })} />
-    </div>
   );
 }
 

--- a/components/develop/InteractiveCropOverlay.tsx
+++ b/components/develop/InteractiveCropOverlay.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyCropDrag,
+  computeContainedImageRect,
+  type CropHandle,
+  resolveAspectRatio,
+} from "@/lib/develop/crop-geometry";
+import { useDevelopStore } from "@/stores/develop-store";
+
+interface InteractiveCropOverlayProps {
+  imageWidth: number;
+  imageHeight: number;
+}
+
+const HANDLE_CURSORS: Record<CropHandle, string> = {
+  move: "move",
+  n: "ns-resize",
+  s: "ns-resize",
+  e: "ew-resize",
+  w: "ew-resize",
+  ne: "nesw-resize",
+  nw: "nwse-resize",
+  se: "nwse-resize",
+  sw: "nesw-resize",
+};
+
+const HANDLE_POSITIONS: Array<{
+  handle: CropHandle;
+  className: string;
+}> = [
+  { handle: "nw", className: "left-0 top-0 -translate-x-1/2 -translate-y-1/2" },
+  { handle: "n", className: "left-1/2 top-0 -translate-x-1/2 -translate-y-1/2" },
+  { handle: "ne", className: "right-0 top-0 translate-x-1/2 -translate-y-1/2" },
+  { handle: "e", className: "right-0 top-1/2 translate-x-1/2 -translate-y-1/2" },
+  { handle: "se", className: "right-0 bottom-0 translate-x-1/2 translate-y-1/2" },
+  { handle: "s", className: "left-1/2 bottom-0 -translate-x-1/2 translate-y-1/2" },
+  { handle: "sw", className: "left-0 bottom-0 -translate-x-1/2 translate-y-1/2" },
+  { handle: "w", className: "left-0 top-1/2 -translate-x-1/2 -translate-y-1/2" },
+];
+
+export function InteractiveCropOverlay({
+  imageWidth,
+  imageHeight,
+}: InteractiveCropOverlayProps) {
+  const crop = useDevelopStore((state) => state.settings.crop);
+  const updatePlugin = useDevelopStore((state) => state.updatePlugin);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [imageRect, setImageRect] = useState({
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+  });
+  const dragRef = useRef<{
+    handle: CropHandle;
+    startX: number;
+    startY: number;
+    startCrop: { x: number; y: number; width: number; height: number };
+  } | null>(null);
+
+  const measureImageRect = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    setImageRect(
+      computeContainedImageRect(
+        container.clientWidth,
+        container.clientHeight,
+        imageWidth,
+        imageHeight,
+      ),
+    );
+  }, [imageWidth, imageHeight]);
+
+  useEffect(() => {
+    measureImageRect();
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const observer = new ResizeObserver(measureImageRect);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [measureImageRect]);
+
+  const aspectRatio = resolveAspectRatio(
+    crop.aspectPreset,
+    imageWidth,
+    imageHeight,
+    crop.customAspectWidth,
+    crop.customAspectHeight,
+  );
+
+  function onPointerDown(handle: CropHandle, event: React.PointerEvent) {
+    if (!crop.enabled) {
+      updatePlugin("crop", { enabled: true });
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    dragRef.current = {
+      handle,
+      startX: event.clientX,
+      startY: event.clientY,
+      startCrop: {
+        x: crop.x,
+        y: crop.y,
+        width: crop.width,
+        height: crop.height,
+      },
+    };
+  }
+
+  function onPointerMove(event: React.PointerEvent) {
+    const drag = dragRef.current;
+    if (!drag || imageRect.width <= 0 || imageRect.height <= 0) {
+      return;
+    }
+
+    const deltaX = (event.clientX - drag.startX) / imageRect.width;
+    const deltaY = (event.clientY - drag.startY) / imageRect.height;
+    const next = applyCropDrag(
+      drag.startCrop,
+      drag.handle,
+      deltaX,
+      deltaY,
+      aspectRatio,
+    );
+    updatePlugin("crop", next);
+  }
+
+  function onPointerUp(event: React.PointerEvent) {
+    if (dragRef.current) {
+      (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
+      dragRef.current = null;
+    }
+  }
+
+  function enableCropOnImageClick(event: React.PointerEvent) {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const bounds = container.getBoundingClientRect();
+    const rect = computeContainedImageRect(
+      container.clientWidth,
+      container.clientHeight,
+      imageWidth,
+      imageHeight,
+    );
+    const localX = event.clientX - bounds.left - rect.x;
+    const localY = event.clientY - bounds.top - rect.y;
+    if (
+      localX < 0 ||
+      localY < 0 ||
+      localX > rect.width ||
+      localY > rect.height
+    ) {
+      return;
+    }
+    updatePlugin("crop", { enabled: true });
+  }
+
+  if (!crop.enabled) {
+    return (
+      <div
+        ref={containerRef}
+        className="absolute inset-0 cursor-crosshair"
+        onPointerDown={enableCropOnImageClick}
+      />
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="absolute inset-0">
+      <div
+        className="absolute overflow-hidden"
+        style={{
+          left: imageRect.x,
+          top: imageRect.y,
+          width: imageRect.width,
+          height: imageRect.height,
+        }}
+      >
+        <div
+          className="absolute cursor-move border border-white/80 shadow-[0_0_0_9999px_rgba(0,0,0,0.32)]"
+          style={{
+            left: `${crop.x * 100}%`,
+            top: `${crop.y * 100}%`,
+            width: `${crop.width * 100}%`,
+            height: `${crop.height * 100}%`,
+            transform: `rotate(${crop.angle}deg)`,
+            transformOrigin: "center center",
+          }}
+          onPointerDown={(event) => onPointerDown("move", event)}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+        >
+          <div className="pointer-events-none grid h-full w-full grid-cols-3 grid-rows-3">
+            {Array.from({ length: 9 }, (_, index) => (
+              <div key={index} className="border border-white/20" />
+            ))}
+          </div>
+
+          {HANDLE_POSITIONS.map(({ handle, className }) => (
+            <div
+              key={handle}
+              className={`absolute z-10 h-3 w-3 rounded-full border border-white/90 bg-lr-accent ${className}`}
+              style={{ cursor: HANDLE_CURSORS[handle] }}
+              onPointerDown={(event) => onPointerDown(handle, event)}
+              onPointerMove={onPointerMove}
+              onPointerUp={onPointerUp}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/develop/SliderRow.tsx
+++ b/components/develop/SliderRow.tsx
@@ -7,6 +7,7 @@ interface SliderRowProps {
   max: number;
   step?: number;
   suffix?: string;
+  disabled?: boolean;
   onChange: (value: number) => void;
   onReset?: () => void;
 }
@@ -18,6 +19,7 @@ export function SliderRow({
   max,
   step = 1,
   suffix = "",
+  disabled = false,
   onChange,
   onReset,
 }: SliderRowProps) {
@@ -33,6 +35,7 @@ export function SliderRow({
         max={max}
         step={step}
         value={value}
+        disabled={disabled}
         onChange={(event) => onChange(Number(event.target.value))}
         className="accent-lr-accent"
       />

--- a/components/develop/useDevelopSettingsSync.ts
+++ b/components/develop/useDevelopSettingsSync.ts
@@ -3,10 +3,8 @@
 import { useEffect, useRef } from "react";
 import type { EntryMetadata } from "@/lib/catalog/types";
 import type { LibraryEntry } from "@/lib/fs/types";
-import {
-  createDevelopSettings,
-  developSettingsHash,
-} from "@/lib/develop/registry";
+import { createDevelopSettings, developSettingsHash } from "@/lib/develop/registry";
+import type { DevelopSettings } from "@/lib/develop/types";
 import { readDevelopSidecar, writeDevelopSidecar } from "@/lib/develop/sidecar";
 import { useDevelopStore } from "@/stores/develop-store";
 
@@ -19,6 +17,17 @@ interface UseDevelopSettingsSyncOptions {
   applyMetadata: (patch: Partial<EntryMetadata>) => void;
 }
 
+function snapshot(
+  settings: DevelopSettings,
+  metadata: Pick<EntryMetadata, "rating" | "colorLabel">,
+): string {
+  return JSON.stringify({
+    settings,
+    rating: metadata.rating,
+    colorLabel: metadata.colorLabel,
+  });
+}
+
 export function useDevelopSettingsSync({
   entry,
   rootPath,
@@ -29,9 +38,16 @@ export function useDevelopSettingsSync({
   const activeEntryId = useDevelopStore((state) => state.activeEntryId);
   const setActiveEntry = useDevelopStore((state) => state.setActiveEntry);
   const setSidecarStatus = useDevelopStore((state) => state.setSidecarStatus);
-  const hydratedEntryId = useRef<string | null>(null);
-  const skipNextPersist = useRef(false);
+  const sidecarStatus = useDevelopStore((state) => state.sidecarStatus);
   const metadataRef = useRef(metadata);
+  const persistedSnapshotRef = useRef<string | null>(null);
+  const sidecarContentsRef = useRef<{ entryId: string; contents: string | null }>({
+    entryId: "",
+    contents: null,
+  });
+  const pendingWriteRef = useRef<Promise<void>>(Promise.resolve());
+  const hydratedEntryIdRef = useRef<string | null>(null);
+  const canWriteSidecarRef = useRef(true);
 
   useEffect(() => {
     metadataRef.current = metadata;
@@ -39,73 +55,80 @@ export function useDevelopSettingsSync({
 
   useEffect(() => {
     let active = true;
-    skipNextPersist.current = true;
-    hydratedEntryId.current = null;
+    hydratedEntryIdRef.current = null;
     setActiveEntry(entry.id, metadataRef.current.develop);
-    const hydrationStartHash = developSettingsHash(
-      useDevelopStore.getState().settings,
-    );
+    setSidecarStatus("loading");
+    const initialSettings = useDevelopStore.getState().settings;
+    const initialSnapshot = snapshot(initialSettings, metadataRef.current);
+    sidecarContentsRef.current = { entryId: entry.id, contents: null };
+    canWriteSidecarRef.current = true;
 
-    async function hydrateFromSidecar() {
-      if (!rootPath) {
-        if (
-          developSettingsHash(useDevelopStore.getState().settings) !==
-          hydrationStartHash
-        ) {
-          skipNextPersist.current = false;
-        }
-        hydratedEntryId.current = entry.id;
-        return;
-      }
+    async function hydrate(): Promise<void> {
+      let sidecarContents: string | null = null;
+      let persisted = initialSnapshot;
 
-      setSidecarStatus("loading");
       try {
-        const sidecar = await readDevelopSidecar(rootPath, entry.relativePath);
-        if (!active) {
-          return;
+        if (rootPath) {
+          const sidecar = await readDevelopSidecar(rootPath, entry.relativePath);
+          if (!active) {
+            return;
+          }
+          sidecarContents = sidecar?.contents ?? null;
+
+          const hasLocalChanges =
+            developSettingsHash(useDevelopStore.getState().settings) !==
+            developSettingsHash(initialSettings);
+          if (
+            sidecar &&
+            !hasLocalChanges &&
+            sidecar.lastModified > metadataRef.current.updatedAt
+          ) {
+            const nextMetadata: Partial<EntryMetadata> = {
+              develop: sidecar.settings,
+              ...(sidecar.rating === undefined ? {} : { rating: sidecar.rating }),
+              ...(sidecar.colorLabel === undefined
+                ? {}
+                : { colorLabel: sidecar.colorLabel }),
+            };
+            setActiveEntry(entry.id, sidecar.settings);
+            applyMetadata(nextMetadata);
+            persisted = snapshot(sidecar.settings, {
+              rating: sidecar.rating ?? metadataRef.current.rating,
+              colorLabel: sidecar.colorLabel ?? metadataRef.current.colorLabel,
+            });
+          } else {
+            const currentSnapshot = snapshot(
+              useDevelopStore.getState().settings,
+              metadataRef.current,
+            );
+            persisted = currentSnapshot === initialSnapshot
+              ? currentSnapshot
+              : initialSnapshot;
+          }
         }
 
-        const hasLocalEdits =
-          developSettingsHash(useDevelopStore.getState().settings) !==
-          hydrationStartHash;
-        if (
-          sidecar &&
-          !hasLocalEdits &&
-          sidecar.lastModified > metadataRef.current.updatedAt
-        ) {
-          const nextMetadata: Partial<EntryMetadata> = {
-            develop: sidecar.settings,
-          };
-          if (sidecar.rating !== undefined) {
-            nextMetadata.rating = sidecar.rating;
-          }
-          if (sidecar.colorLabel !== undefined) {
-            nextMetadata.colorLabel = sidecar.colorLabel;
-          }
-          skipNextPersist.current = true;
-          setActiveEntry(entry.id, sidecar.settings);
-          applyMetadata(nextMetadata);
-        } else if (hasLocalEdits) {
-          skipNextPersist.current = false;
+        if (active) {
+          sidecarContentsRef.current = { entryId: entry.id, contents: sidecarContents };
+          persistedSnapshotRef.current = persisted;
+          setSidecarStatus("saved");
         }
-
-        setSidecarStatus("saved");
       } catch (error) {
         if (active) {
+          canWriteSidecarRef.current = false;
           setSidecarStatus(
             "error",
             error instanceof Error ? error.message : "Could not read XMP sidecar.",
           );
+          persistedSnapshotRef.current = null;
         }
       } finally {
         if (active) {
-          hydratedEntryId.current = entry.id;
+          hydratedEntryIdRef.current = entry.id;
         }
       }
     }
 
-    void hydrateFromSidecar();
-
+    void hydrate();
     return () => {
       active = false;
     };
@@ -119,50 +142,79 @@ export function useDevelopSettingsSync({
   ]);
 
   useEffect(() => {
-    if (activeEntryId !== entry.id || hydratedEntryId.current !== entry.id) {
+    if (
+      activeEntryId !== entry.id ||
+      hydratedEntryIdRef.current !== entry.id
+    ) {
       return;
     }
 
-    if (skipNextPersist.current) {
-      skipNextPersist.current = false;
+    const nextSnapshot = snapshot(settings, metadata);
+    if (nextSnapshot === persistedSnapshotRef.current) {
+      return;
+    }
+    if (rootPath && !canWriteSidecarRef.current) {
       return;
     }
 
+    let cancelled = false;
     const timer = window.setTimeout(() => {
       const develop = createDevelopSettings(settings);
       applyMetadata({ develop });
 
       if (!rootPath) {
+        persistedSnapshotRef.current = nextSnapshot;
         return;
       }
 
       setSidecarStatus("saving");
-      void writeDevelopSidecar(
-        rootPath,
-        entry.relativePath,
-        develop,
-        metadataRef.current,
-      )
-        .then(() => setSidecarStatus("saved"))
-        .catch((error) => {
+      const write = async (): Promise<void> => {
+        if (cancelled) {
+          return;
+        }
+        const sidecar = sidecarContentsRef.current;
+        const contents = await writeDevelopSidecar(
+          rootPath,
+          entry.relativePath,
+          develop,
+          metadata,
+          sidecar.entryId === entry.id ? sidecar.contents : null,
+        );
+        sidecarContentsRef.current = { entryId: entry.id, contents };
+        if (
+          useDevelopStore.getState().activeEntryId === entry.id &&
+          snapshot(useDevelopStore.getState().settings, metadataRef.current) ===
+            nextSnapshot
+        ) {
+          persistedSnapshotRef.current = nextSnapshot;
+          setSidecarStatus("saved");
+        }
+      };
+
+      const queued = pendingWriteRef.current.then(write, write);
+      pendingWriteRef.current = queued.catch(() => undefined);
+      void queued.catch((error) => {
+        if (!cancelled) {
           setSidecarStatus(
             "error",
-            error instanceof Error
-              ? error.message
-              : "Could not write XMP sidecar.",
+            error instanceof Error ? error.message : "Could not write XMP sidecar.",
           );
-        });
+        }
+      });
     }, PERSIST_DEBOUNCE_MS);
 
-    return () => window.clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
   }, [
     activeEntryId,
     entry.id,
     entry.relativePath,
+    metadata,
     rootPath,
+    sidecarStatus,
     settings,
-    metadata.rating,
-    metadata.colorLabel,
     applyMetadata,
     setSidecarStatus,
   ]);

--- a/components/develop/useDevelopSettingsSync.ts
+++ b/components/develop/useDevelopSettingsSync.ts
@@ -32,6 +32,9 @@ export function useDevelopSettingsSync({
   const hydratedEntryId = useRef<string | null>(null);
   const skipNextPersist = useRef(false);
   const metadataRef = useRef(metadata);
+  const sidecarSourceRef = useRef<string | null>(null);
+  const sidecarWritableRef = useRef(true);
+  const sidecarWritesRef = useRef(Promise.resolve());
 
   useEffect(() => {
     metadataRef.current = metadata;
@@ -41,6 +44,8 @@ export function useDevelopSettingsSync({
     let active = true;
     skipNextPersist.current = true;
     hydratedEntryId.current = null;
+    sidecarSourceRef.current = null;
+    sidecarWritableRef.current = true;
     setActiveEntry(entry.id, metadataRef.current.develop);
     const hydrationStartHash = developSettingsHash(
       useDevelopStore.getState().settings,
@@ -64,6 +69,7 @@ export function useDevelopSettingsSync({
         if (!active) {
           return;
         }
+        sidecarSourceRef.current = sidecar?.source ?? null;
 
         const hasLocalEdits =
           developSettingsHash(useDevelopStore.getState().settings) !==
@@ -92,6 +98,7 @@ export function useDevelopSettingsSync({
         setSidecarStatus("saved");
       } catch (error) {
         if (active) {
+          sidecarWritableRef.current = false;
           setSidecarStatus(
             "error",
             error instanceof Error ? error.message : "Could not read XMP sidecar.",
@@ -128,22 +135,33 @@ export function useDevelopSettingsSync({
       return;
     }
 
-    const timer = window.setTimeout(() => {
-      const develop = createDevelopSettings(settings);
-      applyMetadata({ develop });
+    const develop = createDevelopSettings(settings);
+    applyMetadata({ develop });
 
-      if (!rootPath) {
+    const timer = window.setTimeout(() => {
+      if (!rootPath || !sidecarWritableRef.current) {
         return;
       }
 
       setSidecarStatus("saving");
-      void writeDevelopSidecar(
-        rootPath,
-        entry.relativePath,
-        develop,
-        metadataRef.current,
-      )
-        .then(() => setSidecarStatus("saved"))
+      const write = () =>
+        writeDevelopSidecar(
+          rootPath,
+          entry.relativePath,
+          develop,
+          metadataRef.current,
+          sidecarSourceRef.current,
+        );
+      const queuedWrite = sidecarWritesRef.current.then(write, write);
+      sidecarWritesRef.current = queuedWrite.then(
+        () => undefined,
+        () => undefined,
+      );
+      void queuedWrite
+        .then((contents) => {
+          sidecarSourceRef.current = contents;
+          setSidecarStatus("saved");
+        })
         .catch((error) => {
           setSidecarStatus(
             "error",

--- a/components/shell/icons.tsx
+++ b/components/shell/icons.tsx
@@ -85,6 +85,17 @@ export function IconArchive({ className }: { className?: string }) {
   );
 }
 
+export function IconCrop({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path
+        fillRule="evenodd"
+        d="M1.5 1a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 1 0V2.707l7.146 7.147a.5.5 0 0 0 .708-.708L2.707 2H4.5a.5.5 0 0 0 0-1h-3zm11 0a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 1 0V2.707l-7.146 7.147a.5.5 0 0 0 .708.708L13.293 2H11.5a.5.5 0 0 0 0-1h3zm-11 11a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 0-1H2.707l7.147-7.146a.5.5 0 0 0-.708-.708L2 13.293V11.5a.5.5 0 0 0-1 0v3zm11-.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1 0-1h1.793l-7.147-7.146a.5.5 0 0 1 .708-.708L14 13.293V11.5a.5.5 0 0 1-.5-.5z"
+      />
+    </svg>
+  );
+}
+
 export function IconSliders({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>

--- a/components/shell/icons.tsx
+++ b/components/shell/icons.tsx
@@ -85,6 +85,17 @@ export function IconArchive({ className }: { className?: string }) {
   );
 }
 
+export function IconSliders({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path
+        fillRule="evenodd"
+        d="M11.5 2a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM9.05 3a2.5 2.5 0 1 1 4.9 0H14.5a.5.5 0 0 1 0 1h-.55a2.5 2.5 0 1 1-4.9 0H1.5a.5.5 0 0 1 0-1h7.55zM2.5 7a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM1.05 8a2.5 2.5 0 1 1 4.9 0H14.5a.5.5 0 0 1 0 1H5.95a2.5 2.5 0 1 1-4.9 0H1.5a.5.5 0 0 1 0-1h-.45zM11.5 12a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zM9.05 13a2.5 2.5 0 1 1 4.9 0H14.5a.5.5 0 0 1 0 1h-.55a2.5 2.5 0 1 1-4.9 0H1.5a.5.5 0 0 1 0-1h7.55z"
+      />
+    </svg>
+  );
+}
+
 export function IconInfo({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden>

--- a/components/viewer/PhotoViewer.tsx
+++ b/components/viewer/PhotoViewer.tsx
@@ -6,6 +6,7 @@ import type { LibraryEntry } from "@/lib/fs/types";
 import { getDarkroomAPI } from "@/lib/fs/platform";
 import type { DevelopImage } from "@/lib/cache/develop-image-cache";
 import {
+  loadDevelopExportImage,
   loadDevelopImage,
   preloadDevelopImages,
 } from "@/lib/cache/develop-image-cache";
@@ -23,6 +24,7 @@ import { DevelopSidePanels } from "@/components/develop/DevelopSidePanels";
 import { useDevelopSettingsSync } from "@/components/develop/useDevelopSettingsSync";
 import { Filmstrip } from "./Filmstrip";
 import { useEntryMetadataShortcuts } from "@/hooks/useEntryMetadataShortcuts";
+import { isEditableTarget } from "@/hooks/is-editable-target";
 
 interface PhotoViewerProps {
   entry: LibraryEntry;
@@ -104,9 +106,11 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
   useEntryMetadataShortcuts([entry.id]);
 
   async function exportEditedJpeg() {
+    let exportImage: DevelopImage | null = null;
     try {
       setExportStatus("Exporting...");
-      const blob = await canvasRef.current?.exportJpeg();
+      exportImage = await loadDevelopExportImage(entry);
+      const blob = await canvasRef.current?.exportJpeg(exportImage);
       if (!blob) {
         throw new Error("Editor preview is not ready.");
       }
@@ -119,11 +123,18 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
       setExportStatus(
         exportError instanceof Error ? exportError.message : "Export failed.",
       );
+    } finally {
+      if (exportImage) {
+        URL.revokeObjectURL(exportImage.objectUrl);
+      }
     }
   }
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
       if (event.key === "ArrowLeft" && activeIndex > 0) {
         router.push(`/photo?id=${encodeURIComponent(entries[activeIndex - 1].id)}`);
       }

--- a/components/viewer/PhotoViewer.tsx
+++ b/components/viewer/PhotoViewer.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
 import { getDarkroomAPI } from "@/lib/fs/platform";
 import type { DevelopImage } from "@/lib/cache/develop-image-cache";
 import {
+  disposeDevelopImage,
+  loadDevelopExportImage,
   loadDevelopImage,
   preloadDevelopImages,
 } from "@/lib/cache/develop-image-cache";
@@ -15,12 +17,11 @@ import {
   useEntryMetadataForId,
 } from "@/components/library/EntryMetadataBar";
 import { useLibraryStore } from "@/stores/library-store";
-import {
-  DevelopCanvas,
-  type DevelopCanvasHandle,
-} from "@/components/develop/DevelopCanvas";
+import { DevelopCanvas } from "@/components/develop/DevelopCanvas";
 import { DevelopSidePanels } from "@/components/develop/DevelopSidePanels";
 import { useDevelopSettingsSync } from "@/components/develop/useDevelopSettingsSync";
+import { exportDevelopJpeg } from "@/lib/develop/renderer";
+import { useDevelopStore } from "@/stores/develop-store";
 import { Filmstrip } from "./Filmstrip";
 import { useEntryMetadataShortcuts } from "@/hooks/useEntryMetadataShortcuts";
 
@@ -57,7 +58,7 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
     metadata,
     applyMetadata: applyDevelopMetadata,
   });
-  const canvasRef = useRef<DevelopCanvasHandle>(null);
+  const developSettings = useDevelopStore((state) => state.settings);
   const [exportStatus, setExportStatus] = useState<string | null>(null);
 
   useEffect(() => {
@@ -104,12 +105,11 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
   useEntryMetadataShortcuts([entry.id]);
 
   async function exportEditedJpeg() {
+    let exportImage: DevelopImage | null = null;
     try {
       setExportStatus("Exporting...");
-      const blob = await canvasRef.current?.exportJpeg();
-      if (!blob) {
-        throw new Error("Editor preview is not ready.");
-      }
+      exportImage = await loadDevelopExportImage(entry);
+      const blob = await exportDevelopJpeg(exportImage, developSettings);
       const targetPath = await getDarkroomAPI().saveExport(
         entry.name.replace(/\.[^.]+$/, "-darkroom.jpg"),
         await blob.arrayBuffer(),
@@ -119,6 +119,10 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
       setExportStatus(
         exportError instanceof Error ? exportError.message : "Export failed.",
       );
+    } finally {
+      if (exportImage) {
+        disposeDevelopImage(exportImage);
+      }
     }
   }
 
@@ -200,7 +204,7 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
 
           {decoded ? (
             <div className="relative flex-1">
-              <DevelopCanvas ref={canvasRef} image={decoded} alt={entry.name} />
+              <DevelopCanvas image={decoded} alt={entry.name} />
             </div>
           ) : null}
         </div>

--- a/components/viewer/PhotoViewer.tsx
+++ b/components/viewer/PhotoViewer.tsx
@@ -19,10 +19,9 @@ import {
   DevelopCanvas,
   type DevelopCanvasHandle,
 } from "@/components/develop/DevelopCanvas";
-import { EditPanel } from "@/components/develop/EditPanel";
+import { DevelopSidePanels } from "@/components/develop/DevelopSidePanels";
 import { useDevelopSettingsSync } from "@/components/develop/useDevelopSettingsSync";
 import { Filmstrip } from "./Filmstrip";
-import { MetadataPanel } from "./MetadataPanel";
 import { useEntryMetadataShortcuts } from "@/hooks/useEntryMetadataShortcuts";
 
 interface PhotoViewerProps {
@@ -41,7 +40,6 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
   const [decoded, setDecoded] = useState<DevelopImage | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [showMetadata, setShowMetadata] = useState(true);
   const activeIndex = useMemo(
     () => entries.findIndex((item) => item.id === entry.id),
     [entries, entry.id],
@@ -185,13 +183,6 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
               >
                 Export JPEG
               </button>
-              <button
-                type="button"
-                onClick={() => setShowMetadata((value) => !value)}
-                className="rounded border border-lr-border-subtle bg-lr-panel/90 px-2.5 py-1 text-[11px] text-lr-text-muted backdrop-blur hover:text-lr-text"
-              >
-                {showMetadata ? "Hide Info" : "Show Info"}
-              </button>
             </div>
           </div>
 
@@ -214,15 +205,7 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
           ) : null}
         </div>
 
-        {decoded ? <EditPanel /> : null}
-
-        {showMetadata && decoded ? (
-          <MetadataPanel
-            metadata={decoded.metadata}
-            fileName={entry.name}
-            profileId={entry.profileId}
-          />
-        ) : null}
+        {decoded ? <DevelopSidePanels decoded={decoded} entry={entry} /> : null}
       </div>
 
       <Filmstrip

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,5 @@
-import { app, BrowserWindow, dialog, ipcMain } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, type IpcMainInvokeEvent } from "electron";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -19,26 +20,86 @@ const DEV_SERVER_URL = process.env.DARKROOM_DEV_URL ?? "http://localhost:3000";
 
 let mainWindow: BrowserWindow | null = null;
 let staticServerPort: number | null = null;
+let activeLibraryRoot: string | null = null;
 
 const settingsStore = createSettingsStore(app.getPath("userData"));
 const catalogStore = createCatalogStore(app.getPath("userData"));
 
-function resolveLibraryFile(rootPath: string, relativePath: string): string {
-  const root = path.resolve(rootPath);
-  const absolute = path.resolve(root, relativePath);
-  const relative = path.relative(root, absolute);
+async function activateLibraryRoot(rootPath: string): Promise<string> {
+  const stat = await fs.stat(rootPath);
+  if (!stat.isDirectory()) {
+    throw new Error("Library root must be a directory.");
+  }
+  const root = await fs.realpath(rootPath);
+  activeLibraryRoot = root;
+  return root;
+}
+
+function assertTrustedRenderer(event: IpcMainInvokeEvent): void {
+  if (event.sender !== mainWindow?.webContents) {
+    throw new Error("Desktop API is only available to the main Darkroom window.");
+  }
+  if (!event.senderFrame) {
+    throw new Error("Desktop API request has no renderer frame.");
+  }
+
+  const expectedOrigin = isDev
+    ? new URL(DEV_SERVER_URL).origin
+    : `http://127.0.0.1:${staticServerPort}`;
+  if (new URL(event.senderFrame.url).origin !== expectedOrigin) {
+    throw new Error("Desktop API request came from an untrusted origin.");
+  }
+}
+
+async function resolveLibraryFile(
+  event: IpcMainInvokeEvent,
+  rootPath: string,
+  relativePath: string,
+): Promise<string> {
+  assertTrustedRenderer(event);
+  if (!activeLibraryRoot) {
+    throw new Error("No approved library folder is open.");
+  }
+
+  const requestedRoot = await fs.realpath(rootPath);
+  if (requestedRoot !== activeLibraryRoot) {
+    throw new Error("Sidecar path must use the active library.");
+  }
+
+  const absolute = path.resolve(activeLibraryRoot, relativePath);
+  const relative = path.relative(activeLibraryRoot, absolute);
 
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
     throw new Error("Sidecar path must stay inside the active library.");
   }
 
-  return absolute;
+  const directory = await fs.realpath(path.dirname(absolute));
+  const directoryRelative = path.relative(activeLibraryRoot, directory);
+  if (directoryRelative.startsWith("..") || path.isAbsolute(directoryRelative)) {
+    throw new Error("Sidecar path cannot follow a symlink outside the library.");
+  }
+
+  return path.join(directory, path.basename(absolute));
 }
 
-function getSidecarPath(rootPath: string, relativePath: string): string {
-  const source = resolveLibraryFile(rootPath, relativePath);
+async function getSidecarPath(
+  event: IpcMainInvokeEvent,
+  rootPath: string,
+  relativePath: string,
+): Promise<string> {
+  const source = await resolveLibraryFile(event, rootPath, relativePath);
   const parsed = path.parse(source);
   return path.join(parsed.dir, `${parsed.name}.xmp`);
+}
+
+async function writeFileAtomically(filePath: string, contents: string): Promise<void> {
+  const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(temporaryPath, contents, "utf8");
+    await fs.rename(temporaryPath, filePath);
+  } finally {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+  }
 }
 
 function getPreloadPath(): string {
@@ -91,7 +152,7 @@ function registerIpcHandlers(): void {
       return null;
     }
 
-    const folderPath = result.filePaths[0]!;
+    const folderPath = await activateLibraryRoot(result.filePaths[0]!);
     return {
       path: folderPath,
       name: getFolderName(folderPath),
@@ -126,10 +187,26 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle("darkroom:get-last-folder", async () => {
-    return settingsStore.getLastFolder();
+    const folderPath = await settingsStore.getLastFolder();
+    if (folderPath) {
+      try {
+        await activateLibraryRoot(folderPath);
+      } catch {
+        activeLibraryRoot = null;
+      }
+    }
+    return folderPath;
   });
 
   ipcMain.handle("darkroom:set-last-folder", async (_event, folderPath: string | null) => {
+    if (folderPath) {
+      const requestedRoot = await fs.realpath(folderPath);
+      if (requestedRoot !== activeLibraryRoot) {
+        throw new Error("Library folder was not selected through Darkroom.");
+      }
+    } else {
+      activeLibraryRoot = null;
+    }
     await settingsStore.setLastFolder(folderPath);
   });
 
@@ -158,8 +235,8 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(
     "darkroom:read-sidecar",
-    async (_event, rootPath: string, relativePath: string) => {
-      const sidecarPath = getSidecarPath(rootPath, relativePath);
+    async (event, rootPath: string, relativePath: string) => {
+      const sidecarPath = await getSidecarPath(event, rootPath, relativePath);
       try {
         const [contents, stat] = await Promise.all([
           fs.readFile(sidecarPath, "utf8"),
@@ -183,12 +260,12 @@ function registerIpcHandlers(): void {
   ipcMain.handle(
     "darkroom:write-sidecar",
     async (
-      _event,
+      event,
       rootPath: string,
       relativePath: string,
       contents: string | null,
     ) => {
-      const sidecarPath = getSidecarPath(rootPath, relativePath);
+      const sidecarPath = await getSidecarPath(event, rootPath, relativePath);
       if (contents === null) {
         try {
           await fs.unlink(sidecarPath);
@@ -206,16 +283,20 @@ function registerIpcHandlers(): void {
         return;
       }
 
-      await fs.writeFile(sidecarPath, contents, "utf8");
+      await writeFileAtomically(sidecarPath, contents);
     },
   );
 
   ipcMain.handle(
     "darkroom:save-export",
-    async (_event, suggestedName: string, data: ArrayBuffer) => {
+    async (event, suggestedName: string, data: ArrayBuffer) => {
+      assertTrustedRenderer(event);
+      if (data.byteLength > 512 * 1024 * 1024) {
+        throw new Error("Export is too large.");
+      }
       const result = await dialog.showSaveDialog({
         title: "Export edited photo",
-        defaultPath: suggestedName,
+        defaultPath: path.basename(suggestedName),
         filters: [{ name: "JPEG", extensions: ["jpg", "jpeg"] }],
       });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain } from "electron";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -38,7 +39,61 @@ function resolveLibraryFile(rootPath: string, relativePath: string): string {
 function getSidecarPath(rootPath: string, relativePath: string): string {
   const source = resolveLibraryFile(rootPath, relativePath);
   const parsed = path.parse(source);
-  return path.join(parsed.dir, `${parsed.name}.xmp`);
+  const isRaw = parsed.ext.toLowerCase() === ".nef";
+  return path.join(
+    parsed.dir,
+    isRaw ? `${parsed.name}.xmp` : `${parsed.base}.xmp`,
+  );
+}
+
+async function assertRegularSidecar(sidecarPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(sidecarPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error("Refusing to follow a symbolic-link XMP sidecar.");
+    }
+    if (!stat.isFile()) {
+      throw new Error("XMP sidecar is not a regular file.");
+    }
+    return true;
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function writeSidecarAtomically(
+  sidecarPath: string,
+  contents: string,
+): Promise<void> {
+  await assertRegularSidecar(sidecarPath);
+  const temporaryPath = path.join(
+    path.dirname(sidecarPath),
+    `.${path.basename(sidecarPath)}.${randomUUID()}.tmp`,
+  );
+  try {
+    await fs.writeFile(temporaryPath, contents, { encoding: "utf8", flag: "wx" });
+    await fs.rename(temporaryPath, sidecarPath);
+  } finally {
+    await fs.unlink(temporaryPath).catch((error: unknown) => {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return;
+      }
+      throw error;
+    });
+  }
 }
 
 function getPreloadPath(): string {
@@ -161,9 +216,13 @@ function registerIpcHandlers(): void {
     async (_event, rootPath: string, relativePath: string) => {
       const sidecarPath = getSidecarPath(rootPath, relativePath);
       try {
+        const exists = await assertRegularSidecar(sidecarPath);
+        if (!exists) {
+          return null;
+        }
         const [contents, stat] = await Promise.all([
           fs.readFile(sidecarPath, "utf8"),
-          fs.stat(sidecarPath),
+          fs.lstat(sidecarPath),
         ]);
         return { contents, lastModified: stat.mtimeMs };
       } catch (error) {
@@ -191,6 +250,10 @@ function registerIpcHandlers(): void {
       const sidecarPath = getSidecarPath(rootPath, relativePath);
       if (contents === null) {
         try {
+          const exists = await assertRegularSidecar(sidecarPath);
+          if (!exists) {
+            return;
+          }
           await fs.unlink(sidecarPath);
         } catch (error) {
           if (
@@ -206,7 +269,7 @@ function registerIpcHandlers(): void {
         return;
       }
 
-      await fs.writeFile(sidecarPath, contents, "utf8");
+      await writeSidecarAtomically(sidecarPath, contents);
     },
   );
 

--- a/lib/cache/develop-image-cache.ts
+++ b/lib/cache/develop-image-cache.ts
@@ -5,14 +5,12 @@ export interface DevelopImage {
   width: number;
   height: number;
   metadata: Record<string, unknown>;
-  rgb: Uint8Array | Uint16Array | Uint8ClampedArray;
-  bits: number;
-  colors: number;
   blob: Blob;
   objectUrl: string;
 }
 
 const MAX_DEVELOP_IMAGES = 3;
+const PREVIEW_MAX_EDGE = 2_560;
 
 const imageCache = new Map<string, DevelopImage>();
 const inFlightImages = new Map<string, Promise<DevelopImage>>();
@@ -56,14 +54,14 @@ export async function loadDevelopImage(entry: LibraryEntry): Promise<DevelopImag
     return activeLoad;
   }
 
-  const load = decodeEntry(entry, { thumbnail: false }).then((decoded) => {
+  const load = decodeEntry(entry, {
+    thumbnail: true,
+    maxEdge: PREVIEW_MAX_EDGE,
+  }).then((decoded) => {
     const image: DevelopImage = {
       width: decoded.width,
       height: decoded.height,
       metadata: decoded.metadata,
-      rgb: decoded.rgb,
-      bits: decoded.bits,
-      colors: decoded.colors,
       blob: decoded.blob,
       objectUrl: decoded.objectUrl,
     };
@@ -78,6 +76,23 @@ export async function loadDevelopImage(entry: LibraryEntry): Promise<DevelopImag
   } finally {
     inFlightImages.delete(key);
   }
+}
+
+export async function loadDevelopExportImage(
+  entry: LibraryEntry,
+): Promise<DevelopImage> {
+  const decoded = await decodeEntry(entry, { fullResolution: true });
+  return {
+    width: decoded.width,
+    height: decoded.height,
+    metadata: decoded.metadata,
+    blob: decoded.blob,
+    objectUrl: decoded.objectUrl,
+  };
+}
+
+export function disposeDevelopImage(image: DevelopImage): void {
+  URL.revokeObjectURL(image.objectUrl);
 }
 
 export function preloadDevelopImages(

--- a/lib/cache/develop-image-cache.ts
+++ b/lib/cache/develop-image-cache.ts
@@ -5,17 +5,30 @@ export interface DevelopImage {
   width: number;
   height: number;
   metadata: Record<string, unknown>;
-  rgb: Uint8Array | Uint16Array | Uint8ClampedArray;
+  rgb?: Uint16Array;
   bits: number;
   colors: number;
   blob: Blob;
   objectUrl: string;
 }
 
-const MAX_DEVELOP_IMAGES = 3;
+const MAX_DEVELOP_IMAGES = 2;
 
 const imageCache = new Map<string, DevelopImage>();
 const inFlightImages = new Map<string, Promise<DevelopImage>>();
+
+function toDevelopImage(decoded: Awaited<ReturnType<typeof decodeEntry>>): DevelopImage {
+  return {
+    width: decoded.width,
+    height: decoded.height,
+    metadata: decoded.metadata,
+    rgb: decoded.rgb instanceof Uint16Array ? decoded.rgb : undefined,
+    bits: decoded.bits,
+    colors: decoded.colors,
+    blob: decoded.blob,
+    objectUrl: decoded.objectUrl,
+  };
+}
 
 function cacheKey(entry: LibraryEntry): string {
   return `${entry.relativePath}:${entry.lastModified}`;
@@ -57,16 +70,7 @@ export async function loadDevelopImage(entry: LibraryEntry): Promise<DevelopImag
   }
 
   const load = decodeEntry(entry, { thumbnail: false }).then((decoded) => {
-    const image: DevelopImage = {
-      width: decoded.width,
-      height: decoded.height,
-      metadata: decoded.metadata,
-      rgb: decoded.rgb,
-      bits: decoded.bits,
-      colors: decoded.colors,
-      blob: decoded.blob,
-      objectUrl: decoded.objectUrl,
-    };
+    const image = toDevelopImage(decoded);
     rememberImage(key, image);
     return image;
   });
@@ -78,6 +82,16 @@ export async function loadDevelopImage(entry: LibraryEntry): Promise<DevelopImag
   } finally {
     inFlightImages.delete(key);
   }
+}
+
+export async function loadDevelopExportImage(
+  entry: LibraryEntry,
+): Promise<DevelopImage> {
+  const decoded = await decodeEntry(entry, {
+    thumbnail: false,
+    fullResolution: true,
+  });
+  return toDevelopImage(decoded);
 }
 
 export function preloadDevelopImages(

--- a/lib/catalog/defaults.ts
+++ b/lib/catalog/defaults.ts
@@ -41,7 +41,7 @@ export const COLOR_LABEL_SHORTCUTS: Record<string, Exclude<ColorLabel, null>> = 
   "7": "yellow",
   "8": "green",
   "9": "blue",
-  "\\": "purple",
+  "]": "purple",
 };
 
 export const COLOR_LABEL_SHORTCUT_HINTS = Object.fromEntries(

--- a/lib/develop/crop-geometry.ts
+++ b/lib/develop/crop-geometry.ts
@@ -1,0 +1,242 @@
+export const MIN_CROP_SIZE = 0.05;
+
+export interface CropRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ImageRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type CropHandle =
+  | "move"
+  | "n"
+  | "s"
+  | "e"
+  | "w"
+  | "ne"
+  | "nw"
+  | "se"
+  | "sw";
+
+export function computeContainedImageRect(
+  containerWidth: number,
+  containerHeight: number,
+  imageWidth: number,
+  imageHeight: number,
+): ImageRect {
+  const containerRatio = containerWidth / containerHeight;
+  const imageRatio = imageWidth / imageHeight;
+  let width = containerWidth;
+  let height = containerHeight;
+
+  if (imageRatio > containerRatio) {
+    height = width / imageRatio;
+  } else {
+    width = height * imageRatio;
+  }
+
+  return {
+    x: (containerWidth - width) / 2,
+    y: (containerHeight - height) / 2,
+    width,
+    height,
+  };
+}
+
+export function clampCropRect(rect: CropRect): CropRect {
+  const width = Math.max(MIN_CROP_SIZE, Math.min(1, rect.width));
+  const height = Math.max(MIN_CROP_SIZE, Math.min(1, rect.height));
+  const x = Math.max(0, Math.min(1 - width, rect.x));
+  const y = Math.max(0, Math.min(1 - height, rect.y));
+  return { x, y, width, height };
+}
+
+export function fitCropToAspectRatio(
+  rect: CropRect,
+  aspectRatio: number,
+): CropRect {
+  const centerX = rect.x + rect.width / 2;
+  const centerY = rect.y + rect.height / 2;
+  const area = rect.width * rect.height;
+
+  let width = Math.sqrt(area * aspectRatio);
+  let height = width / aspectRatio;
+
+  const maxWidth = Math.min(centerX, 1 - centerX) * 2;
+  const maxHeight = Math.min(centerY, 1 - centerY) * 2;
+
+  if (width > maxWidth) {
+    width = maxWidth;
+    height = width / aspectRatio;
+  }
+  if (height > maxHeight) {
+    height = maxHeight;
+    width = height * aspectRatio;
+  }
+
+  width = Math.max(MIN_CROP_SIZE, width);
+  height = Math.max(MIN_CROP_SIZE, height);
+
+  return clampCropRect({
+    x: centerX - width / 2,
+    y: centerY - height / 2,
+    width,
+    height,
+  });
+}
+
+function constrainSize(
+  width: number,
+  height: number,
+  aspectRatio: number | null,
+  anchor: "width" | "height",
+): { width: number; height: number } {
+  if (!aspectRatio || aspectRatio <= 0) {
+    return { width, height };
+  }
+  if (anchor === "width") {
+    return { width, height: width / aspectRatio };
+  }
+  return { width: height * aspectRatio, height };
+}
+
+export function applyCropDrag(
+  rect: CropRect,
+  handle: CropHandle,
+  deltaX: number,
+  deltaY: number,
+  aspectRatio: number | null,
+): CropRect {
+  let { x, y, width, height } = rect;
+
+  if (handle === "move") {
+    return clampCropRect({
+      x: x + deltaX,
+      y: y + deltaY,
+      width,
+      height,
+    });
+  }
+
+  if (handle.includes("e")) {
+    width += deltaX;
+  }
+  if (handle.includes("w")) {
+    x += deltaX;
+    width -= deltaX;
+  }
+  if (handle.includes("s")) {
+    height += deltaY;
+  }
+  if (handle.includes("n")) {
+    y += deltaY;
+    height -= deltaY;
+  }
+
+  width = Math.max(MIN_CROP_SIZE, width);
+  height = Math.max(MIN_CROP_SIZE, height);
+
+  if (aspectRatio && aspectRatio > 0) {
+    const horizontal = handle === "e" || handle === "w";
+    const vertical = handle === "n" || handle === "s";
+    const corner = handle.length === 2;
+    const centerX = rect.x + rect.width / 2;
+    const centerY = rect.y + rect.height / 2;
+
+    if (corner) {
+      const useWidth = Math.abs(deltaX) >= Math.abs(deltaY);
+      ({ width, height } = constrainSize(
+        width,
+        height,
+        aspectRatio,
+        useWidth ? "width" : "height",
+      ));
+      if (handle.includes("w")) {
+        x = rect.x + rect.width - width;
+      }
+      if (handle.includes("n")) {
+        y = rect.y + rect.height - height;
+      }
+    } else if (horizontal) {
+      ({ width, height } = constrainSize(width, height, aspectRatio, "width"));
+      if (handle === "w") {
+        x = rect.x + rect.width - width;
+      }
+      y = centerY - height / 2;
+    } else if (vertical) {
+      ({ width, height } = constrainSize(width, height, aspectRatio, "height"));
+      if (handle === "n") {
+        y = rect.y + rect.height - height;
+      }
+      x = centerX - width / 2;
+    }
+  }
+
+  return clampCropRect({ x, y, width, height });
+}
+
+export function parseAspectRatioInput(
+  widthText: string,
+  heightText: string,
+): number | null {
+  const width = Number(widthText);
+  const height = Number(heightText);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return null;
+  }
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+  return width / height;
+}
+
+export const ASPECT_RATIO_PRESETS = [
+  { id: "original", label: "Original" },
+  { id: "free", label: "Free" },
+  { id: "1:1", label: "1 : 1", ratio: 1 },
+  { id: "4:3", label: "4 : 3", ratio: 4 / 3 },
+  { id: "3:2", label: "3 : 2", ratio: 3 / 2 },
+  { id: "16:9", label: "16 : 9", ratio: 16 / 9 },
+  { id: "5:4", label: "5 : 4", ratio: 5 / 4 },
+  { id: "2:3", label: "2 : 3", ratio: 2 / 3 },
+  { id: "9:16", label: "9 : 16", ratio: 9 / 16 },
+  { id: "custom", label: "Custom" },
+] as const;
+
+export type AspectRatioPresetId = (typeof ASPECT_RATIO_PRESETS)[number]["id"];
+
+export function getPresetAspectRatio(
+  presetId: AspectRatioPresetId,
+): number | null {
+  const preset = ASPECT_RATIO_PRESETS.find((item) => item.id === presetId);
+  if (!preset || preset.id === "free" || preset.id === "original" || preset.id === "custom") {
+    return null;
+  }
+  return preset.ratio;
+}
+
+export function resolveAspectRatio(
+  presetId: AspectRatioPresetId,
+  imageWidth: number,
+  imageHeight: number,
+  customWidth: number,
+  customHeight: number,
+): number | null {
+  if (presetId === "free") {
+    return null;
+  }
+  if (presetId === "original") {
+    return imageWidth / imageHeight;
+  }
+  if (presetId === "custom") {
+    return parseAspectRatioInput(String(customWidth), String(customHeight));
+  }
+  return getPresetAspectRatio(presetId);
+}

--- a/lib/develop/number-prop.ts
+++ b/lib/develop/number-prop.ts
@@ -1,0 +1,11 @@
+export function numberProp(
+  props: Record<string, string>,
+  key: string,
+): number | null {
+  const raw = props[key];
+  if (raw === undefined) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}

--- a/lib/develop/plugins/basic.ts
+++ b/lib/develop/plugins/basic.ts
@@ -1,4 +1,5 @@
 import type { BasicSettings, DevelopPlugin } from "@/lib/develop/types";
+import { numberProp } from "@/lib/develop/xmp-value";
 
 export const DEFAULT_BASIC_SETTINGS: BasicSettings = {
   exposure: 0,
@@ -12,15 +13,6 @@ export const DEFAULT_BASIC_SETTINGS: BasicSettings = {
   vibrance: 0,
   saturation: 0,
 };
-
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
 
 function isDefault(settings: BasicSettings): boolean {
   return Object.values(settings).every((value) => value === 0);

--- a/lib/develop/plugins/basic.ts
+++ b/lib/develop/plugins/basic.ts
@@ -1,4 +1,5 @@
 import type { BasicSettings, DevelopPlugin } from "@/lib/develop/types";
+import { numberProp } from "@/lib/develop/number-prop";
 
 export const DEFAULT_BASIC_SETTINGS: BasicSettings = {
   exposure: 0,
@@ -12,15 +13,6 @@ export const DEFAULT_BASIC_SETTINGS: BasicSettings = {
   vibrance: 0,
   saturation: 0,
 };
-
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
 
 function isDefault(settings: BasicSettings): boolean {
   return Object.values(settings).every((value) => value === 0);

--- a/lib/develop/plugins/crop.ts
+++ b/lib/develop/plugins/crop.ts
@@ -1,4 +1,5 @@
 import type { CropSettings, DevelopPlugin } from "@/lib/develop/types";
+import { numberProp } from "@/lib/develop/number-prop";
 
 export const DEFAULT_CROP_SETTINGS: CropSettings = {
   enabled: false,
@@ -11,15 +12,6 @@ export const DEFAULT_CROP_SETTINGS: CropSettings = {
   perspectiveY: 0,
   distortion: 0,
 };
-
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
 
 function isDefault(settings: CropSettings): boolean {
   return (
@@ -60,12 +52,15 @@ export const cropPlugin: DevelopPlugin<"crop"> = {
       };
     },
     read: (props) => {
+      if (props["crs:HasCrop"] !== "True") {
+        return { ...DEFAULT_CROP_SETTINGS };
+      }
       const left = numberProp(props, "crs:CropLeft") ?? 0;
       const top = numberProp(props, "crs:CropTop") ?? 0;
       const right = numberProp(props, "crs:CropRight") ?? 1;
       const bottom = numberProp(props, "crs:CropBottom") ?? 1;
       return {
-        enabled: props["crs:HasCrop"] === "True" || left > 0 || top > 0,
+        enabled: true,
         x: left,
         y: top,
         width: Math.max(0.05, right - left),

--- a/lib/develop/plugins/crop.ts
+++ b/lib/develop/plugins/crop.ts
@@ -1,4 +1,5 @@
 import type { CropSettings, DevelopPlugin } from "@/lib/develop/types";
+import { numberProp } from "@/lib/develop/xmp-value";
 
 export const DEFAULT_CROP_SETTINGS: CropSettings = {
   enabled: false,
@@ -14,15 +15,6 @@ export const DEFAULT_CROP_SETTINGS: CropSettings = {
   customAspectWidth: 1,
   customAspectHeight: 1,
 };
-
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
 
 function isDefault(settings: CropSettings): boolean {
   return (
@@ -47,12 +39,8 @@ export const cropPlugin: DevelopPlugin<"crop"> = {
   defaults: DEFAULT_CROP_SETTINGS,
   isDefault,
   xmp: {
-    write: (settings) => {
-      if (!settings.enabled) {
-        return {} as Record<string, string>;
-      }
-      return {
-        "crs:HasCrop": "True",
+    write: (settings) => ({
+        "crs:HasCrop": settings.enabled ? "True" : "False",
         "crs:CropLeft": settings.x.toFixed(6),
         "crs:CropTop": settings.y.toFixed(6),
         "crs:CropRight": (settings.x + settings.width).toFixed(6),
@@ -63,8 +51,7 @@ export const cropPlugin: DevelopPlugin<"crop"> = {
         "crs:LensManualDistortionAmount": String(
           Math.round(settings.distortion),
         ),
-      };
-    },
+      }),
     read: (props) => {
       const left = numberProp(props, "crs:CropLeft") ?? 0;
       const top = numberProp(props, "crs:CropTop") ?? 0;

--- a/lib/develop/plugins/crop.ts
+++ b/lib/develop/plugins/crop.ts
@@ -10,6 +10,9 @@ export const DEFAULT_CROP_SETTINGS: CropSettings = {
   perspectiveX: 0,
   perspectiveY: 0,
   distortion: 0,
+  aspectPreset: "original",
+  customAspectWidth: 1,
+  customAspectHeight: 1,
 };
 
 function numberProp(props: Record<string, string>, key: string): number | null {
@@ -31,7 +34,10 @@ function isDefault(settings: CropSettings): boolean {
     settings.angle === 0 &&
     settings.perspectiveX === 0 &&
     settings.perspectiveY === 0 &&
-    settings.distortion === 0
+    settings.distortion === 0 &&
+    settings.aspectPreset === "original" &&
+    settings.customAspectWidth === 1 &&
+    settings.customAspectHeight === 1
   );
 }
 

--- a/lib/develop/plugins/effects.ts
+++ b/lib/develop/plugins/effects.ts
@@ -1,4 +1,5 @@
 import type { DevelopPlugin, EffectsSettings } from "@/lib/develop/types";
+import { numberProp } from "@/lib/develop/number-prop";
 
 export const DEFAULT_EFFECTS_SETTINGS: EffectsSettings = {
   vignette: 0,
@@ -6,15 +7,6 @@ export const DEFAULT_EFFECTS_SETTINGS: EffectsSettings = {
   sharpening: 0,
   noiseReduction: 0,
 };
-
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
 
 function isDefault(settings: EffectsSettings): boolean {
   return Object.values(settings).every((value) => value === 0);

--- a/lib/develop/plugins/effects.ts
+++ b/lib/develop/plugins/effects.ts
@@ -1,4 +1,5 @@
 import type { DevelopPlugin, EffectsSettings } from "@/lib/develop/types";
+import { numberProp } from "@/lib/develop/xmp-value";
 
 export const DEFAULT_EFFECTS_SETTINGS: EffectsSettings = {
   vignette: 0,
@@ -6,15 +7,6 @@ export const DEFAULT_EFFECTS_SETTINGS: EffectsSettings = {
   sharpening: 0,
   noiseReduction: 0,
 };
-
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
 
 function isDefault(settings: EffectsSettings): boolean {
   return Object.values(settings).every((value) => value === 0);

--- a/lib/develop/plugins/mixer.ts
+++ b/lib/develop/plugins/mixer.ts
@@ -4,6 +4,7 @@ import type {
   MixerColor,
   MixerSettings,
 } from "@/lib/develop/types";
+import { numberProp } from "@/lib/develop/number-prop";
 
 export const MIXER_COLORS: MixerColor[] = [
   "red",
@@ -36,15 +37,6 @@ const DEFAULT_BAND: MixerBandSettings = {
 export const DEFAULT_MIXER_SETTINGS = Object.fromEntries(
   MIXER_COLORS.map((color) => [color, { ...DEFAULT_BAND }]),
 ) as MixerSettings;
-
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
 
 function isDefault(settings: MixerSettings): boolean {
   return MIXER_COLORS.every((color) =>

--- a/lib/develop/plugins/mixer.ts
+++ b/lib/develop/plugins/mixer.ts
@@ -4,6 +4,7 @@ import type {
   MixerColor,
   MixerSettings,
 } from "@/lib/develop/types";
+import { numberProp } from "@/lib/develop/xmp-value";
 
 export const MIXER_COLORS: MixerColor[] = [
   "red",
@@ -36,15 +37,6 @@ const DEFAULT_BAND: MixerBandSettings = {
 export const DEFAULT_MIXER_SETTINGS = Object.fromEntries(
   MIXER_COLORS.map((color) => [color, { ...DEFAULT_BAND }]),
 ) as MixerSettings;
-
-function numberProp(props: Record<string, string>, key: string): number | null {
-  const raw = props[key];
-  if (raw === undefined) {
-    return null;
-  }
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
-}
 
 function isDefault(settings: MixerSettings): boolean {
   return MIXER_COLORS.every((color) =>

--- a/lib/develop/renderer.ts
+++ b/lib/develop/renderer.ts
@@ -242,10 +242,10 @@ function createProgram(gl: WebGL2RenderingContext): WebGLProgram {
 }
 
 function toFloatRgba(image: DevelopImage): Float32Array {
-  const source =
-    image.rgb instanceof Uint16Array
-      ? image.rgb
-      : new Uint16Array(image.rgb.buffer);
+  const source = image.rgb;
+  if (!source) {
+    throw new Error("16-bit image data is unavailable.");
+  }
   const channels = Math.max(1, image.colors);
   const maxValue = image.bits > 8 ? 65535 : 255;
   const output = new Float32Array(image.width * image.height * 4);
@@ -264,12 +264,16 @@ export class DevelopRenderer {
   private readonly canvas: HTMLCanvasElement;
   private readonly gl: WebGL2RenderingContext;
   private readonly program: WebGLProgram;
+  private readonly buffer: WebGLBuffer;
   private texture: WebGLTexture | null = null;
   private textureWidth = 1;
   private textureHeight = 1;
 
-  constructor(canvas: HTMLCanvasElement) {
-    const gl = canvas.getContext("webgl2", { preserveDrawingBuffer: true });
+  constructor(
+    canvas: HTMLCanvasElement,
+    preserveDrawingBuffer = false,
+  ) {
+    const gl = canvas.getContext("webgl2", { preserveDrawingBuffer });
     if (!gl) {
       throw new Error("WebGL2 is not available.");
     }
@@ -277,18 +281,22 @@ export class DevelopRenderer {
     this.canvas = canvas;
     this.gl = gl;
     this.program = createProgram(gl);
-    this.configureGeometry();
+    this.buffer = this.configureGeometry();
   }
 
-  private configureGeometry(): void {
+  private configureGeometry(): WebGLBuffer {
     const gl = this.gl;
     gl.useProgram(this.program);
     const buffer = gl.createBuffer();
+    if (!buffer) {
+      throw new Error("Could not create WebGL buffer.");
+    }
     gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
     gl.bufferData(gl.ARRAY_BUFFER, QUAD, gl.STATIC_DRAW);
     const location = gl.getAttribLocation(this.program, "a_position");
     gl.enableVertexAttribArray(location);
     gl.vertexAttribPointer(location, 2, gl.FLOAT, false, 0, 0);
+    return buffer;
   }
 
   async setImage(image: DevelopImage): Promise<void> {
@@ -304,7 +312,7 @@ export class DevelopRenderer {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
-    if (image.bits > 8 && image.rgb.length > 0) {
+    if (image.bits > 8 && image.rgb?.length) {
       const floatLinear = gl.getExtension("OES_texture_float_linear");
       if (!floatLinear) {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
@@ -344,7 +352,11 @@ export class DevelopRenderer {
     }
   }
 
-  render(settings: DevelopSettings, showOriginal: boolean): void {
+  render(
+    settings: DevelopSettings,
+    showOriginal: boolean,
+    contain = true,
+  ): void {
     const gl = this.gl;
     if (!this.texture) {
       return;
@@ -353,7 +365,9 @@ export class DevelopRenderer {
     gl.viewport(0, 0, this.canvas.width, this.canvas.height);
     gl.clearColor(0, 0, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    this.applyContainViewport();
+    if (contain) {
+      this.applyContainViewport();
+    }
     gl.useProgram(this.program);
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
@@ -370,9 +384,18 @@ export class DevelopRenderer {
       settings.crop.height,
     );
     this.uniform1f("u_crop_angle", settings.crop.angle);
-    this.uniform1f("u_perspective_x", settings.crop.perspectiveX);
-    this.uniform1f("u_perspective_y", settings.crop.perspectiveY);
-    this.uniform1f("u_distortion", settings.crop.distortion);
+    this.uniform1f(
+      "u_perspective_x",
+      settings.crop.enabled ? settings.crop.perspectiveX : 0,
+    );
+    this.uniform1f(
+      "u_perspective_y",
+      settings.crop.enabled ? settings.crop.perspectiveY : 0,
+    );
+    this.uniform1f(
+      "u_distortion",
+      settings.crop.enabled ? settings.crop.distortion : 0,
+    );
 
     this.uniform1f("u_exposure", settings.basic.exposure);
     this.uniform1f("u_contrast", settings.basic.contrast);
@@ -422,7 +445,31 @@ export class DevelopRenderer {
       this.gl.deleteTexture(this.texture);
       this.texture = null;
     }
+    this.gl.deleteBuffer(this.buffer);
     this.gl.deleteProgram(this.program);
+  }
+
+  async exportJpeg(
+    image: DevelopImage,
+    settings: DevelopSettings,
+  ): Promise<Blob> {
+    const canvas = document.createElement("canvas");
+    const width = settings.crop.enabled
+      ? Math.max(1, Math.round(image.width * settings.crop.width))
+      : image.width;
+    const height = settings.crop.enabled
+      ? Math.max(1, Math.round(image.height * settings.crop.height))
+      : image.height;
+    const renderer = new DevelopRenderer(canvas, true);
+
+    try {
+      await renderer.setImage(image);
+      renderer.resize(width, height);
+      renderer.render(settings, false, false);
+      return await renderer.toBlob();
+    } finally {
+      renderer.dispose();
+    }
   }
 
   toBlob(type = "image/jpeg", quality = 0.92): Promise<Blob> {

--- a/lib/develop/renderer.ts
+++ b/lib/develop/renderer.ts
@@ -241,25 +241,6 @@ function createProgram(gl: WebGL2RenderingContext): WebGLProgram {
   return program;
 }
 
-function toFloatRgba(image: DevelopImage): Float32Array {
-  const source =
-    image.rgb instanceof Uint16Array
-      ? image.rgb
-      : new Uint16Array(image.rgb.buffer);
-  const channels = Math.max(1, image.colors);
-  const maxValue = image.bits > 8 ? 65535 : 255;
-  const output = new Float32Array(image.width * image.height * 4);
-
-  for (let sourceIndex = 0, outputIndex = 0; outputIndex < output.length; sourceIndex += channels, outputIndex += 4) {
-    output[outputIndex] = source[sourceIndex] / maxValue;
-    output[outputIndex + 1] = source[sourceIndex + 1] / maxValue;
-    output[outputIndex + 2] = source[sourceIndex + 2] / maxValue;
-    output[outputIndex + 3] = 1;
-  }
-
-  return output;
-}
-
 export class DevelopRenderer {
   private readonly canvas: HTMLCanvasElement;
   private readonly gl: WebGL2RenderingContext;
@@ -293,6 +274,13 @@ export class DevelopRenderer {
 
   async setImage(image: DevelopImage): Promise<void> {
     const gl = this.gl;
+    const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE) as number;
+    if (image.width > maxTextureSize || image.height > maxTextureSize) {
+      throw new Error(
+        `Image exceeds this device's ${maxTextureSize}px texture limit.`,
+      );
+    }
+
     const texture = gl.createTexture();
     if (!texture) {
       throw new Error("Could not create WebGL texture.");
@@ -304,26 +292,12 @@ export class DevelopRenderer {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
-    if (image.bits > 8 && image.rgb.length > 0) {
-      const floatLinear = gl.getExtension("OES_texture_float_linear");
-      if (!floatLinear) {
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-      }
-      gl.texImage2D(
-        gl.TEXTURE_2D,
-        0,
-        gl.RGBA32F,
-        image.width,
-        image.height,
-        0,
-        gl.RGBA,
-        gl.FLOAT,
-        toFloatRgba(image),
-      );
-    } else {
-      const bitmap = await createImageBitmap(image.blob);
+    const bitmap = await createImageBitmap(image.blob);
+    try {
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmap);
+      this.textureWidth = bitmap.width;
+      this.textureHeight = bitmap.height;
+    } finally {
       bitmap.close();
     }
 
@@ -331,8 +305,6 @@ export class DevelopRenderer {
       gl.deleteTexture(this.texture);
     }
     this.texture = texture;
-    this.textureWidth = image.width;
-    this.textureHeight = image.height;
   }
 
   resize(width: number, height: number): void {
@@ -344,7 +316,11 @@ export class DevelopRenderer {
     }
   }
 
-  render(settings: DevelopSettings, showOriginal: boolean): void {
+  render(
+    settings: DevelopSettings,
+    showOriginal: boolean,
+    contain = true,
+  ): void {
     const gl = this.gl;
     if (!this.texture) {
       return;
@@ -353,7 +329,9 @@ export class DevelopRenderer {
     gl.viewport(0, 0, this.canvas.width, this.canvas.height);
     gl.clearColor(0, 0, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    this.applyContainViewport();
+    if (contain) {
+      this.applyContainViewport();
+    }
     gl.useProgram(this.program);
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.texture);
@@ -473,5 +451,42 @@ export class DevelopRenderer {
     w: number,
   ): void {
     this.gl.uniform4f(this.gl.getUniformLocation(this.program, name), x, y, z, w);
+  }
+}
+
+const MAX_EXPORT_PIXELS = 50_000_000;
+
+function exportSize(image: DevelopImage, settings: DevelopSettings): {
+  width: number;
+  height: number;
+} {
+  const crop = settings.crop;
+  if (!crop.enabled) {
+    return { width: image.width, height: image.height };
+  }
+  return {
+    width: Math.max(1, Math.round(image.width * crop.width)),
+    height: Math.max(1, Math.round(image.height * crop.height)),
+  };
+}
+
+export async function exportDevelopJpeg(
+  image: DevelopImage,
+  settings: DevelopSettings,
+): Promise<Blob> {
+  const { width, height } = exportSize(image, settings);
+  if (width * height > MAX_EXPORT_PIXELS) {
+    throw new Error("This edit exceeds the 50 megapixel export limit.");
+  }
+
+  const canvas = document.createElement("canvas");
+  const renderer = new DevelopRenderer(canvas);
+  try {
+    await renderer.setImage(image);
+    renderer.resize(width, height);
+    renderer.render(settings, false, false);
+    return await renderer.toBlob();
+  } finally {
+    renderer.dispose();
   }
 }

--- a/lib/develop/sidecar.ts
+++ b/lib/develop/sidecar.ts
@@ -1,12 +1,12 @@
 import type { EntryMetadata } from "@/lib/catalog/types";
 import { getDarkroomAPI } from "@/lib/fs/platform";
-import { isDefaultDevelopSettings } from "@/lib/develop/registry";
 import type { DevelopSettings } from "@/lib/develop/types";
 import { parseDevelopXmp, serializeDevelopXmp } from "@/lib/develop/xmp";
 
 export interface DevelopSidecar {
   settings: DevelopSettings;
   lastModified: number;
+  source: string;
   rating?: EntryMetadata["rating"];
   colorLabel?: EntryMetadata["colorLabel"];
 }
@@ -23,6 +23,7 @@ export async function readDevelopSidecar(
   return {
     ...parseDevelopXmp(sidecar.contents),
     lastModified: sidecar.lastModified,
+    source: sidecar.contents,
   };
 }
 
@@ -31,9 +32,9 @@ export async function writeDevelopSidecar(
   relativePath: string,
   settings: DevelopSettings,
   metadata: Pick<EntryMetadata, "rating" | "colorLabel">,
-): Promise<void> {
-  const contents = isDefaultDevelopSettings(settings)
-    ? null
-    : serializeDevelopXmp(settings, metadata);
+  existing?: string | null,
+): Promise<string> {
+  const contents = serializeDevelopXmp(settings, metadata, existing);
   await getDarkroomAPI().writeSidecar(rootPath, relativePath, contents);
+  return contents;
 }

--- a/lib/develop/sidecar.ts
+++ b/lib/develop/sidecar.ts
@@ -1,10 +1,10 @@
 import type { EntryMetadata } from "@/lib/catalog/types";
 import { getDarkroomAPI } from "@/lib/fs/platform";
-import { isDefaultDevelopSettings } from "@/lib/develop/registry";
 import type { DevelopSettings } from "@/lib/develop/types";
 import { parseDevelopXmp, serializeDevelopXmp } from "@/lib/develop/xmp";
 
 export interface DevelopSidecar {
+  contents: string;
   settings: DevelopSettings;
   lastModified: number;
   rating?: EntryMetadata["rating"];
@@ -21,6 +21,7 @@ export async function readDevelopSidecar(
   }
 
   return {
+    contents: sidecar.contents,
     ...parseDevelopXmp(sidecar.contents),
     lastModified: sidecar.lastModified,
   };
@@ -31,9 +32,12 @@ export async function writeDevelopSidecar(
   relativePath: string,
   settings: DevelopSettings,
   metadata: Pick<EntryMetadata, "rating" | "colorLabel">,
-): Promise<void> {
-  const contents = isDefaultDevelopSettings(settings)
-    ? null
-    : serializeDevelopXmp(settings, metadata);
+  existingContents: string | null,
+): Promise<string | null> {
+  const contents = serializeDevelopXmp(settings, metadata, existingContents);
+  if (contents === null) {
+    return null;
+  }
   await getDarkroomAPI().writeSidecar(rootPath, relativePath, contents);
+  return contents;
 }

--- a/lib/develop/types.ts
+++ b/lib/develop/types.ts
@@ -11,6 +11,8 @@ export interface BasicSettings {
   saturation: number;
 }
 
+import type { AspectRatioPresetId } from "@/lib/develop/crop-geometry";
+
 export interface CropSettings {
   enabled: boolean;
   x: number;
@@ -21,6 +23,9 @@ export interface CropSettings {
   perspectiveX: number;
   perspectiveY: number;
   distortion: number;
+  aspectPreset: AspectRatioPresetId;
+  customAspectWidth: number;
+  customAspectHeight: number;
 }
 
 export interface CurveSettings {

--- a/lib/develop/xmp-value.ts
+++ b/lib/develop/xmp-value.ts
@@ -1,0 +1,7 @@
+export function numberProp(
+  props: Record<string, string>,
+  key: string,
+): number | null {
+  const value = Number(props[key]);
+  return Number.isFinite(value) ? value : null;
+}

--- a/lib/develop/xmp.ts
+++ b/lib/develop/xmp.ts
@@ -25,9 +25,49 @@ function collectDevelopProps(settings: DevelopSettings): Record<string, string> 
   return props;
 }
 
+const OWNED_XMP_KEYS = (() => {
+  const settings = createDevelopSettings();
+  settings.crop.enabled = true;
+  return new Set([
+    ...Object.keys(collectDevelopProps(settings)),
+    "xmp:Rating",
+    "xmp:Label",
+  ]);
+})();
+
+function getDescription(doc: Document): Element | null {
+  return doc.getElementsByTagNameNS("*", "Description")[0] ?? null;
+}
+
+function mergeDevelopProps(
+  existing: string,
+  props: Record<string, string>,
+): string {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(existing, "application/xml");
+  if (doc.querySelector("parsererror")) {
+    throw new Error("Could not parse existing XMP sidecar; refusing to overwrite it.");
+  }
+
+  const description = getDescription(doc);
+  if (!description) {
+    throw new Error("Existing XMP sidecar has no rdf:Description; refusing to overwrite it.");
+  }
+
+  for (const key of OWNED_XMP_KEYS) {
+    description.removeAttribute(key);
+  }
+  for (const [key, value] of Object.entries(props)) {
+    description.setAttribute(key, value);
+  }
+
+  return new XMLSerializer().serializeToString(doc);
+}
+
 export function serializeDevelopXmp(
   settings: DevelopSettings,
   metadata?: Pick<EntryMetadata, "rating" | "colorLabel">,
+  existing?: string | null,
 ): string {
   const props: Record<string, string> = {
     ...collectDevelopProps(settings),
@@ -38,6 +78,10 @@ export function serializeDevelopXmp(
   }
   if (metadata?.colorLabel) {
     props["xmp:Label"] = metadata.colorLabel;
+  }
+
+  if (existing) {
+    return mergeDevelopProps(existing, props);
   }
 
   const attributes = Object.entries(props)
@@ -65,7 +109,7 @@ function extractAttributes(xml: string): Record<string, string> {
     throw new Error("Could not parse XMP sidecar.");
   }
 
-  const description = doc.querySelector("Description");
+  const description = getDescription(doc);
   if (!description) {
     return {};
   }

--- a/lib/develop/xmp.ts
+++ b/lib/develop/xmp.ts
@@ -1,20 +1,20 @@
 import type { EntryMetadata } from "@/lib/catalog/types";
 import { COLOR_LABELS } from "@/lib/catalog/types";
-import { DEVELOP_PLUGINS, createDevelopSettings } from "@/lib/develop/registry";
+import {
+  DEVELOP_PLUGINS,
+  createDevelopSettings,
+  isDefaultDevelopSettings,
+} from "@/lib/develop/registry";
 import type { DevelopSettings } from "@/lib/develop/types";
+
+const RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+const CRS_NS = "http://ns.adobe.com/camera-raw-settings/1.0/";
+const XMP_NS = "http://ns.adobe.com/xap/1.0/";
 
 export interface ParsedDevelopXmp {
   settings: DevelopSettings;
   rating?: EntryMetadata["rating"];
   colorLabel?: EntryMetadata["colorLabel"];
-}
-
-function escapeXml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
 }
 
 function collectDevelopProps(settings: DevelopSettings): Record<string, string> {
@@ -25,51 +25,65 @@ function collectDevelopProps(settings: DevelopSettings): Record<string, string> 
   return props;
 }
 
-export function serializeDevelopXmp(
-  settings: DevelopSettings,
-  metadata?: Pick<EntryMetadata, "rating" | "colorLabel">,
-): string {
-  const props: Record<string, string> = {
-    ...collectDevelopProps(settings),
-  };
-
-  if (metadata?.rating) {
-    props["xmp:Rating"] = String(metadata.rating);
-  }
-  if (metadata?.colorLabel) {
-    props["xmp:Label"] = metadata.colorLabel;
-  }
-
-  const attributes = Object.entries(props)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, value]) => `   ${key}="${escapeXml(value)}"`)
-    .join("\n");
-
-  return `<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
-<x:xmpmeta xmlns:x="adobe:ns:meta/">
- <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description
-   xmlns:crs="http://ns.adobe.com/camera-raw-settings/1.0/"
-   xmlns:xmp="http://ns.adobe.com/xap/1.0/"
-${attributes}
-  />
- </rdf:RDF>
-</x:xmpmeta>
-<?xpacket end="w"?>`;
+function createXmpDocument(): XMLDocument {
+  return new DOMParser().parseFromString(
+    `<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="${RDF_NS}"><rdf:Description xmlns:crs="${CRS_NS}" xmlns:xmp="${XMP_NS}"/></rdf:RDF></x:xmpmeta>`,
+    "application/xml",
+  );
 }
 
-function extractAttributes(xml: string): Record<string, string> {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(xml, "application/xml");
+function descriptionFor(doc: XMLDocument): Element {
+  const description = doc.getElementsByTagNameNS(RDF_NS, "Description")[0];
+  if (!description) {
+    throw new Error("Could not find an XMP description.");
+  }
+  return description;
+}
+
+function parseXmpDocument(xml: string): XMLDocument {
+  const doc = new DOMParser().parseFromString(xml, "application/xml");
   if (doc.querySelector("parsererror")) {
     throw new Error("Could not parse XMP sidecar.");
   }
+  descriptionFor(doc);
+  return doc;
+}
 
-  const description = doc.querySelector("Description");
-  if (!description) {
-    return {};
+export function serializeDevelopXmp(
+  settings: DevelopSettings,
+  metadata: Pick<EntryMetadata, "rating" | "colorLabel">,
+  existingContents: string | null,
+): string | null {
+  if (
+    existingContents === null &&
+    isDefaultDevelopSettings(settings) &&
+    metadata.rating === 0 &&
+    metadata.colorLabel === null
+  ) {
+    return null;
   }
 
+  const doc = existingContents ? parseXmpDocument(existingContents) : createXmpDocument();
+  const description = descriptionFor(doc);
+  description.setAttribute("xmlns:crs", CRS_NS);
+  description.setAttribute("xmlns:xmp", XMP_NS);
+
+  for (const [key, value] of Object.entries(collectDevelopProps(settings))) {
+    description.setAttributeNS(CRS_NS, key, value);
+  }
+  description.setAttributeNS(XMP_NS, "xmp:Rating", String(metadata.rating));
+  if (metadata.colorLabel) {
+    description.setAttributeNS(XMP_NS, "xmp:Label", metadata.colorLabel);
+  } else {
+    description.removeAttributeNS(XMP_NS, "Label");
+    description.removeAttribute("xmp:Label");
+  }
+
+  return new XMLSerializer().serializeToString(doc);
+}
+
+function extractAttributes(xml: string): Record<string, string> {
+  const description = descriptionFor(parseXmpDocument(xml));
   return Array.from(description.attributes).reduce<Record<string, string>>(
     (props, attribute) => {
       if (attribute.name.startsWith("crs:") || attribute.name.startsWith("xmp:")) {

--- a/lib/raw/libraw-client.ts
+++ b/lib/raw/libraw-client.ts
@@ -203,6 +203,13 @@ export async function decodeWithLibRaw(
     throw new Error("Could not decode RAW thumbnail");
   }
 
+  if (options.fullResolution) {
+    const fullResolution = await decodeOpenedRaw(input, options, false);
+    if (fullResolution) {
+      return fullResolution;
+    }
+  }
+
   const preview = await decodeOpenedRaw(input, options, true);
   if (preview) {
     return preview;

--- a/lib/raw/libraw-client.ts
+++ b/lib/raw/libraw-client.ts
@@ -43,7 +43,7 @@ function buildSettings(
 ): LibRawSettings {
   return {
     halfSize,
-    outputBps: options.thumbnail ? 8 : 16,
+    outputBps: 8,
     useCameraWb: true,
     userQual: options.thumbnail ? 0 : halfSize ? 1 : 2,
   };
@@ -189,6 +189,14 @@ export async function decodeWithLibRaw(
   input: Uint8Array,
   options: DecodeOptions = {},
 ): Promise<DecodedImage> {
+  if (options.fullResolution) {
+    const fullResolution = await decodeOpenedRaw(input, options, false);
+    if (fullResolution) {
+      return fullResolution;
+    }
+    throw new Error("Could not decode RAW image");
+  }
+
   if (options.thumbnail) {
     const embedded = await decodeEmbeddedThumbnail(input);
     if (embedded) {

--- a/lib/raw/types.ts
+++ b/lib/raw/types.ts
@@ -1,5 +1,6 @@
 export interface DecodeOptions {
   thumbnail?: boolean;
+  fullResolution?: boolean;
   maxEdge?: number;
   priority?: number;
   signal?: AbortSignal;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "electron:dev": "concurrently -k \"npm run dev\" \"wait-on http://localhost:3000 && npm run build:electron && cross-env ELECTRON_DEV=1 electron .\"",
     "electron:start": "npm run build:electron && electron .",
     "dist": "npm run build && electron-builder",
+    "test": "node --no-warnings --experimental-strip-types --test tests/*.test.mts",
     "lint": "eslint",
     "postinstall": "node scripts/patch-libraw.mjs && node scripts/ensure-electron.mjs"
   },

--- a/tests/crop-geometry.test.mts
+++ b/tests/crop-geometry.test.mts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyCropDrag,
+  fitCropToAspectRatio,
+  parseAspectRatioInput,
+} from "../lib/develop/crop-geometry.ts";
+
+test("crop drags stay inside the source image", () => {
+  const crop = applyCropDrag(
+    { x: 0.7, y: 0.7, width: 0.25, height: 0.25 },
+    "se",
+    1,
+    1,
+    null,
+  );
+
+  assert.equal(crop.x + crop.width, 1);
+  assert.equal(crop.y + crop.height, 1);
+});
+
+test("locked crops retain their selected aspect ratio", () => {
+  const crop = fitCropToAspectRatio(
+    { x: 0.1, y: 0.1, width: 0.6, height: 0.4 },
+    16 / 9,
+  );
+
+  assert.ok(Math.abs(crop.width / crop.height - 16 / 9) < 0.000001);
+});
+
+test("custom aspect ratios reject invalid input", () => {
+  assert.equal(parseAspectRatioInput("0", "4"), null);
+  assert.equal(parseAspectRatioInput("4", "nope"), null);
+  assert.equal(parseAspectRatioInput("4", "3"), 4 / 3);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Develop view previously showed the Edit panel and Metadata (details) panel side by side, which crowded the layout. This change adds a narrow icon rail on the right so only one panel is visible at a time.

## Changes

- Add `DevelopPanelRail` — vertical icon sidebar with Crop, Edit, and Info buttons
- Add `DevelopSidePanels` — manages mutually exclusive panel visibility
- Add `CropPanel` — dedicated crop/transform controls (split out of Edit)
- Update `EditPanel` to show only basic, curve, mixer, and effects adjustments
- Update `PhotoViewer` to use the new sidebar layout and remove the floating "Hide Info" toggle
- Add `IconCrop` and `IconSliders` for panel buttons

## Behavior

- **Crop**, **Edit**, and **Info** panels are mutually exclusive
- Clicking the active icon collapses the panel for a full-width canvas
- Edit panel opens by default when an image is decoded

## Demo

[develop-panel-sidebar-demo.mp4](https://cursor.com/agents/bc-aa12b557-ca90-430f-86b2-e835aecfdab1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdevelop-panel-sidebar-demo.mp4)

### Edit panel (default)

[Develop Edit panel with adjustment sliders and icon rail](https://cursor.com/agents/bc-aa12b557-ca90-430f-86b2-e835aecfdab1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdevelop-edit-panel.png)

### Crop panel

[Develop Crop panel with transform controls](https://cursor.com/agents/bc-aa12b557-ca90-430f-86b2-e835aecfdab1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdevelop-crop-panel.png)

### Info panel

[Develop Info panel with file metadata](https://cursor.com/agents/bc-aa12b557-ca90-430f-86b2-e835aecfdab1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdevelop-info-panel.png)

## Notes

This branch builds on the raw editing foundation from `cursor/raw-editing-plugins-6c0f`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa12b557-ca90-430f-86b2-e835aecfdab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa12b557-ca90-430f-86b2-e835aecfdab1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

