### PR TITLE
Restore Lightroom editing controls and harden rendering

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,47 @@ body {
   font-size: 13px;
 }
 
+.develop-slider {
+  appearance: none;
+  width: 100%;
+  height: 16px;
+  background: transparent;
+  cursor: ew-resize;
+}
+
+.develop-slider::-webkit-slider-runnable-track {
+  height: 2px;
+  border-radius: 1px;
+  background: var(--develop-slider-track, var(--lr-text-dim));
+}
+
+.develop-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 10px;
+  height: 10px;
+  margin-top: -4px;
+  border: 1px solid var(--lr-bg);
+  border-radius: 50%;
+  background: var(--lr-text-muted);
+}
+
+.develop-slider:hover::-webkit-slider-thumb {
+  background: var(--lr-text);
+}
+
+.develop-slider:focus-visible {
+  outline: none;
+}
+
+.develop-slider:focus-visible::-webkit-slider-thumb {
+  background: var(--lr-text);
+  box-shadow: 0 0 0 2px var(--lr-panel), 0 0 0 3px var(--lr-text-muted);
+}
+
+.develop-slider:disabled {
+  cursor: default;
+}
+
 /* Lightroom-style thin scrollbars */
 ::-webkit-scrollbar {
   width: 8px;

--- a/components/develop/CropPanel.tsx
+++ b/components/develop/CropPanel.tsx
@@ -138,8 +138,8 @@ export function CropPanel({ imageWidth, imageHeight }: CropPanelProps) {
         />
         <SliderRow label="Left" value={crop.x} min={0} max={0.95} step={0.01} disabled={!crop.enabled} onChange={(x) => updateCrop({ x })} />
         <SliderRow label="Top" value={crop.y} min={0} max={0.95} step={0.01} disabled={!crop.enabled} onChange={(y) => updateCrop({ y })} />
-        <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} disabled={!crop.enabled} onChange={(width) => updateCrop({ width })} />
-        <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} disabled={!crop.enabled} onChange={(height) => updateCrop({ height })} />
+        <SliderRow label="Width" value={crop.width} min={0.05} max={1} step={0.01} disabled={!crop.enabled} resetValue={1} onChange={(width) => updateCrop({ width })} />
+        <SliderRow label="Height" value={crop.height} min={0.05} max={1} step={0.01} disabled={!crop.enabled} resetValue={1} onChange={(height) => updateCrop({ height })} />
         <SliderRow label="Perspective X" value={crop.perspectiveX} min={-100} max={100} disabled={!crop.enabled} onChange={(perspectiveX) => updatePlugin("crop", { perspectiveX })} />
         <SliderRow label="Perspective Y" value={crop.perspectiveY} min={-100} max={100} disabled={!crop.enabled} onChange={(perspectiveY) => updatePlugin("crop", { perspectiveY })} />
         <SliderRow label="Distortion" value={crop.distortion} min={-100} max={100} disabled={!crop.enabled} onChange={(distortion) => updatePlugin("crop", { distortion })} />

--- a/components/develop/DevelopCanvas.tsx
+++ b/components/develop/DevelopCanvas.tsx
@@ -71,25 +71,28 @@ export function DevelopCanvas({ image, alt }: DevelopCanvasProps) {
     if (!canvas || !renderer || !container || !ready) {
       return;
     }
-    const currentCanvas = canvas;
     const currentContainer = container;
     const currentRenderer = renderer;
 
-    function render() {
-      if (!currentCanvas || !currentContainer) {
-        return;
-      }
+    function resize() {
       currentRenderer.resize(
         currentContainer.clientWidth,
         currentContainer.clientHeight,
       );
-      currentRenderer.render(settings, showOriginal);
+      const state = useDevelopStore.getState();
+      currentRenderer.render(state.settings, state.showOriginal);
     }
 
-    render();
-    const observer = new ResizeObserver(render);
+    resize();
+    const observer = new ResizeObserver(resize);
     observer.observe(currentContainer);
     return () => observer.disconnect();
+  }, [ready]);
+
+  useEffect(() => {
+    if (ready) {
+      rendererRef.current?.render(settings, showOriginal);
+    }
   }, [settings, showOriginal, ready]);
 
   useEffect(() => {

--- a/components/develop/EditPanel.tsx
+++ b/components/develop/EditPanel.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { DEVELOP_PLUGINS, DEFAULT_DEVELOP_SETTINGS } from "@/lib/develop/registry";
+import { DEVELOP_PLUGINS } from "@/lib/develop/registry";
 import { MIXER_COLORS } from "@/lib/develop/plugins/mixer";
 import type { DevelopPluginId, MixerColor } from "@/lib/develop/types";
 import { useDevelopStore } from "@/stores/develop-store";
 import { SliderRow } from "@/components/develop/SliderRow";
+import { ToneCurveEditor } from "@/components/develop/ToneCurveEditor";
+import { useState } from "react";
 
 const EDIT_PLUGINS = DEVELOP_PLUGINS.filter((plugin) => plugin.id !== "crop");
 
@@ -17,6 +19,37 @@ const MIXER_LABELS: Record<MixerColor, string> = {
   blue: "Blue",
   purple: "Purple",
   magenta: "Magenta",
+};
+
+type MixerMode = "hue" | "saturation" | "luminance" | "all";
+
+const MIXER_MODES: { id: MixerMode; label: string }[] = [
+  { id: "hue", label: "Hue" },
+  { id: "saturation", label: "Saturation" },
+  { id: "luminance", label: "Luminance" },
+  { id: "all", label: "All" },
+];
+
+const COLOR_HEX: Record<MixerColor, string> = {
+  red: "#d64d52",
+  orange: "#df8438",
+  yellow: "#d9c83f",
+  green: "#55a85c",
+  aqua: "#4cb8b5",
+  blue: "#4d78c9",
+  purple: "#8b63c5",
+  magenta: "#c35b9e",
+};
+
+const HUE_TRACKS: Record<MixerColor, string> = {
+  red: "linear-gradient(90deg, #bd4f83, #d64d52, #df7438)",
+  orange: "linear-gradient(90deg, #d64d52, #df8438, #d9b83f)",
+  yellow: "linear-gradient(90deg, #df8438, #d9c83f, #75a94d)",
+  green: "linear-gradient(90deg, #d9c83f, #55a85c, #45aaa0)",
+  aqua: "linear-gradient(90deg, #55a85c, #4cb8b5, #4d8bc9)",
+  blue: "linear-gradient(90deg, #4cb8b5, #4d78c9, #7767c6)",
+  purple: "linear-gradient(90deg, #4d78c9, #8b63c5, #bd5aa7)",
+  magenta: "linear-gradient(90deg, #8b63c5, #c35b9e, #d64d52)",
 };
 
 export function EditPanel() {
@@ -88,11 +121,10 @@ function PluginSection({
 function BasicControls() {
   const basic = useDevelopStore((state) => state.settings.basic);
   const updatePlugin = useDevelopStore((state) => state.updatePlugin);
-  const defaults = DEFAULT_DEVELOP_SETTINGS.basic;
 
   return (
     <div>
-      <SliderRow label="Exposure" value={basic.exposure} min={-5} max={5} step={0.05} onChange={(exposure) => updatePlugin("basic", { exposure })} onReset={() => updatePlugin("basic", { exposure: defaults.exposure })} />
+      <SliderRow label="Exposure" value={basic.exposure} min={-5} max={5} step={0.05} onChange={(exposure) => updatePlugin("basic", { exposure })} />
       <SliderRow label="Contrast" value={basic.contrast} min={-100} max={100} onChange={(contrast) => updatePlugin("basic", { contrast })} />
       <SliderRow label="Highlights" value={basic.highlights} min={-100} max={100} onChange={(highlights) => updatePlugin("basic", { highlights })} />
       <SliderRow label="Shadows" value={basic.shadows} min={-100} max={100} onChange={(shadows) => updatePlugin("basic", { shadows })} />
@@ -110,31 +142,75 @@ function CurveControls() {
   const curve = useDevelopStore((state) => state.settings.curve);
   const updatePlugin = useDevelopStore((state) => state.updatePlugin);
 
-  return (
-    <div>
-      <SliderRow label="Shadows" value={curve.shadows} min={-100} max={100} onChange={(shadows) => updatePlugin("curve", { shadows })} />
-      <SliderRow label="Midtones" value={curve.midtones} min={-100} max={100} onChange={(midtones) => updatePlugin("curve", { midtones })} />
-      <SliderRow label="Highlights" value={curve.highlights} min={-100} max={100} onChange={(highlights) => updatePlugin("curve", { highlights })} />
-    </div>
-  );
+  return <ToneCurveEditor settings={curve} onChange={(settings) => updatePlugin("curve", settings)} />;
 }
 
 function MixerControls() {
+  const [mode, setMode] = useState<MixerMode>("hue");
   const mixer = useDevelopStore((state) => state.settings.mixer);
   const updatePlugin = useDevelopStore((state) => state.updatePlugin);
 
-  return (
-    <div className="space-y-3">
+  const rows = (property: Exclude<MixerMode, "all">) => (
+    <div>
       {MIXER_COLORS.map((color) => (
-        <div key={color}>
-          <h3 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
-            {MIXER_LABELS[color]}
-          </h3>
-          <SliderRow label="Hue" value={mixer[color].hue} min={-100} max={100} onChange={(hue) => updatePlugin("mixer", { [color]: { ...mixer[color], hue } })} />
-          <SliderRow label="Sat" value={mixer[color].saturation} min={-100} max={100} onChange={(saturation) => updatePlugin("mixer", { [color]: { ...mixer[color], saturation } })} />
-          <SliderRow label="Lum" value={mixer[color].luminance} min={-100} max={100} onChange={(luminance) => updatePlugin("mixer", { [color]: { ...mixer[color], luminance } })} />
-        </div>
+        <SliderRow
+          key={color}
+          label={MIXER_LABELS[color]}
+          value={mixer[color][property]}
+          min={-100}
+          max={100}
+          track={
+            property === "hue"
+              ? HUE_TRACKS[color]
+              : property === "saturation"
+                ? `linear-gradient(90deg, #555, ${COLOR_HEX[color]})`
+                : `linear-gradient(90deg, #151515, ${COLOR_HEX[color]}, #e8e8e8)`
+          }
+          onChange={(value) =>
+            updatePlugin("mixer", {
+              [color]: { ...mixer[color], [property]: value },
+            })
+          }
+        />
       ))}
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="mb-2 grid grid-cols-4 border-b border-lr-border-subtle" role="tablist" aria-label="HSL adjustment">
+        {MIXER_MODES.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={mode === item.id}
+            onClick={() => setMode(item.id)}
+            className={`border-b px-1 py-1.5 text-[10px] ${
+              mode === item.id
+                ? "border-lr-text-muted text-lr-text"
+                : "border-transparent text-lr-text-dim hover:text-lr-text-muted"
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      {mode === "all" ? (
+        <div className="space-y-3">
+          {(["hue", "saturation", "luminance"] as const).map((property) => (
+            <section key={property}>
+              <h3 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-lr-text-dim">
+                {property}
+              </h3>
+              {rows(property)}
+            </section>
+          ))}
+        </div>
+      ) : (
+        rows(mode)
+      )}
     </div>
   );
 }

--- a/components/develop/SliderRow.tsx
+++ b/components/develop/SliderRow.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { CSSProperties } from "react";
+
 interface SliderRowProps {
   label: string;
   value: number;
@@ -8,8 +10,9 @@ interface SliderRowProps {
   step?: number;
   suffix?: string;
   disabled?: boolean;
+  resetValue?: number;
+  track?: string;
   onChange: (value: number) => void;
-  onReset?: () => void;
 }
 
 export function SliderRow({
@@ -20,30 +23,43 @@ export function SliderRow({
   step = 1,
   suffix = "",
   disabled = false,
+  resetValue = 0,
+  track,
   onChange,
-  onReset,
 }: SliderRowProps) {
   return (
-    <label
-      className="grid grid-cols-[86px_1fr_42px] items-center gap-2 py-1 text-xs"
-      onDoubleClick={onReset}
-    >
-      <span className="text-lr-text-dim">{label}</span>
+    <div className={`grid grid-cols-[86px_1fr_42px] items-center gap-2 py-1 text-xs ${disabled ? "opacity-40" : ""}`}>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label={`Reset ${label}`}
+        onClick={() => onChange(resetValue)}
+        className="group cursor-pointer select-none rounded-sm text-left text-lr-text-dim hover:text-lr-text-muted focus-visible:outline focus-visible:outline-lr-text-dim disabled:pointer-events-none"
+      >
+        <span aria-hidden="true" className="group-hover:hidden group-focus-visible:hidden">
+          {label}
+        </span>
+        <span aria-hidden="true" className="hidden group-hover:inline group-focus-visible:inline">
+          Reset
+        </span>
+      </button>
       <input
         type="range"
+        aria-label={label}
         min={min}
         max={max}
         step={step}
         value={value}
         disabled={disabled}
         onChange={(event) => onChange(Number(event.target.value))}
-        className="accent-lr-accent"
+        style={track ? ({ "--develop-slider-track": track } as CSSProperties) : undefined}
+        className="develop-slider"
       />
       <span className="text-right font-mono text-[10px] text-lr-text-muted">
         {value > 0 ? "+" : ""}
         {value}
         {suffix}
       </span>
-    </label>
+    </div>
   );
 }

--- a/components/develop/ToneCurveEditor.tsx
+++ b/components/develop/ToneCurveEditor.tsx
@@ -1,0 +1,251 @@
+import { useRef, useState } from "react";
+import type {
+  KeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+} from "react";
+import {
+  DEFAULT_CURVE_SETTINGS,
+  CURVE_LUT_SIZE,
+  sampleCurve,
+} from "@/lib/develop/plugins/curve";
+import type {
+  CurveChannel,
+  CurvePoint,
+  CurveSettings,
+} from "@/lib/develop/types";
+
+const SIZE = 256;
+const INSET = 8;
+const PLOT_SIZE = SIZE - INSET * 2;
+const MIN_GAP = 1 / (CURVE_LUT_SIZE - 1);
+
+const CHANNELS: { id: CurveChannel; label: string; color: string }[] = [
+  { id: "rgb", label: "RGB", color: "#d4d4d4" },
+  { id: "red", label: "R", color: "#ef6767" },
+  { id: "green", label: "G", color: "#62c979" },
+  { id: "blue", label: "B", color: "#69a7f5" },
+];
+
+function svgPoint(point: CurvePoint): { x: number; y: number } {
+  return {
+    x: INSET + point.x * PLOT_SIZE,
+    y: INSET + (1 - point.y) * PLOT_SIZE,
+  };
+}
+
+function pathFor(points: CurvePoint[]): string {
+  return Array.from({ length: CURVE_LUT_SIZE }, (_, index) => {
+    const x = index / (CURVE_LUT_SIZE - 1);
+    const point = svgPoint({ x, y: sampleCurve(points, x) });
+    return `${index === 0 ? "M" : "L"}${point.x} ${point.y}`;
+  }).join(" ");
+}
+
+export function ToneCurveEditor({
+  settings,
+  onChange,
+}: {
+  settings: CurveSettings;
+  onChange: (settings: CurveSettings) => void;
+}) {
+  const [channel, setChannel] = useState<CurveChannel>("rgb");
+  const [selected, setSelected] = useState<number | null>(null);
+  const dragIndex = useRef<number | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const points = settings[channel];
+  const channelInfo = CHANNELS.find((item) => item.id === channel)!;
+
+  const eventPoint = (clientX: number, clientY: number): CurvePoint => {
+    const rect = svgRef.current!.getBoundingClientRect();
+    const x = ((clientX - rect.left) / rect.width) * SIZE;
+    const y = ((clientY - rect.top) / rect.height) * SIZE;
+    return {
+      x: Math.min(1, Math.max(0, (x - INSET) / PLOT_SIZE)),
+      y: Math.min(1, Math.max(0, 1 - (y - INSET) / PLOT_SIZE)),
+    };
+  };
+
+  const commitPoint = (index: number, point: CurvePoint) => {
+    const next = points.map((current, currentIndex) => {
+      if (currentIndex !== index) {
+        return current;
+      }
+      const isFirst = index === 0;
+      const isLast = index === points.length - 1;
+      const minX = isFirst ? 0 : points[index - 1].x + MIN_GAP;
+      const maxX = isLast ? 1 : points[index + 1].x - MIN_GAP;
+      return {
+        x: isFirst ? 0 : isLast ? 1 : Math.min(maxX, Math.max(minX, point.x)),
+        y: point.y,
+      };
+    });
+    onChange({ ...settings, [channel]: next });
+  };
+
+  const addPoint = (event: ReactPointerEvent<SVGSVGElement>) => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    const point = eventPoint(event.clientX, event.clientY);
+    const existingIndex = points.findIndex(
+      (current) => Math.abs(current.x - point.x) < MIN_GAP,
+    );
+    if (existingIndex >= 0) {
+      commitPoint(existingIndex, { ...point, x: points[existingIndex].x });
+      setSelected(existingIndex);
+      dragIndex.current = existingIndex;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      return;
+    }
+    const next = [...points, point].sort((a, b) => a.x - b.x);
+    const index = next.indexOf(point);
+    onChange({ ...settings, [channel]: next });
+    setSelected(index);
+    dragIndex.current = index;
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const removePoint = (index: number) => {
+    if (index === 0 || index === points.length - 1) {
+      return;
+    }
+    onChange({
+      ...settings,
+      [channel]: points.filter((_, pointIndex) => pointIndex !== index),
+    });
+    setSelected(null);
+  };
+
+  const handlePointKey = (event: KeyboardEvent<SVGCircleElement>, index: number) => {
+    if (event.key === "Delete" || event.key === "Backspace") {
+      event.preventDefault();
+      removePoint(index);
+      return;
+    }
+    const step = (event.shiftKey ? 5 : 1) / 255;
+    const point = points[index];
+    const deltaX = event.key === "ArrowLeft" ? -step : event.key === "ArrowRight" ? step : 0;
+    const deltaY = event.key === "ArrowDown" ? -step : event.key === "ArrowUp" ? step : 0;
+    if (deltaX || deltaY) {
+      event.preventDefault();
+      commitPoint(index, {
+        x: point.x + deltaX,
+        y: Math.min(1, Math.max(0, point.y + deltaY)),
+      });
+    }
+  };
+
+  const selectedPoint = selected === null ? null : points[selected];
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex gap-1" role="tablist" aria-label="Tone curve channel">
+          {CHANNELS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={channel === item.id}
+              onClick={() => {
+                setChannel(item.id);
+                setSelected(null);
+              }}
+              className={`min-w-8 rounded-sm border px-2 py-1 text-[10px] font-semibold ${
+                channel === item.id
+                  ? "border-lr-text-dim bg-lr-panel-raised text-lr-text"
+                  : "border-transparent text-lr-text-dim hover:text-lr-text-muted"
+              }`}
+              style={{ color: channel === item.id ? item.color : undefined }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            onChange({
+              ...settings,
+              [channel]: structuredClone(DEFAULT_CURVE_SETTINGS[channel]),
+            });
+            setSelected(null);
+          }}
+          className="text-[10px] text-lr-text-dim hover:text-lr-text-muted"
+        >
+          Reset channel
+        </button>
+      </div>
+
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        role="group"
+        aria-label={`${channelInfo.label} point curve. Click to add a point and drag points to adjust.`}
+        onPointerDown={addPoint}
+        onPointerMove={(event) => {
+          if (dragIndex.current === null) {
+            return;
+          }
+          commitPoint(dragIndex.current, eventPoint(event.clientX, event.clientY));
+        }}
+        onPointerUp={() => {
+          dragIndex.current = null;
+        }}
+        onPointerCancel={() => {
+          dragIndex.current = null;
+        }}
+        className="block w-full touch-none cursor-crosshair rounded-sm border border-lr-border bg-[#181818]"
+      >
+        <rect x={INSET} y={INSET} width={PLOT_SIZE} height={PLOT_SIZE} fill="transparent" pointerEvents="none" />
+        {[0.25, 0.5, 0.75].map((position) => (
+          <g key={position} pointerEvents="none" stroke="#353535" strokeWidth="1">
+            <line x1={INSET + position * PLOT_SIZE} y1={INSET} x2={INSET + position * PLOT_SIZE} y2={SIZE - INSET} />
+            <line x1={INSET} y1={INSET + position * PLOT_SIZE} x2={SIZE - INSET} y2={INSET + position * PLOT_SIZE} />
+          </g>
+        ))}
+        <line x1={INSET} y1={SIZE - INSET} x2={SIZE - INSET} y2={INSET} stroke="#464646" strokeWidth="1" pointerEvents="none" />
+        <path d={pathFor(points)} fill="none" stroke={channelInfo.color} strokeWidth="2" pointerEvents="none" />
+        {points.map((point, index) => {
+          const position = svgPoint(point);
+          return (
+            <circle
+              key={index}
+              cx={position.x}
+              cy={position.y}
+              r={selected === index ? 5 : 4}
+              fill="#1a1a1a"
+              stroke={channelInfo.color}
+              strokeWidth="2"
+              tabIndex={0}
+              role="button"
+              aria-label={`Point ${index + 1}: input ${Math.round(point.x * 255)}, output ${Math.round(point.y * 255)}`}
+              onFocus={() => setSelected(index)}
+              onKeyDown={(event) => handlePointKey(event, index)}
+              onDoubleClick={(event) => {
+                event.stopPropagation();
+                removePoint(index);
+              }}
+              onPointerDown={(event) => {
+                event.stopPropagation();
+                setSelected(index);
+                dragIndex.current = index;
+                event.currentTarget.setPointerCapture(event.pointerId);
+              }}
+              className="cursor-grab outline-none focus-visible:stroke-[3px] active:cursor-grabbing"
+            />
+          );
+        })}
+      </svg>
+
+      <div className="mt-1 flex justify-between text-[10px] text-lr-text-dim">
+        <span>Double-click a point to remove</span>
+        <span className="font-mono">
+          {selectedPoint
+            ? `${Math.round(selectedPoint.x * 255)} / ${Math.round(selectedPoint.y * 255)}`
+            : "Input / Output"}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/viewer/PhotoViewer.tsx
+++ b/components/viewer/PhotoViewer.tsx
@@ -24,6 +24,7 @@ import { exportDevelopJpeg } from "@/lib/develop/renderer";
 import { useDevelopStore } from "@/stores/develop-store";
 import { Filmstrip } from "./Filmstrip";
 import { useEntryMetadataShortcuts } from "@/hooks/useEntryMetadataShortcuts";
+import { isEditableTarget } from "@/hooks/is-editable-target";
 
 interface PhotoViewerProps {
   entry: LibraryEntry;
@@ -136,6 +137,9 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
+      if (event.defaultPrevented || isEditableTarget(event.target)) {
+        return;
+      }
       if (event.key === "ArrowLeft" && activeIndex > 0) {
         router.push(`/photo?id=${encodeURIComponent(entries[activeIndex - 1].id)}`);
       }

--- a/lib/develop/plugins/curve.ts
+++ b/lib/develop/plugins/curve.ts
@@ -1,13 +1,185 @@
-import type { CurveSettings, DevelopPlugin } from "@/lib/develop/types";
+import type {
+  CurveChannel,
+  CurvePoint,
+  CurveSettings,
+  DevelopPlugin,
+  XmpValue,
+} from "@/lib/develop/types";
+
+export const CURVE_CHANNELS: CurveChannel[] = ["rgb", "red", "green", "blue"];
+export const CURVE_LUT_SIZE = 256;
+
+const LINEAR_CURVE: CurvePoint[] = [
+  { x: 0, y: 0 },
+  { x: 1, y: 1 },
+];
 
 export const DEFAULT_CURVE_SETTINGS: CurveSettings = {
-  shadows: 0,
-  midtones: 0,
-  highlights: 0,
+  rgb: LINEAR_CURVE.map((point) => ({ ...point })),
+  red: LINEAR_CURVE.map((point) => ({ ...point })),
+  green: LINEAR_CURVE.map((point) => ({ ...point })),
+  blue: LINEAR_CURVE.map((point) => ({ ...point })),
 };
 
+function clamp(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+export function normalizeCurvePoints(value: unknown): CurvePoint[] {
+  if (!Array.isArray(value)) {
+    return LINEAR_CURVE.map((point) => ({ ...point }));
+  }
+
+  const points = value
+    .filter(
+      (point): point is CurvePoint =>
+        typeof point === "object" &&
+        point !== null &&
+        Number.isFinite((point as CurvePoint).x) &&
+        Number.isFinite((point as CurvePoint).y),
+    )
+    .map((point) => ({ x: clamp(point.x), y: clamp(point.y) }))
+    .sort((a, b) => a.x - b.x);
+
+  const unique = points.filter(
+    (point, index) =>
+      index === points.length - 1 ||
+      Math.round(point.x * 255) !== Math.round(points[index + 1].x * 255),
+  );
+
+  if (unique.length < 2) {
+    return LINEAR_CURVE.map((point) => ({ ...point }));
+  }
+
+  unique[0].x = 0;
+  unique[unique.length - 1].x = 1;
+  return unique;
+}
+
+export function normalizeCurveSettings(value: unknown): CurveSettings {
+  const settings = value as Partial<CurveSettings> & {
+    shadows?: number;
+    midtones?: number;
+    highlights?: number;
+  };
+
+  if (
+    Number.isFinite(settings?.shadows) ||
+    Number.isFinite(settings?.midtones) ||
+    Number.isFinite(settings?.highlights)
+  ) {
+    const legacyPoint = (x: number, adjustment = 0): CurvePoint => ({
+      x: x / 255,
+      y: clamp((x + adjustment) / 255),
+    });
+    return {
+      ...structuredClone(DEFAULT_CURVE_SETTINGS),
+      rgb: [
+        legacyPoint(0),
+        legacyPoint(64, settings.shadows ?? 0),
+        legacyPoint(128, settings.midtones ?? 0),
+        legacyPoint(192, settings.highlights ?? 0),
+        legacyPoint(255),
+      ],
+    };
+  }
+
+  return Object.fromEntries(
+    CURVE_CHANNELS.map((channel) => [
+      channel,
+      normalizeCurvePoints(settings?.[channel]),
+    ]),
+  ) as CurveSettings;
+}
+
+export function sampleCurve(points: CurvePoint[], input: number): number {
+  const value = clamp(input);
+  for (let index = 1; index < points.length; index += 1) {
+    const right = points[index];
+    if (value <= right.x) {
+      const left = points[index - 1];
+      const width = right.x - left.x;
+      if (width === 0) {
+        return left.y;
+      }
+      const amount = (value - left.x) / width;
+      const before = points[Math.max(0, index - 2)];
+      const after = points[Math.min(points.length - 1, index + 1)];
+      const leftWidth = right.x - before.x;
+      const rightWidth = after.x - left.x;
+      let leftSlope = leftWidth === 0 ? 0 : (right.y - before.y) / leftWidth;
+      let rightSlope = rightWidth === 0 ? 0 : (after.y - left.y) / rightWidth;
+      const segmentSlope = (right.y - left.y) / width;
+      if (segmentSlope === 0) {
+        leftSlope = 0;
+        rightSlope = 0;
+      } else {
+        if (leftSlope * segmentSlope < 0) leftSlope = 0;
+        if (rightSlope * segmentSlope < 0) rightSlope = 0;
+        const magnitude = Math.hypot(
+          leftSlope / segmentSlope,
+          rightSlope / segmentSlope,
+        );
+        if (magnitude > 3) {
+          leftSlope *= 3 / magnitude;
+          rightSlope *= 3 / magnitude;
+        }
+      }
+      const squared = amount * amount;
+      const cubed = squared * amount;
+      return clamp(
+        (2 * cubed - 3 * squared + 1) * left.y +
+          (cubed - 2 * squared + amount) * width * leftSlope +
+          (-2 * cubed + 3 * squared) * right.y +
+          (cubed - squared) * width * rightSlope,
+      );
+    }
+  }
+  return points[points.length - 1]?.y ?? value;
+}
+
+export function createCurveLut(settings: CurveSettings): Float32Array {
+  const values = new Float32Array(CURVE_CHANNELS.length * CURVE_LUT_SIZE);
+  for (const [channelIndex, channel] of CURVE_CHANNELS.entries()) {
+    for (let index = 0; index < CURVE_LUT_SIZE; index += 1) {
+      values[index * CURVE_CHANNELS.length + channelIndex] = sampleCurve(
+        settings[channel],
+        index / (CURVE_LUT_SIZE - 1),
+      );
+    }
+  }
+  return values;
+}
+
+function curveProp(points: CurvePoint[]): string[] {
+  return normalizeCurvePoints(points).map(
+    ({ x, y }) => `${Math.round(x * 255)}, ${Math.round(y * 255)}`,
+  );
+}
+
+function parseCurve(value: XmpValue | undefined): CurvePoint[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const pairs = Array.isArray(value) ? value : value.split(";");
+  const points = pairs.map((pair) => {
+    const [x, y] = pair.split(",").map((part) => Number(part.trim()) / 255);
+    return { x, y };
+  });
+  return normalizeCurvePoints(points);
+}
+
 function isDefault(settings: CurveSettings): boolean {
-  return Object.values(settings).every((value) => value === 0);
+  return CURVE_CHANNELS.every((channel) => {
+    const points = settings[channel];
+    return (
+      points.length === 2 &&
+      points[0].x === 0 &&
+      points[0].y === 0 &&
+      points[1].x === 1 &&
+      points[1].y === 1
+    );
+  });
 }
 
 export const curvePlugin: DevelopPlugin<"curve"> = {
@@ -17,29 +189,21 @@ export const curvePlugin: DevelopPlugin<"curve"> = {
   isDefault,
   xmp: {
     write: (settings) => ({
-      "crs:ToneCurvePV2012": [
-        "0, 0",
-        `64, ${Math.round(64 + settings.shadows)}`,
-        `128, ${Math.round(128 + settings.midtones)}`,
-        `192, ${Math.round(192 + settings.highlights)}`,
-        "255, 255",
-      ].join("; "),
+      "crs:ToneCurveName2012": "Custom",
+      "crs:ToneCurvePV2012": curveProp(settings.rgb),
+      "crs:ToneCurvePV2012Red": curveProp(settings.red),
+      "crs:ToneCurvePV2012Green": curveProp(settings.green),
+      "crs:ToneCurvePV2012Blue": curveProp(settings.blue),
     }),
     read: (props) => {
-      const curve = props["crs:ToneCurvePV2012"];
-      if (!curve) {
+      const rgb = parseCurve(props["crs:ToneCurvePV2012"]);
+      const red = parseCurve(props["crs:ToneCurvePV2012Red"]);
+      const green = parseCurve(props["crs:ToneCurvePV2012Green"]);
+      const blue = parseCurve(props["crs:ToneCurvePV2012Blue"]);
+      if (!rgb && !red && !green && !blue) {
         return {};
       }
-      const values = curve
-        .split(";")
-        .map((pair) => pair.split(",").map((value) => Number(value.trim())));
-      const pointAt = (x: number) =>
-        values.find(([pointX]) => pointX === x)?.[1] ?? x;
-      return {
-        shadows: pointAt(64) - 64,
-        midtones: pointAt(128) - 128,
-        highlights: pointAt(192) - 192,
-      };
+      return normalizeCurveSettings({ rgb, red, green, blue });
     },
   },
 };

--- a/lib/develop/plugins/mixer.ts
+++ b/lib/develop/plugins/mixer.ts
@@ -46,7 +46,7 @@ function isDefault(settings: MixerSettings): boolean {
 
 export const mixerPlugin: DevelopPlugin<"mixer"> = {
   id: "mixer",
-  label: "Color Mixer",
+  label: "HSL / Color",
   defaults: DEFAULT_MIXER_SETTINGS,
   isDefault,
   xmp: {

--- a/lib/develop/registry.ts
+++ b/lib/develop/registry.ts
@@ -1,6 +1,9 @@
 import { basicPlugin } from "@/lib/develop/plugins/basic";
 import { cropPlugin } from "@/lib/develop/plugins/crop";
-import { curvePlugin } from "@/lib/develop/plugins/curve";
+import {
+  curvePlugin,
+  normalizeCurveSettings,
+} from "@/lib/develop/plugins/curve";
 import { effectsPlugin } from "@/lib/develop/plugins/effects";
 import { mixerPlugin } from "@/lib/develop/plugins/mixer";
 import type {
@@ -32,7 +35,7 @@ export function createDevelopSettings(
   patch: Partial<DevelopSettings> = {},
 ): DevelopSettings {
   const defaults = structuredClone(DEFAULT_DEVELOP_SETTINGS);
-  return {
+  const settings = {
     ...defaults,
     ...Object.fromEntries(
       Object.entries(patch).map(([pluginId, pluginSettings]) => [
@@ -43,7 +46,9 @@ export function createDevelopSettings(
         },
       ]),
     ),
-  };
+  } as DevelopSettings;
+  settings.curve = normalizeCurveSettings(patch.curve ?? settings.curve);
+  return settings;
 }
 
 export function isDefaultDevelopSettings(settings: DevelopSettings): boolean {

--- a/lib/develop/renderer.ts
+++ b/lib/develop/renderer.ts
@@ -2,6 +2,10 @@ import type { DevelopImage } from "@/lib/cache/develop-image-cache";
 import { clampCropRect } from "@/lib/develop/crop-geometry";
 import type { DevelopSettings } from "@/lib/develop/types";
 import { MIXER_COLORS } from "@/lib/develop/plugins/mixer";
+import {
+  createCurveLut,
+  CURVE_LUT_SIZE,
+} from "@/lib/develop/plugins/curve";
 
 const VERTEX_SHADER = `#version 300 es
 in vec2 a_position;
@@ -50,9 +54,7 @@ uniform float u_tint;
 uniform float u_vibrance;
 uniform float u_saturation;
 
-uniform float u_curve_shadows;
-uniform float u_curve_midtones;
-uniform float u_curve_highlights;
+uniform highp sampler2D u_curve;
 uniform float u_mixer[24];
 uniform float u_vignette;
 uniform float u_grain;
@@ -152,13 +154,28 @@ vec3 adjust_basic(vec3 color) {
   return color;
 }
 
+float sample_curve(float value, int channel) {
+  float position = clamp(value, 0.0, 1.0) * ${CURVE_LUT_SIZE - 1}.0;
+  int low = int(floor(position));
+  int high = min(low + 1, ${CURVE_LUT_SIZE - 1});
+  return mix(
+    texelFetch(u_curve, ivec2(low, 0), 0)[channel],
+    texelFetch(u_curve, ivec2(high, 0), 0)[channel],
+    fract(position)
+  );
+}
+
 vec3 adjust_curve(vec3 color) {
-  float lum = luma(color);
-  float lift =
-    (1.0 - smoothstep(0.0, 0.45, lum)) * u_curve_shadows +
-    (1.0 - abs(lum - 0.5) * 2.0) * u_curve_midtones +
-    smoothstep(0.55, 1.0, lum) * u_curve_highlights;
-  return color + lift * 0.0012;
+  vec3 master = vec3(
+    sample_curve(color.r, 0),
+    sample_curve(color.g, 0),
+    sample_curve(color.b, 0)
+  );
+  return vec3(
+    sample_curve(master.r, 1),
+    sample_curve(master.g, 2),
+    sample_curve(master.b, 3)
+  );
 }
 
 vec3 rgb_to_hsl(vec3 c) {
@@ -202,16 +219,33 @@ vec3 hsl_to_rgb(vec3 hsl) {
 }
 
 vec3 adjust_mixer(vec3 color) {
+  const float centers[8] = float[8](
+    0.0,
+    0.0833333333,
+    0.1666666667,
+    0.3333333333,
+    0.5,
+    0.6666666667,
+    0.75,
+    0.8333333333
+  );
   vec3 hsl = rgb_to_hsl(clamp(color, 0.0, 1.0));
+  float source_hue = hsl.x;
+  float hue_shift = 0.0;
+  float saturation_scale = 1.0;
+  float luminance_shift = 0.0;
   for (int i = 0; i < 8; i++) {
-    float center = float(i) / 8.0;
-    float distance = min(abs(hsl.x - center), 1.0 - abs(hsl.x - center));
+    float center = centers[i];
+    float distance = min(abs(source_hue - center), 1.0 - abs(source_hue - center));
     float weight = smoothstep(0.18, 0.0, distance);
     int base = i * 3;
-    hsl.x = fract(hsl.x + u_mixer[base] * weight / 360.0);
-    hsl.y = clamp(hsl.y * (1.0 + u_mixer[base + 1] * weight * 0.01), 0.0, 1.0);
-    hsl.z = clamp(hsl.z + u_mixer[base + 2] * weight * 0.005, 0.0, 1.0);
+    hue_shift += u_mixer[base] * weight / 360.0;
+    saturation_scale += u_mixer[base + 1] * weight * 0.01;
+    luminance_shift += u_mixer[base + 2] * weight * 0.005;
   }
+  hsl.x = fract(source_hue + hue_shift);
+  hsl.y = clamp(hsl.y * saturation_scale, 0.0, 1.0);
+  hsl.z = clamp(hsl.z + luminance_shift, 0.0, 1.0);
   return hsl_to_rgb(hsl);
 }
 
@@ -239,14 +273,16 @@ void main() {
     return;
   }
 
-  vec3 neighbors =
-    sample_image(clamp(uv + vec2(u_source_texel.x, 0.0), min_uv, max_uv)) +
-    sample_image(clamp(uv - vec2(u_source_texel.x, 0.0), min_uv, max_uv)) +
-    sample_image(clamp(uv + vec2(0.0, u_source_texel.y), min_uv, max_uv)) +
-    sample_image(clamp(uv - vec2(0.0, u_source_texel.y), min_uv, max_uv));
-  vec3 average = neighbors * 0.25;
-  center = mix(center, average, u_noise_reduction * 0.003);
-  center += (center - average) * u_sharpening * 0.015;
+  if (u_noise_reduction > 0.0 || u_sharpening > 0.0) {
+    vec3 neighbors =
+      sample_image(clamp(uv + vec2(u_source_texel.x, 0.0), min_uv, max_uv)) +
+      sample_image(clamp(uv - vec2(u_source_texel.x, 0.0), min_uv, max_uv)) +
+      sample_image(clamp(uv + vec2(0.0, u_source_texel.y), min_uv, max_uv)) +
+      sample_image(clamp(uv - vec2(0.0, u_source_texel.y), min_uv, max_uv));
+    vec3 average = neighbors * 0.25;
+    center = mix(center, average, u_noise_reduction * 0.003);
+    center += (center - average) * u_sharpening * 0.015;
+  }
 
   vec3 color = adjust_basic(center);
   color = adjust_curve(color);
@@ -313,6 +349,8 @@ export class DevelopRenderer {
   private readonly integerProgram: WebGLProgram;
   private activeProgram: WebGLProgram;
   private readonly geometry: WebGLBuffer;
+  private readonly curveTexture: WebGLTexture;
+  private curveSettings: DevelopSettings["curve"] | null = null;
   private texture: WebGLTexture | null = null;
   private textureWidth = 1;
   private textureHeight = 1;
@@ -322,8 +360,8 @@ export class DevelopRenderer {
   private inputLinear = false;
   private orientation = 1;
 
-  constructor(canvas: HTMLCanvasElement) {
-    const gl = canvas.getContext("webgl2", { preserveDrawingBuffer: true });
+  constructor(canvas: HTMLCanvasElement, preserveDrawingBuffer = false) {
+    const gl = canvas.getContext("webgl2", { preserveDrawingBuffer });
     if (!gl) {
       throw new Error("WebGL2 is not available.");
     }
@@ -333,8 +371,34 @@ export class DevelopRenderer {
     this.program = createProgram(gl);
     this.integerProgram = createProgram(gl, true);
     this.activeProgram = this.program;
+    const curveTexture = gl.createTexture();
+    if (!curveTexture) {
+      gl.deleteProgram(this.program);
+      gl.deleteProgram(this.integerProgram);
+      throw new Error("Could not create curve texture.");
+    }
+    this.curveTexture = curveTexture;
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, curveTexture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA32F,
+      CURVE_LUT_SIZE,
+      1,
+      0,
+      gl.RGBA,
+      gl.FLOAT,
+      null,
+    );
+    gl.activeTexture(gl.TEXTURE0);
     const geometry = gl.createBuffer();
     if (!geometry) {
+      gl.deleteTexture(this.curveTexture);
       gl.deleteProgram(this.program);
       gl.deleteProgram(this.integerProgram);
       throw new Error("Could not create WebGL geometry.");
@@ -396,6 +460,7 @@ export class DevelopRenderer {
       throw new Error("Could not create WebGL texture.");
     }
 
+    gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
@@ -541,9 +606,7 @@ export class DevelopRenderer {
     this.uniform1f("u_vibrance", settings.basic.vibrance);
     this.uniform1f("u_saturation", settings.basic.saturation);
 
-    this.uniform1f("u_curve_shadows", settings.curve.shadows);
-    this.uniform1f("u_curve_midtones", settings.curve.midtones);
-    this.uniform1f("u_curve_highlights", settings.curve.highlights);
+    this.uniformCurve(settings);
     this.uniformMixer(settings);
     this.uniform1f("u_vignette", settings.effects.vignette);
     this.uniform1f("u_grain", settings.effects.grain);
@@ -579,6 +642,7 @@ export class DevelopRenderer {
       this.texture = null;
     }
     this.gl.deleteBuffer(this.geometry);
+    this.gl.deleteTexture(this.curveTexture);
     this.gl.deleteProgram(this.program);
     this.gl.deleteProgram(this.integerProgram);
   }
@@ -609,6 +673,28 @@ export class DevelopRenderer {
     }
     const location = this.gl.getUniformLocation(this.activeProgram, "u_mixer");
     this.gl.uniform1fv(location, values);
+  }
+
+  private uniformCurve(settings: DevelopSettings): void {
+    const gl = this.gl;
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.curveTexture);
+    if (settings.curve !== this.curveSettings) {
+      gl.texSubImage2D(
+        gl.TEXTURE_2D,
+        0,
+        0,
+        0,
+        CURVE_LUT_SIZE,
+        1,
+        gl.RGBA,
+        gl.FLOAT,
+        createCurveLut(settings.curve),
+      );
+      this.curveSettings = settings.curve;
+    }
+    this.uniform1i("u_curve", 1);
+    gl.activeTexture(gl.TEXTURE0);
   }
 
   private uniform1i(name: string, value: number): void {
@@ -661,7 +747,7 @@ export async function exportDevelopJpeg(
   }
 
   const canvas = document.createElement("canvas");
-  const renderer = new DevelopRenderer(canvas);
+  const renderer = new DevelopRenderer(canvas, true);
   try {
     await renderer.setImage(image);
     renderer.resize(width, height);

--- a/lib/develop/types.ts
+++ b/lib/develop/types.ts
@@ -28,11 +28,14 @@ export interface CropSettings {
   customAspectHeight: number;
 }
 
-export interface CurveSettings {
-  shadows: number;
-  midtones: number;
-  highlights: number;
+export type CurveChannel = "rgb" | "red" | "green" | "blue";
+
+export interface CurvePoint {
+  x: number;
+  y: number;
 }
+
+export type CurveSettings = Record<CurveChannel, CurvePoint[]>;
 
 export type MixerColor =
   | "red"
@@ -72,9 +75,12 @@ export type DevelopPluginId = keyof DevelopSettings;
 export type DevelopPluginSettings<T extends DevelopPluginId> =
   DevelopSettings[T];
 
+export type XmpValue = string | string[];
+export type XmpProps = Record<string, XmpValue>;
+
 export interface XmpPluginAdapter<T extends DevelopPluginId> {
-  write(settings: DevelopSettings[T]): Record<string, string>;
-  read(props: Record<string, string>): Partial<DevelopSettings[T]>;
+  write(settings: DevelopSettings[T]): XmpProps;
+  read(props: XmpProps): Partial<DevelopSettings[T]>;
 }
 
 export interface DevelopPlugin<T extends DevelopPluginId> {

--- a/lib/develop/xmp-value.ts
+++ b/lib/develop/xmp-value.ts
@@ -1,7 +1,10 @@
+import type { XmpProps } from "@/lib/develop/types";
+
 export function numberProp(
-  props: Record<string, string>,
+  props: XmpProps,
   key: string,
 ): number | null {
-  const value = Number(props[key]);
+  const prop = props[key];
+  const value = typeof prop === "string" ? Number(prop) : Number.NaN;
   return Number.isFinite(value) ? value : null;
 }

--- a/lib/develop/xmp.ts
+++ b/lib/develop/xmp.ts
@@ -5,7 +5,11 @@ import {
   createDevelopSettings,
   isDefaultDevelopSettings,
 } from "@/lib/develop/registry";
-import type { DevelopSettings } from "@/lib/develop/types";
+import type {
+  DevelopSettings,
+  XmpProps,
+  XmpValue,
+} from "@/lib/develop/types";
 
 const RDF_NS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 const CRS_NS = "http://ns.adobe.com/camera-raw-settings/1.0/";
@@ -17,12 +21,51 @@ export interface ParsedDevelopXmp {
   colorLabel?: EntryMetadata["colorLabel"];
 }
 
-function collectDevelopProps(settings: DevelopSettings): Record<string, string> {
-  const props: Record<string, string> = {};
+function collectDevelopProps(settings: DevelopSettings): XmpProps {
+  const props: XmpProps = {};
   for (const plugin of DEVELOP_PLUGINS) {
     Object.assign(props, plugin.xmp.write(settings[plugin.id] as never));
   }
   return props;
+}
+
+function propNamespace(key: string): string {
+  return key.startsWith("xmp:") ? XMP_NS : CRS_NS;
+}
+
+function propLocalName(key: string): string {
+  return key.slice(key.indexOf(":") + 1);
+}
+
+function setProp(
+  doc: XMLDocument,
+  description: Element,
+  key: string,
+  value: XmpValue,
+): void {
+  const namespace = propNamespace(key);
+  const localName = propLocalName(key);
+  description.removeAttributeNS(namespace, localName);
+  for (const child of Array.from(description.children)) {
+    if (child.namespaceURI === namespace && child.localName === localName) {
+      child.remove();
+    }
+  }
+
+  if (typeof value === "string") {
+    description.setAttributeNS(namespace, key, value);
+    return;
+  }
+
+  const property = doc.createElementNS(namespace, key);
+  const sequence = doc.createElementNS(RDF_NS, "rdf:Seq");
+  for (const item of value) {
+    const entry = doc.createElementNS(RDF_NS, "rdf:li");
+    entry.textContent = item;
+    sequence.append(entry);
+  }
+  property.append(sequence);
+  description.append(property);
 }
 
 function createXmpDocument(): XMLDocument {
@@ -69,7 +112,7 @@ export function serializeDevelopXmp(
   description.setAttribute("xmlns:xmp", XMP_NS);
 
   for (const [key, value] of Object.entries(collectDevelopProps(settings))) {
-    description.setAttributeNS(CRS_NS, key, value);
+    setProp(doc, description, key, value);
   }
   description.setAttributeNS(XMP_NS, "xmp:Rating", String(metadata.rating));
   if (metadata.colorLabel) {
@@ -82,9 +125,9 @@ export function serializeDevelopXmp(
   return new XMLSerializer().serializeToString(doc);
 }
 
-function extractAttributes(xml: string): Record<string, string> {
+function extractProps(xml: string): XmpProps {
   const description = descriptionFor(parseXmpDocument(xml));
-  return Array.from(description.attributes).reduce<Record<string, string>>(
+  const props = Array.from(description.attributes).reduce<XmpProps>(
     (props, attribute) => {
       if (attribute.name.startsWith("crs:") || attribute.name.startsWith("xmp:")) {
         props[attribute.name] = attribute.value;
@@ -93,6 +136,25 @@ function extractAttributes(xml: string): Record<string, string> {
     },
     {},
   );
+
+  for (const child of Array.from(description.children)) {
+    const prefix = child.namespaceURI === CRS_NS
+      ? "crs"
+      : child.namespaceURI === XMP_NS
+        ? "xmp"
+        : null;
+    if (!prefix) {
+      continue;
+    }
+    const items = Array.from(child.getElementsByTagNameNS(RDF_NS, "li"));
+    if (items.length) {
+      props[`${prefix}:${child.localName}`] = items.map(
+        (item) => item.textContent?.trim() ?? "",
+      );
+    }
+  }
+
+  return props;
 }
 
 function parseRating(value: string | undefined): EntryMetadata["rating"] | undefined {
@@ -117,7 +179,7 @@ function parseColorLabel(
 }
 
 export function parseDevelopXmp(xml: string): ParsedDevelopXmp {
-  const props = extractAttributes(xml);
+  const props = extractProps(xml);
   const patch: Partial<DevelopSettings> = {};
 
   for (const plugin of DEVELOP_PLUGINS) {
@@ -126,7 +188,11 @@ export function parseDevelopXmp(xml: string): ParsedDevelopXmp {
 
   return {
     settings: createDevelopSettings(patch),
-    rating: parseRating(props["xmp:Rating"]),
-    colorLabel: parseColorLabel(props["xmp:Label"]),
+    rating: parseRating(
+      typeof props["xmp:Rating"] === "string" ? props["xmp:Rating"] : undefined,
+    ),
+    colorLabel: parseColorLabel(
+      typeof props["xmp:Label"] === "string" ? props["xmp:Label"] : undefined,
+    ),
   };
 }


### PR DESCRIPTION
## Summary

- restore the custom Lightroom-style sliders, RGB tone curve, HSL controls, curve LUT rendering, and XMP round-tripping removed by the accidental pre-PR tree rollback
- prevent editing arrow keys from navigating between photos and restore valid crop dimension resets
- make HSL mixing order-independent, skip unused neighbor sampling, keep resize observation stable during edits, and retain WebGL buffers only for export

## Root cause

Commit `5b89f79` restored the exact tree from before PR #10 while describing the tone-curve implementation as unused. The editor recovery brings back the merged implementation and addresses the review findings discovered after restoration.

## Impact

The tone curve and HSL editor are visible and functional again. Slider and keyboard editing no longer trigger unrelated navigation, crop resets remain valid, and the live preview avoids unnecessary observer churn, framebuffer retention, and default texture reads.

## Validation

- targeted ESLint on all changed TypeScript and TSX files
- `npm run build`
- Electron runtime launch with a photo opened in Develop; tone curve and HSL controls rendered and the WebGL shader compiled without editor errors
