### PR TITLE
Add configurable photo export workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,45 @@
 <!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+
 <!-- END:nextjs-agent-rules -->
+
+# Model use
+
+Always follow this section when orchestrating work or delegating to subagents. The pattern is: **write the code with the cheap model, then debug and review it with the expensive ones.**
+
+Scores are 1–10, higher is better. Cost is value for money (higher = cheaper), intelligence is capability.
+
+| Model                  | Cost | Intelligence | Use for                                                                                                                                              |
+| ---------------------- | ---- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gpt-5.6-sol` (high)   | 1    | 9            | Last resort. Hard debugging, subtle correctness or security problems, and tasks the other models have already failed at.                             |
+| Claude Opus 5 (high)   | 2    | 8            | Orchestration, task breakdown, planning, and architecture. Reviews the finished work and owns changes touching auth, permissions, or the data model. |
+| `gpt-5.6-sol` (medium) | 4    | 7            | First escalation. Reviewing and debugging luna's output, and bug fixes luna could not land.                                                          |
+| `gpt-5.6-luna` (max)   | 7    | 5            | **Default workhorse.** All delegated implementation: features, refactors, tests, boilerplate, Danish text, docs.                                     |
+
+Rules:
+
+- Delegate implementation to luna by default. Only write the code yourself or with a stronger model when luna has already failed at it, or when it touches auth, permissions, or the data model.
+- Every delegated change gets a review pass from a stronger model afterwards. This is the normal flow, not an exception — cheap generation is only safe because review follows it.
+- Escalate one step at a time on failure: luna → terra → Opus 5 → sol. Escalate on an actual failure, not in anticipation of one.
+- Orchestration, task decomposition, and the final review stay with Opus 5 even though the implementation runs on luna.
+- Never delegate a task that the orchestrator has not fully specified. luna does exactly what it is told, so the quality of the output is the quality of the task definition.
+- Run independent subtasks in parallel instead of chaining them through one expensive model.
+- State the chosen model and the reason when delegating, so the choice can be corrected.
+
+## Breaking down tasks before delegating
+
+Before sending anything to a subagent, split the work into tasks that are independently verifiable, and write each one out with:
+
+1. **Goal** — what must be true when the task is done.
+2. **Scope** — the files or modules to change, and what is explicitly out of scope.
+3. **Context** — the relevant rules from this file (Danish UI text, organization scoping, server-side permission checks, shadcn/ui, Convex guidelines) and any existing pattern to copy.
+4. **Constraints** — APIs, contracts, or schemas that must not change.
+5. **Verification** — the command, test, or observable behaviour that proves it works.
+
+If a task cannot be described this way, it is not ready to delegate: investigate it first, or split it further.
 
 ## Cursor Cloud specific instructions
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,6 +31,7 @@ import { useLibraryGridShortcuts } from "@/hooks/useEntryMetadataShortcuts";
 import { useAlbumPickerShortcut } from "@/hooks/useAlbumPickerShortcut";
 import { useLibraryContextMenu } from "@/hooks/useLibraryContextMenu";
 import { useLibraryStore } from "@/stores/library-store";
+import { ExportDialog } from "@/components/export/ExportDialog";
 
 export default function HomePage() {
   const router = useRouter();
@@ -63,6 +64,7 @@ export default function HomePage() {
   const [thumbSize, setThumbSize] = useState(180);
   const [viewMode, setViewMode] = useState<GridViewMode>("grid");
   const [gridRows, setGridRows] = useState<string[][]>([]);
+  const [exportEntryIds, setExportEntryIds] = useState<string[] | null>(null);
 
   const libraryEntries = useMemo(
     () => filterArchivedEntries(entries, archivedEntryIds),
@@ -108,12 +110,12 @@ export default function HomePage() {
   );
 
   const { openContextMenu, contextMenu, actionOverlayOpen } =
-    useLibraryContextMenu(visibleOrder);
+    useLibraryContextMenu(visibleOrder, setExportEntryIds);
 
   const { albumPicker, removePopup, overlayOpen } = useAlbumPickerShortcut({
     selectedEntryId,
     selectedEntryIds,
-    disabled: actionOverlayOpen,
+    disabled: actionOverlayOpen || exportEntryIds !== null,
   });
 
   useLibraryGridShortcuts({
@@ -123,7 +125,7 @@ export default function HomePage() {
     selectedEntryId,
     selectedEntryIds,
     onOpen: (id) => router.push(`/photo?id=${encodeURIComponent(id)}`),
-    disabled: overlayOpen || actionOverlayOpen,
+    disabled: overlayOpen || actionOverlayOpen || exportEntryIds !== null,
     metadataShortcutsDisabled: catalogView.type === "archive",
   });
 
@@ -150,6 +152,7 @@ export default function HomePage() {
             onCurationFilterChange={setCurationFilter}
             onThumbSizeChange={setThumbSize}
             onViewModeChange={setViewMode}
+            onExport={() => setExportEntryIds(selectedEntryIds)}
           />
 
           <main className="min-h-0 flex-1 bg-lr-bg">
@@ -267,6 +270,12 @@ export default function HomePage() {
           </main>
         </div>
       </div>
+      {exportEntryIds ? (
+        <ExportDialog
+          entries={entries.filter((entry) => exportEntryIds.includes(entry.id))}
+          onClose={() => setExportEntryIds(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/develop/useDevelopSettingsSync.ts
+++ b/components/develop/useDevelopSettingsSync.ts
@@ -5,6 +5,7 @@ import type { EntryMetadata } from "@/lib/catalog/types";
 import type { LibraryEntry } from "@/lib/fs/types";
 import { createDevelopSettings, developSettingsHash } from "@/lib/develop/registry";
 import type { DevelopSettings } from "@/lib/develop/types";
+import { resolveDevelopSettings } from "@/lib/export/settings";
 import { readDevelopSidecar, writeDevelopSidecar } from "@/lib/develop/sidecar";
 import { useDevelopStore } from "@/stores/develop-store";
 
@@ -56,7 +57,7 @@ export function useDevelopSettingsSync({
   useEffect(() => {
     let active = true;
     hydratedEntryIdRef.current = null;
-    setActiveEntry(entry.id, metadataRef.current.develop);
+    setActiveEntry(entry.id, resolveDevelopSettings(null, metadataRef.current));
     setSidecarStatus("loading");
     const initialSettings = useDevelopStore.getState().settings;
     const initialSnapshot = snapshot(initialSettings, metadataRef.current);
@@ -83,16 +84,20 @@ export function useDevelopSettingsSync({
             !hasLocalChanges &&
             sidecar.lastModified > metadataRef.current.updatedAt
           ) {
+            const resolvedSettings = resolveDevelopSettings(
+              sidecar,
+              metadataRef.current,
+            );
             const nextMetadata: Partial<EntryMetadata> = {
-              develop: sidecar.settings,
+              develop: resolvedSettings,
               ...(sidecar.rating === undefined ? {} : { rating: sidecar.rating }),
               ...(sidecar.colorLabel === undefined
                 ? {}
                 : { colorLabel: sidecar.colorLabel }),
             };
-            setActiveEntry(entry.id, sidecar.settings);
+            setActiveEntry(entry.id, resolvedSettings);
             applyMetadata(nextMetadata);
-            persisted = snapshot(sidecar.settings, {
+            persisted = snapshot(resolvedSettings, {
               rating: sidecar.rating ?? metadataRef.current.rating,
               colorLabel: sidecar.colorLabel ?? metadataRef.current.colorLabel,
             });

--- a/components/export/ExportDialog.tsx
+++ b/components/export/ExportDialog.tsx
@@ -1,0 +1,650 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { LibraryEntry } from "@/lib/fs/types";
+import { getDarkroomAPI, isElectronApp } from "@/lib/fs/platform";
+import { useLibraryStore } from "@/stores/library-store";
+import {
+  DEFAULT_EXPORT_PREFERENCES as DEFAULT_PREFERENCES,
+  EXPORT_FORMAT_IDS,
+} from "@/lib/export/types";
+import type {
+  ExportConflictBehavior,
+  ExportDestinationRequest,
+  ExportFormatDescriptor,
+  ExportFormatId,
+  ExportPreferences,
+  ExportRevealCapability,
+  ExportSizeOptions,
+} from "@/lib/export/types";
+import { runExportBatch, type ExportBatchSummary, type ExportPhase } from "@/lib/export/runner";
+
+interface ExportDialogProps {
+  entries: LibraryEntry[];
+  onClose: () => void;
+}
+
+type DialogState = "idle" | "running" | "done";
+
+type PersistedExportOptions = Partial<ExportPreferences>;
+
+function defaultSize(): ExportSizeOptions {
+  return { mode: "original" };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Export failed.";
+}
+
+function phaseLabel(phase: ExportPhase | null): string {
+  switch (phase) {
+    case "decoding":
+      return "Decoding";
+    case "rendering":
+      return "Rendering";
+    case "encoding":
+      return "Encoding";
+    default:
+      return "Preparing";
+  }
+}
+
+function validateSuffix(suffix: string): string | null {
+  if (suffix.length > 200) {
+    return "Filename suffix is too long.";
+  }
+  if (suffix.includes("\0") || suffix.includes("/") || suffix.includes("\\") || suffix.includes("..")) {
+    return "Filename suffix cannot contain path separators or '..'.";
+  }
+  return null;
+}
+
+function validateSize(size: ExportSizeOptions): string | null {
+  if (size.mode === "long-edge" || size.mode === "longEdge") {
+    const longEdge = size.longEdge ?? size.pixels;
+    if (typeof longEdge !== "number" || !Number.isInteger(longEdge) || longEdge < 1) {
+      return "Long edge must be a positive whole number.";
+    }
+  }
+  if (size.mode === "fit") {
+    if (!Number.isInteger(size.width) || Number(size.width) < 1) {
+      return "Fit width must be a positive whole number.";
+    }
+    if (!Number.isInteger(size.height) || Number(size.height) < 1) {
+      return "Fit height must be a positive whole number.";
+    }
+  }
+  return null;
+}
+
+function isFormatId(value: unknown): value is ExportFormatId {
+  return typeof value === "string" && (EXPORT_FORMAT_IDS as readonly string[]).includes(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function normalizeSize(value: unknown): ExportSizeOptions {
+  const record = asRecord(value);
+  if (!record) {
+    return defaultSize();
+  }
+
+  if (record.mode === "long-edge" || record.mode === "longEdge") {
+    const longEdge = record.longEdge ?? record.pixels;
+    if (Number.isInteger(longEdge) && Number(longEdge) > 0) {
+      return {
+        mode: "long-edge",
+        longEdge: Number(longEdge),
+        neverUpscale: record.neverUpscale !== false,
+      };
+    }
+  }
+
+  if (record.mode === "fit") {
+    const width = record.width;
+    const height = record.height;
+    if (
+      Number.isInteger(width) && Number(width) > 0 &&
+      Number.isInteger(height) && Number(height) > 0
+    ) {
+      return {
+        mode: "fit",
+        width: Number(width),
+        height: Number(height),
+        neverUpscale: record.neverUpscale !== false,
+      };
+    }
+  }
+
+  return defaultSize();
+}
+
+function normalizePreferences(
+  persisted: PersistedExportOptions | null,
+  available: ExportFormatDescriptor[],
+): ExportPreferences {
+  const next: ExportPreferences = {
+    ...DEFAULT_PREFERENCES,
+    size: defaultSize(),
+  };
+  if (!persisted) {
+    const first = available[0];
+    if (first) {
+      next.format = first.id;
+      next.quality = first.defaultQuality ?? next.quality;
+    }
+    return next;
+  }
+
+  if (
+    isFormatId(persisted.format) &&
+    available.some((candidate) => candidate.id === persisted.format)
+  ) {
+    next.format = persisted.format;
+  } else if (available[0]) {
+    next.format = available[0].id;
+  }
+
+  const selected = available.find((candidate) => candidate.id === next.format);
+  if (
+    typeof persisted.quality === "number" &&
+    Number.isInteger(persisted.quality) &&
+    persisted.quality >= 1 &&
+    persisted.quality <= 100
+  ) {
+    next.quality = persisted.quality;
+  } else {
+    next.quality = selected?.defaultQuality ?? next.quality;
+  }
+  if (typeof persisted.lossless === "boolean") {
+    next.lossless = persisted.lossless && Boolean(selected?.supportsLossless);
+  }
+  next.size = normalizeSize(persisted.size);
+  if (typeof persisted.suffix === "string" && !validateSuffix(persisted.suffix)) {
+    next.suffix = persisted.suffix;
+  }
+  if (
+    persisted.conflict === "rename" ||
+    persisted.conflict === "skip" ||
+    persisted.conflict === "replace"
+  ) {
+    next.conflict = persisted.conflict;
+  }
+  return next;
+}
+
+function safeSuggestedFilename(
+  entry: LibraryEntry | undefined,
+  suffix: string,
+  format: ExportFormatDescriptor,
+): string {
+  const source = entry?.name.replace(/\.[^.]+$/, "") ?? "darkroom-export";
+  const base = source
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_")
+    .replace(/\.\./g, "_")
+    .trim() || "darkroom-export";
+  const safeSuffix = suffix
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_")
+    .replace(/\.\./g, "_");
+  return `${base}${safeSuffix}.${format.extensions[0] ?? "jpg"}`;
+}
+
+export function ExportDialog({ entries, onClose }: ExportDialogProps) {
+  const rootPath = useLibraryStore((state) => state.rootPath);
+  const metadata = useLibraryStore((state) => state.entryMetadata);
+  const [formats, setFormats] = useState<ExportFormatDescriptor[]>([]);
+  const [format, setFormat] = useState<ExportFormatId>(DEFAULT_PREFERENCES.format);
+  const [quality, setQuality] = useState(DEFAULT_PREFERENCES.quality);
+  const [lossless, setLossless] = useState(DEFAULT_PREFERENCES.lossless);
+  const [size, setSize] = useState<ExportSizeOptions>(defaultSize);
+  const [suffix, setSuffix] = useState(DEFAULT_PREFERENCES.suffix);
+  const [conflict, setConflict] = useState<ExportConflictBehavior>(DEFAULT_PREFERENCES.conflict);
+  const [dialogState, setDialogState] = useState<DialogState>("idle");
+  const [formatsLoading, setFormatsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [phase, setPhase] = useState<ExportPhase | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [currentEntry, setCurrentEntry] = useState<LibraryEntry | null>(null);
+  const [summary, setSummary] = useState<ExportBatchSummary | null>(null);
+  const cancelledRef = useRef(false);
+
+  const selectedFormat = useMemo(
+    () => formats.find((candidate) => candidate.id === format) ?? null,
+    [formats, format],
+  );
+
+  useEffect(() => {
+    if (!isElectronApp()) {
+      return;
+    }
+
+    let active = true;
+    const api = getDarkroomAPI();
+    void Promise.all([
+      api.getExportFormats(),
+      api.getExportOptions(),
+    ])
+      .then(([available, persisted]) => {
+        if (!active) {
+          return;
+        }
+        setFormats(available);
+        const next = normalizePreferences(persisted, available);
+        setFormat(next.format);
+        setQuality(next.quality);
+        setLossless(next.lossless);
+        setSize(next.size);
+        setSuffix(next.suffix);
+        setConflict(next.conflict);
+      })
+      .catch((loadError) => {
+        if (active) {
+          setError(errorMessage(loadError));
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setFormatsLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      if (dialogState === "running") {
+        // The current file is allowed to finish; the runner checks this
+        // before starting the next file and leaves the dialog mounted.
+        cancelledRef.current = true;
+        return;
+      }
+      onClose();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [dialogState, onClose]);
+
+  const close = useCallback(() => {
+    if (dialogState === "running") {
+      return;
+    }
+    onClose();
+  }, [dialogState, onClose]);
+
+  const startExport = useCallback(async () => {
+    if (!selectedFormat || entries.length === 0) {
+      return;
+    }
+    if (!rootPath) {
+      setError("No approved photo folder is open.");
+      return;
+    }
+    const sizeError = validateSize(size);
+    const suffixError = validateSuffix(suffix);
+    if (sizeError || suffixError) {
+      setError(sizeError ?? suffixError);
+      return;
+    }
+    if (selectedFormat.supportsQuality && (!Number.isInteger(quality) || quality < 1 || quality > 100)) {
+      setError("Quality must be a whole number from 1 to 100.");
+      return;
+    }
+
+    setError(null);
+    setSummary(null);
+    setDialogState("running");
+    setCurrentIndex(0);
+    setCurrentEntry(null);
+    setPhase(null);
+    cancelledRef.current = false;
+
+    try {
+      const api = getDarkroomAPI();
+      const destinationRequest: ExportDestinationRequest = {
+        count: entries.length,
+        format: selectedFormat.id,
+        suggestedFilename: safeSuggestedFilename(entries[0], suffix, selectedFormat),
+        sources: entries.map((entry) => ({
+          rootPath: rootPath ?? "",
+          relativePath: entry.relativePath,
+        })),
+      };
+      const destination = await api.chooseExportDestination(destinationRequest);
+      if (!destination) {
+        setDialogState("idle");
+        return;
+      }
+
+      const persisted: ExportPreferences = {
+        format,
+        quality,
+        lossless,
+        size,
+        suffix,
+        conflict,
+      };
+      await api.setExportOptions(persisted).catch(() => undefined);
+
+      const result = await runExportBatch({
+        entries,
+        metadata,
+        rootPath,
+        destinationToken: destination.token,
+        options: {
+          format,
+          size,
+          quality: selectedFormat.supportsQuality ? quality : undefined,
+          lossless: selectedFormat.supportsLossless ? lossless : undefined,
+          suffix,
+          conflict,
+        },
+        onProgress: ({ phase: nextPhase, index, entry }) => {
+          setPhase(nextPhase);
+          setCurrentIndex(index);
+          setCurrentEntry(entry);
+        },
+        isCancelled: () => cancelledRef.current,
+      });
+      setSummary(result);
+      setDialogState("done");
+    } catch (exportError) {
+      setError(errorMessage(exportError));
+      setDialogState("idle");
+    }
+  }, [
+    conflict,
+    entries,
+    format,
+    lossless,
+    metadata,
+    quality,
+    rootPath,
+    selectedFormat,
+    size,
+    suffix,
+  ]);
+
+  const showInFolder = useCallback(() => {
+    const capability: ExportRevealCapability | null = summary?.revealCapability ?? null;
+    if (!capability) {
+      return;
+    }
+    void getDarkroomAPI()
+      .showInFolder(capability)
+      .catch((showError: unknown) => setError(errorMessage(showError)));
+  }, [summary]);
+
+  const content = (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/55 p-4" role="presentation">
+      <div
+        className="w-full max-w-[430px] overflow-hidden rounded-lg border border-lr-border bg-lr-panel shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="export-dialog-title"
+      >
+        <div className="flex items-center justify-between border-b border-lr-border-subtle px-4 py-3">
+          <div>
+            <h2 id="export-dialog-title" className="text-sm font-semibold text-lr-text">
+              Export {entries.length} photo{entries.length === 1 ? "" : "s"}
+            </h2>
+            <p className="mt-0.5 text-[11px] text-lr-text-dim">
+              Developed pixels · destination chosen on start
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            disabled={dialogState === "running"}
+            className="rounded px-2 py-1 text-lg leading-none text-lr-text-dim transition hover:bg-lr-panel-raised hover:text-lr-text disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label="Close export dialog"
+          >
+            ×
+          </button>
+        </div>
+
+        {dialogState === "idle" ? (
+          <div className="space-y-3 p-4">
+            {!isElectronApp() ? (
+              <p className="rounded border border-amber-700/40 bg-amber-950/20 px-3 py-2 text-xs text-amber-300">
+                Export is available in the Darkroom desktop app only.
+              </p>
+            ) : null}
+            <Field label="Format">
+              <select
+                value={format}
+                disabled={formatsLoading || formats.length === 0}
+                onChange={(event) => {
+                  const next = event.target.value as ExportFormatId;
+                  const descriptor = formats.find((item) => item.id === next);
+                  setFormat(next);
+                  setLossless(false);
+                  if (descriptor?.defaultQuality) {
+                    setQuality(descriptor.defaultQuality);
+                  }
+                }}
+                className="control"
+              >
+                {formats.length === 0 ? <option>Loading formats…</option> : null}
+                {formats.map((item) => (
+                  <option key={item.id} value={item.id}>{item.label}</option>
+                ))}
+              </select>
+            </Field>
+            {selectedFormat?.supportsQuality ? (
+              <Field label={`Quality · ${quality}`}>
+                <input
+                  type="range"
+                  min={1}
+                  max={100}
+                  value={quality}
+                  onChange={(event) => setQuality(Number(event.target.value))}
+                  className="h-1 w-full cursor-pointer accent-lr-accent"
+                />
+              </Field>
+            ) : null}
+            {selectedFormat?.supportsLossless ? (
+              <label className="flex items-center gap-2 text-xs text-lr-text-muted">
+                <input
+                  type="checkbox"
+                  checked={lossless}
+                  onChange={(event) => setLossless(event.target.checked)}
+                  className="accent-lr-accent"
+                />
+                WebP lossless
+              </label>
+            ) : null}
+            <Field label="Size">
+              <select
+                value={size.mode}
+                onChange={(event) => {
+                  const mode = event.target.value as ExportSizeOptions["mode"];
+                  setSize(mode === "long-edge"
+                    ? { mode, longEdge: 2048, neverUpscale: true }
+                    : mode === "fit"
+                      ? { mode, width: 2048, height: 2048, neverUpscale: true }
+                      : defaultSize());
+                }}
+                className="control"
+              >
+                <option value="original">Original</option>
+                <option value="long-edge">Long edge</option>
+                <option value="fit">Fit within</option>
+              </select>
+            </Field>
+            {size.mode === "long-edge" ? (
+              <Field label="Long edge (px)">
+                <input
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={size.longEdge ?? ""}
+                  onChange={(event) => setSize({ ...size, longEdge: Number(event.target.value) })}
+                  className="control"
+                />
+              </Field>
+            ) : null}
+            {size.mode === "fit" ? (
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Width (px)">
+                  <input
+                    type="number"
+                    min={1}
+                    step={1}
+                    value={size.width ?? ""}
+                    onChange={(event) => setSize({ ...size, width: Number(event.target.value) })}
+                    className="control"
+                  />
+                </Field>
+                <Field label="Height (px)">
+                  <input
+                    type="number"
+                    min={1}
+                    step={1}
+                    value={size.height ?? ""}
+                    onChange={(event) => setSize({ ...size, height: Number(event.target.value) })}
+                    className="control"
+                  />
+                </Field>
+              </div>
+            ) : null}
+            {size.mode !== "original" ? (
+              <label className="flex items-center gap-2 text-xs text-lr-text-muted">
+                <input
+                  type="checkbox"
+                  checked={size.neverUpscale !== false}
+                  onChange={(event) => setSize({ ...size, neverUpscale: event.target.checked })}
+                  className="accent-lr-accent"
+                />
+                Never upscale
+              </label>
+            ) : null}
+            <Field label="Filename suffix">
+              <input
+                type="text"
+                value={suffix}
+                onChange={(event) => setSuffix(event.target.value)}
+                className="control"
+                spellCheck={false}
+              />
+            </Field>
+            <Field label="Existing files">
+              <select
+                value={conflict}
+                onChange={(event) => setConflict(event.target.value as ExportConflictBehavior)}
+                className="control"
+              >
+                <option value="rename">Rename with -2, -3…</option>
+                <option value="skip">Skip</option>
+                <option value="replace">Replace</option>
+              </select>
+            </Field>
+            {error ? <p className="text-xs text-red-400">{error}</p> : null}
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <button type="button" onClick={onClose} className="button-secondary">Cancel</button>
+              <button
+                type="button"
+                onClick={() => void startExport()}
+                disabled={formatsLoading || !selectedFormat || entries.length === 0}
+                className="button-primary"
+              >
+                Start export
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {dialogState === "running" ? (
+          <div className="space-y-4 p-4">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-lr-accent">{phaseLabel(phase)}</span>
+              <span className="text-lr-text-muted">{currentIndex + 1} of {entries.length}</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-lr-panel-raised">
+              <div className="h-full bg-lr-accent transition-all" style={{ width: `${Math.min(100, (currentIndex / Math.max(1, entries.length)) * 100)}%` }} />
+            </div>
+            <p className="truncate text-xs text-lr-text-muted">{currentEntry?.name ?? "Preparing export…"}</p>
+            <div className="flex justify-end">
+              <button type="button" onClick={() => { cancelledRef.current = true; }} className="button-secondary">Cancel after this file</button>
+            </div>
+          </div>
+        ) : null}
+
+        {dialogState === "done" && summary ? (
+          <div className="space-y-4 p-4">
+            <div className="grid grid-cols-3 gap-2 text-center">
+              <SummaryStat label="Exported" value={summary.exported} tone="good" />
+              <SummaryStat label="Skipped" value={summary.skipped} tone="muted" />
+              <SummaryStat label="Failed" value={summary.failed} tone="bad" />
+            </div>
+            {summary.cancelled ? <p className="text-xs text-amber-300">Stopped before the next file.</p> : null}
+            {summary.warnings.length > 0 ? (
+              <div className="rounded border border-amber-700/40 bg-amber-950/20 px-3 py-2 text-xs text-amber-300">
+                <p className="font-medium">Embedded preview warning</p>
+                <p className="mt-1">{summary.warnings.join(" ")}</p>
+              </div>
+            ) : null}
+            {summary.results.some((result) => result.status === "error") ? (
+              <div className="max-h-28 overflow-auto rounded border border-red-900/50 bg-red-950/20 px-3 py-2 text-xs text-red-300">
+                {summary.results.filter((result) => result.status === "error").map((result) => (
+                  <p key={result.entryId}>{result.sourceName}: {result.error}</p>
+                ))}
+              </div>
+            ) : null}
+            {error ? <p className="text-xs text-red-400">{error}</p> : null}
+            <div className="flex items-center justify-end gap-2">
+              {summary.revealCapability ? (
+                <button type="button" onClick={showInFolder} className="button-secondary">Show in folder</button>
+              ) : null}
+              <button type="button" onClick={onClose} className="button-primary">Done</button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+      <style jsx>{`
+        .control { width: 100%; height: 29px; border: 1px solid rgb(71 68 66); border-radius: 4px; background: rgb(43 40 39); padding: 0 8px; color: rgb(236 231 227); font-size: 12px; outline: none; }
+        .control:focus { border-color: rgb(217 160 102); }
+        .button-primary, .button-secondary { height: 29px; border-radius: 4px; padding: 0 11px; font-size: 12px; transition: background .15s, color .15s; }
+        .button-primary { background: rgb(217 160 102); color: rgb(35 27 23); }
+        .button-primary:hover { background: rgb(230 177 120); }
+        .button-primary:disabled { cursor: not-allowed; opacity: .45; }
+        .button-secondary { border: 1px solid rgb(71 68 66); color: rgb(185 177 171); }
+        .button-secondary:hover { background: rgb(56 53 51); color: rgb(236 231 227); }
+      `}</style>
+    </div>
+  );
+
+  return typeof document === "undefined" ? null : createPortal(content, document.body);
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1 text-[11px] text-lr-text-dim">
+      <span>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function SummaryStat({ label, value, tone }: { label: string; value: number; tone: "good" | "muted" | "bad" }) {
+  const textClass = tone === "good" ? "text-green-400" : tone === "bad" ? "text-red-400" : "text-lr-text-muted";
+  return (
+    <div className="rounded border border-lr-border-subtle bg-lr-panel-raised px-2 py-2">
+      <div className={`text-lg font-semibold ${textClass}`}>{value}</div>
+      <div className="text-[10px] text-lr-text-dim">{label}</div>
+    </div>
+  );
+}

--- a/components/library/DynamicPhotoGrid.tsx
+++ b/components/library/DynamicPhotoGrid.tsx
@@ -189,7 +189,7 @@ export function DynamicPhotoGrid({
             return (
               <div
                 key={virtualRow.key}
-                className="absolute left-0 top-0 flex items-stretch"
+                className="absolute left-0 top-0 flex items-start"
                 style={{
                   transform: `translateY(${virtualRow.start}px)`,
                   width: `${containerWidth}px`,

--- a/components/library/PhotoGrid.tsx
+++ b/components/library/PhotoGrid.tsx
@@ -109,7 +109,7 @@ export function PhotoGrid({ entries, thumbSize, onGridRowsChange, onPhotoContext
             return (
               <div
                 key={virtualRow.key}
-                className="absolute left-0 top-0 flex items-stretch"
+                className="absolute left-0 top-0 flex items-start"
                 style={{
                   transform: `translateY(${virtualRow.start}px)`,
                   width: `${containerWidth}px`,

--- a/components/shell/LibraryToolbar.tsx
+++ b/components/shell/LibraryToolbar.tsx
@@ -31,6 +31,7 @@ interface LibraryToolbarProps {
   onCurationFilterChange: (filter: CurationFilter) => void;
   onThumbSizeChange: (size: number) => void;
   onViewModeChange: (mode: GridViewMode) => void;
+  onExport: () => void;
 }
 
 export function LibraryToolbar({
@@ -45,11 +46,13 @@ export function LibraryToolbar({
   onCurationFilterChange,
   onThumbSizeChange,
   onViewModeChange,
+  onExport,
 }: LibraryToolbarProps) {
   const {
     folderName,
     importState,
     needsFolderAccess,
+    selectedEntryIds,
     clearLibrary,
   } = useLibraryStore();
 
@@ -99,6 +102,16 @@ export function LibraryToolbar({
         title="Clear saved library and reset folder access"
       >
         Reset
+      </button>
+
+      <button
+        type="button"
+        onClick={onExport}
+        disabled={selectedEntryIds.length === 0 || needsFolderAccess}
+        className="h-7 rounded bg-lr-panel-raised px-2.5 text-xs text-lr-text transition hover:bg-[#383838] disabled:cursor-not-allowed disabled:opacity-40"
+        title={selectedEntryIds.length === 0 ? "Select photos to export" : "Export selected photos"}
+      >
+        Export selected…
       </button>
 
       <div className="mx-1 h-4 w-px bg-lr-border-subtle" />

--- a/components/viewer/PhotoViewer.tsx
+++ b/components/viewer/PhotoViewer.tsx
@@ -3,11 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { LibraryEntry } from "@/lib/fs/types";
-import { getDarkroomAPI } from "@/lib/fs/platform";
 import type { DevelopImage } from "@/lib/cache/develop-image-cache";
 import {
-  disposeDevelopImage,
-  loadDevelopExportImage,
   loadDevelopImage,
   preloadDevelopImages,
 } from "@/lib/cache/develop-image-cache";
@@ -24,10 +21,10 @@ import {
 import { DevelopSidePanels } from "@/components/develop/DevelopSidePanels";
 import type { DevelopPanelId } from "@/components/develop/DevelopPanelRail";
 import { useDevelopSettingsSync } from "@/components/develop/useDevelopSettingsSync";
-import { exportDevelopJpeg } from "@/lib/develop/renderer";
 import { DEFAULT_CROP_SETTINGS } from "@/lib/develop/plugins/crop";
 import type { CropSettings } from "@/lib/develop/types";
 import { useDevelopStore } from "@/stores/develop-store";
+import { ExportDialog } from "@/components/export/ExportDialog";
 import { Filmstrip } from "./Filmstrip";
 import { useEntryMetadataShortcuts } from "@/hooks/useEntryMetadataShortcuts";
 import { isEditableTarget } from "@/hooks/is-editable-target";
@@ -73,7 +70,7 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
   });
   const developSettings = useDevelopStore((state) => state.settings);
   const updatePlugin = useDevelopStore((state) => state.updatePlugin);
-  const [exportStatus, setExportStatus] = useState<string | null>(null);
+  const [exportOpen, setExportOpen] = useState(false);
 
   useEffect(() => {
     setSelectedEntryId(entry.id);
@@ -116,37 +113,7 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
     };
   }, [entry, entries, activeIndex]);
 
-  useEntryMetadataShortcuts([entry.id]);
-
-  async function exportEditedJpeg() {
-    let exportImage: DevelopImage | null = null;
-    try {
-      setExportStatus("Exporting...");
-      exportImage = await loadDevelopExportImage(entry);
-      const usesEmbeddedFallback = exportImage.metadata.decoderProvenance === "embedded";
-      if (usesEmbeddedFallback) {
-        setExportStatus("Exporting embedded preview — full RAW unavailable...");
-      }
-      const blob = await exportDevelopJpeg(exportImage, developSettings);
-      const targetPath = await getDarkroomAPI().saveExport(
-        entry.name.replace(/\.[^.]+$/, "-darkroom.jpg"),
-        await blob.arrayBuffer(),
-      );
-      setExportStatus(targetPath
-        ? `${usesEmbeddedFallback ? "Exported embedded preview" : "Exported"} ${targetPath}`
-        : usesEmbeddedFallback
-          ? "Export canceled — embedded preview fallback"
-          : "Export canceled");
-    } catch (exportError) {
-      setExportStatus(
-        exportError instanceof Error ? exportError.message : "Export failed.",
-      );
-    } finally {
-      if (exportImage) {
-        disposeDevelopImage(exportImage);
-      }
-    }
-  }
+  useEntryMetadataShortcuts([entry.id], exportOpen);
 
   const discardCrop = useCallback((nextPanel: DevelopPanelId | null = "edit") => {
     cropDraftRef.current = null;
@@ -203,6 +170,11 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
+      // The export dialog owns keyboard handling while it is mounted. In
+      // particular, do not navigate away and unmount an in-flight export.
+      if (exportOpen) {
+        return;
+      }
       if (event.defaultPrevented) {
         return;
       }
@@ -240,7 +212,15 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [entries, activeIndex, router, activePanel, applyCrop, discardCrop]);
+  }, [
+    entries,
+    activeIndex,
+    router,
+    activePanel,
+    applyCrop,
+    discardCrop,
+    exportOpen,
+  ]);
 
   function selectPhoto(id: string) {
     discardCrop("edit");
@@ -275,17 +255,12 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
         <div className="relative flex min-w-0 flex-1 flex-col bg-lr-bg">
           <div className="absolute right-3 top-3 z-10">
             <div className="flex items-center gap-2">
-              {exportStatus ? (
-                <span className="max-w-64 truncate rounded bg-lr-panel/90 px-2 py-1 text-[11px] text-lr-text-dim">
-                  {exportStatus}
-                </span>
-              ) : null}
               <button
                 type="button"
-                onClick={exportEditedJpeg}
+                onClick={() => setExportOpen(true)}
                 className="rounded border border-lr-border-subtle bg-lr-panel/90 px-2.5 py-1 text-[11px] text-lr-text-muted backdrop-blur hover:text-lr-text"
               >
-                Export JPEG
+                Export…
               </button>
             </div>
           </div>
@@ -338,6 +313,9 @@ export function PhotoViewer({ entry, entries }: PhotoViewerProps) {
         activeId={entry.id}
         onSelect={selectPhoto}
       />
+      {exportOpen ? (
+        <ExportDialog entries={[entry]} onClose={() => setExportOpen(false)} />
+      ) : null}
     </div>
   );
 }

--- a/electron/build.mjs
+++ b/electron/build.mjs
@@ -11,7 +11,7 @@ const shared = {
   platform: "node",
   target: "node20",
   sourcemap: true,
-  external: ["electron"],
+  external: ["electron", "sharp"],
 };
 
 await esbuild.build({

--- a/electron/export-service.ts
+++ b/electron/export-service.ts
@@ -1,0 +1,1301 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  DEFAULT_EXPORT_SUFFIX,
+  type ExportEncodeOptions,
+  type ExportEncodeResult,
+  type ExportFormatDescriptor,
+  type ExportFormatId,
+  type ExportPixelPayload,
+  type ExportPixels,
+} from "../lib/export/types";
+
+export type {
+  ExportConflictBehavior,
+  ExportEncodeOptions,
+  ExportEncodeResult,
+  ExportFormatDescriptor,
+  ExportFormatId,
+  ExportPixelPayload,
+  ExportPixels,
+  ExportSizeOptions,
+} from "../lib/export/types";
+import { scanFolderTree } from "./fs-service";
+export type ExportResult = ExportEncodeResult;
+
+export interface ExportDialog {
+  showSaveDialog(options: {
+    title?: string;
+    defaultPath?: string;
+    filters?: Array<{ name: string; extensions: string[] }>;
+  }): Promise<{ canceled: boolean; filePath?: string }>;
+  showOpenDialog(options: {
+    title?: string;
+    properties: Array<"openDirectory">;
+  }): Promise<{ canceled: boolean; filePaths: string[] }>;
+}
+
+export interface ExportDestinationRequest {
+  count: number;
+  format: ExportFormatId;
+  suggestedFilename: string;
+  /** Renderer-selected sources, validated against the main-process scan. */
+  sources?: Array<{
+    rootPath: string;
+    relativePath: string;
+  }>;
+}
+
+export interface ExportFinalizeResult {
+  revealToken: string | null;
+  outputPath: string | null;
+}
+
+export interface ApprovedExportSource {
+  path: string;
+  directory: string;
+  basename: string;
+  device?: number;
+  inode?: number;
+}
+
+const MAX_EXPORT_PIXELS = 50_000_000;
+const MAX_EXPORT_EDGE = 100_000;
+const MAX_FILENAME_LENGTH = 240;
+const MAX_RENAME_ATTEMPTS = 999;
+const MAX_DESTINATIONS = 64;
+const MAX_REVEAL_CAPABILITIES = 64;
+const MAX_PROVENANCE_RECORDS = 4096;
+const DESTINATION_IDLE_TTL_MS = 15 * 60 * 1000;
+const DESTINATION_FINALIZE_GRACE_MS = 30 * 60 * 1000;
+const REVEAL_IDLE_TTL_MS = 30 * 60 * 1000;
+
+const FORMAT_DEFINITIONS: readonly ExportFormatDescriptor[] = [
+  {
+    id: "jpeg",
+    label: "JPEG",
+    extensions: ["jpg", "jpeg"],
+    supportsQuality: true,
+    supportsLossless: false,
+    defaultQuality: 90,
+  },
+  {
+    id: "png",
+    label: "PNG",
+    extensions: ["png"],
+    supportsQuality: false,
+    supportsLossless: false,
+  },
+  {
+    id: "webp",
+    label: "WebP",
+    extensions: ["webp"],
+    supportsQuality: true,
+    supportsLossless: true,
+    defaultQuality: 85,
+  },
+  {
+    id: "avif",
+    label: "AVIF",
+    extensions: ["avif"],
+    supportsQuality: true,
+    supportsLossless: false,
+    defaultQuality: 55,
+  },
+  {
+    id: "tiff",
+    label: "TIFF",
+    extensions: ["tif", "tiff"],
+    supportsQuality: false,
+    supportsLossless: false,
+  },
+];
+
+type SharpModule = typeof import("sharp");
+type SharpFactory = SharpModule;
+
+let sharpModulePromise: Promise<SharpFactory> | null = null;
+
+async function loadSharp(): Promise<SharpFactory> {
+  sharpModulePromise ??= import("sharp").then((module) => {
+    const factory = (module as unknown as { default?: SharpFactory }).default ?? module;
+    return factory as SharpFactory;
+  });
+  return sharpModulePromise;
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === code
+  );
+}
+
+function isAbsolutePathWithin(directory: string, candidate: string): boolean {
+  const relative = path.relative(directory, candidate);
+  return (
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function pathsEqual(left: string, right: string): boolean {
+  const normalizedLeft = path.normalize(left);
+  const normalizedRight = path.normalize(right);
+  return process.platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+function normalizedPathKey(value: string): string {
+  const normalized = path.normalize(path.resolve(value));
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function isNodePath(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && !value.includes("\0");
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  return isAbsolutePathWithin(root, path.resolve(candidate));
+}
+
+function statIdentity(stat: {
+  dev?: number;
+  ino?: number;
+}): Pick<ApprovedExportSource, "device" | "inode"> {
+  const identity: Pick<ApprovedExportSource, "device" | "inode"> = {};
+  if (typeof stat.dev === "number" && Number.isFinite(stat.dev)) {
+    identity.device = stat.dev;
+  }
+  if (typeof stat.ino === "number" && Number.isFinite(stat.ino)) {
+    identity.inode = stat.ino;
+  }
+  return identity;
+}
+
+function sameFileIdentity(
+  left: Pick<ApprovedExportSource, "device" | "inode">,
+  right: Pick<ApprovedExportSource, "device" | "inode">,
+): boolean {
+  return (
+    left.device !== undefined &&
+    left.inode !== undefined &&
+    right.device !== undefined &&
+    right.inode !== undefined &&
+    left.device === right.device &&
+    left.inode === right.inode
+  );
+}
+
+function assertPositiveInteger(value: unknown, label: string): number {
+  if (!Number.isInteger(value) || Number(value) <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return Number(value);
+}
+
+function assertPixelDimensions(width: unknown, height: unknown): {
+  width: number;
+  height: number;
+} {
+  const validWidth = assertPositiveInteger(width, "Export width");
+  const validHeight = assertPositiveInteger(height, "Export height");
+  if (validWidth > MAX_EXPORT_EDGE || validHeight > MAX_EXPORT_EDGE) {
+    throw new Error("Export dimensions are too large.");
+  }
+  if (validWidth * validHeight > MAX_EXPORT_PIXELS) {
+    throw new Error("This edit exceeds the 50 megapixel export limit.");
+  }
+  return { width: validWidth, height: validHeight };
+}
+
+function toBuffer(pixels: ArrayBuffer | Uint8Array): Buffer {
+  if (pixels instanceof Uint8Array) {
+    return Buffer.from(pixels.buffer, pixels.byteOffset, pixels.byteLength);
+  }
+  if (pixels instanceof ArrayBuffer) {
+    return Buffer.from(pixels);
+  }
+  throw new Error("Export pixels must be an ArrayBuffer.");
+}
+
+function normalizePixels(
+  payload: ExportPixels,
+  options: ExportEncodeOptions,
+): { buffer: Buffer; width: number; height: number } {
+  const isPayload =
+    typeof payload === "object" &&
+    payload !== null &&
+    "pixels" in payload &&
+    "width" in payload &&
+    "height" in payload;
+  const pixels = isPayload
+    ? (payload as ExportPixelPayload).pixels
+    : payload;
+  const width = isPayload
+    ? (payload as ExportPixelPayload).width
+    : options.width;
+  const height = isPayload
+    ? (payload as ExportPixelPayload).height
+    : options.height;
+  const dimensions = assertPixelDimensions(width, height);
+  const buffer = toBuffer(pixels as ArrayBuffer | Uint8Array);
+  const expectedBytes = dimensions.width * dimensions.height * 4;
+  if (buffer.byteLength !== expectedBytes) {
+    throw new Error("Export pixel data does not match its dimensions.");
+  }
+  return { buffer, ...dimensions };
+}
+
+function sanitizeFilenamePart(value: string, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string.`);
+  }
+  if (
+    !value ||
+    value.includes("\0") ||
+    value.includes("/") ||
+    value.includes("\\") ||
+    value.includes("..")
+  ) {
+    throw new Error(`${label} contains an invalid path sequence.`);
+  }
+
+  let sanitized = value;
+  if (process.platform === "win32") {
+    sanitized = sanitized.replace(/[<>:"|?*\u0000-\u001f]/g, "_");
+    sanitized = sanitized.replace(/[. ]+$/g, "");
+  } else {
+    sanitized = sanitized.replace(/[\u0000]/g, "_");
+  }
+  sanitized = sanitized.trim();
+  if (!sanitized || sanitized === "." || sanitized === "..") {
+    throw new Error(`${label} is empty after sanitization.`);
+  }
+  if (sanitized.length > MAX_FILENAME_LENGTH) {
+    sanitized = sanitized.slice(0, MAX_FILENAME_LENGTH).trim();
+  }
+  if (process.platform === "win32" && /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(?:\..*)?$/i.test(sanitized)) {
+    sanitized = `_${sanitized}`;
+  }
+  return sanitized;
+}
+
+function sanitizeSuffix(value: unknown): string {
+  if (value === undefined) {
+    return "-darkroom";
+  }
+  if (typeof value !== "string") {
+    throw new Error("Filename suffix must be a string.");
+  }
+  if (value === "") {
+    return "";
+  }
+  return sanitizeFilenamePart(value, "Filename suffix");
+}
+
+function getExtensionForFormat(format: ExportFormatDescriptor): string {
+  return `.${format.extensions[0]}`;
+}
+
+function stripKnownExtension(value: string): string {
+  const extension = path.extname(value).toLowerCase();
+  const knownExtensions = new Set(
+    FORMAT_DEFINITIONS.flatMap((format) =>
+      format.extensions.map((item) => `.${item}`),
+    ),
+  );
+  return knownExtensions.has(extension) ? value.slice(0, -extension.length) : value;
+}
+
+/**
+ * Resolve every supported source in the main-owned active library. The
+ * renderer's selection is intentionally not part of this capability: it may
+ * omit a file or lie about a path, so the complete scan is what protects
+ * source photos from replacement.
+ */
+export async function resolveApprovedExportSources(
+  activeLibraryRoot: string | null,
+): Promise<ApprovedExportSource[]> {
+  if (!activeLibraryRoot || !isNodePath(activeLibraryRoot) || !path.isAbsolute(activeLibraryRoot)) {
+    throw new Error("No approved library folder is open.");
+  }
+
+  const root = await fs.realpath(activeLibraryRoot);
+  const rootStat = await fs.stat(root);
+  if (!rootStat.isDirectory()) {
+    throw new Error("Approved library root is not a directory.");
+  }
+
+  const scannedFiles = await scanFolderTree(root);
+  const sources: ApprovedExportSource[] = [];
+  for (const file of scannedFiles) {
+    const requestedPath = path.resolve(root, file.relativePath);
+    if (!isWithinRoot(root, requestedPath)) {
+      throw new Error("Approved source must stay inside the active library.");
+    }
+
+    const sourcePath = await fs.realpath(requestedPath);
+    if (!isWithinRoot(root, sourcePath)) {
+      throw new Error("Approved source cannot follow a symlink outside the library.");
+    }
+    const sourceStat = await fs.stat(sourcePath);
+    if (!sourceStat.isFile()) {
+      throw new Error("Approved source is not a regular file.");
+    }
+    sources.push({
+      path: sourcePath,
+      directory: path.dirname(sourcePath),
+      basename: path.basename(sourcePath),
+      ...statIdentity(sourceStat),
+    });
+  }
+  return sources;
+}
+
+function normalizeFormatOptions(
+  format: ExportFormatDescriptor,
+  options: ExportEncodeOptions,
+  sourceWidth: number,
+  sourceHeight: number,
+): {
+  quality?: number;
+  lossless: boolean;
+  resize?: { width?: number; height?: number; withoutEnlargement: boolean };
+} {
+  const quality = options.quality ?? format.defaultQuality;
+  if (format.supportsQuality) {
+    if (
+      quality !== undefined &&
+      (!Number.isInteger(quality) || quality < 1 || quality > 100)
+    ) {
+      throw new Error("Export quality must be an integer from 1 to 100.");
+    }
+  } else if (options.quality !== undefined) {
+    throw new Error(`${format.label} does not support quality.`);
+  }
+
+  const lossless = options.lossless ?? false;
+  if (lossless && !format.supportsLossless) {
+    throw new Error(`${format.label} does not support lossless mode.`);
+  }
+
+  const size = options.size;
+  const neverUpscale = options.neverUpscale ?? true;
+  if (!size || size.mode === "original") {
+    return { quality, lossless };
+  }
+
+  if (size.mode === "long-edge" || size.mode === "longEdge") {
+    const edge = assertPositiveInteger(
+      size.longEdge ?? size.pixels,
+      "Long edge",
+    );
+    if (edge > MAX_EXPORT_EDGE) {
+      throw new Error("Long edge is too large.");
+    }
+    const sourceEdge = Math.max(sourceWidth, sourceHeight);
+    const constrainedNeverUpscale = size.neverUpscale ?? neverUpscale;
+    if (constrainedNeverUpscale && edge >= sourceEdge) {
+      return { quality, lossless };
+    }
+    const ratio = edge / sourceEdge;
+    const width = Math.max(1, Math.round(sourceWidth * ratio));
+    const height = Math.max(1, Math.round(sourceHeight * ratio));
+    assertPixelDimensions(width, height);
+    return {
+      quality,
+      lossless,
+      resize: { width, height, withoutEnlargement: constrainedNeverUpscale },
+    };
+  }
+
+  if (size.mode === "fit") {
+    const width = assertPositiveInteger(size.width, "Fit width");
+    const height = assertPositiveInteger(size.height, "Fit height");
+    if (width > MAX_EXPORT_EDGE || height > MAX_EXPORT_EDGE) {
+      throw new Error("Fit dimensions are too large.");
+    }
+    const constrainedNeverUpscale = size.neverUpscale ?? neverUpscale;
+    if (
+      constrainedNeverUpscale &&
+      sourceWidth <= width &&
+      sourceHeight <= height
+    ) {
+      return { quality, lossless };
+    }
+    const ratio = Math.min(width / sourceWidth, height / sourceHeight);
+    const resizedWidth = Math.max(1, Math.round(sourceWidth * ratio));
+    const resizedHeight = Math.max(1, Math.round(sourceHeight * ratio));
+    assertPixelDimensions(resizedWidth, resizedHeight);
+    return {
+      quality,
+      lossless,
+      resize: {
+        width,
+        height,
+        withoutEnlargement: constrainedNeverUpscale,
+      },
+    };
+  }
+
+  throw new Error("Unsupported export size mode.");
+}
+
+function toDestinationPath(
+  directory: string,
+  basename: string,
+  format: ExportFormatDescriptor,
+  suffix: string,
+): string {
+  const safeBase = sanitizeFilenamePart(stripKnownExtension(basename), "Filename");
+  const safeSuffix = sanitizeSuffix(suffix);
+  const fullBase = sanitizeFilenamePart(`${safeBase}${safeSuffix}`, "Filename");
+  return path.resolve(directory, `${fullBase}${getExtensionForFormat(format)}`);
+}
+
+function toSelectedDestinationFilename(
+  basename: string,
+  format: ExportFormatDescriptor,
+): string {
+  const safeBasename = sanitizeFilenamePart(basename, "Filename");
+  const lowerBasename = safeBasename.toLowerCase();
+  const compatible = format.extensions.some((candidate) =>
+    lowerBasename.endsWith(`.${candidate.toLowerCase()}`),
+  );
+  return compatible
+    ? safeBasename
+    : `${safeBasename}${getExtensionForFormat(format)}`;
+}
+
+async function assertDirectory(directory: string): Promise<string> {
+  const resolved = await fs.realpath(directory);
+  const stat = await fs.stat(resolved);
+  if (!stat.isDirectory()) {
+    throw new Error("Export destination is not a directory.");
+  }
+  return resolved;
+}
+
+async function assertSafeTarget(
+  directory: string,
+  targetPath: string,
+  sources: readonly ApprovedExportSource[],
+  options: {
+    selectedSources?: ReadonlySet<string>;
+    isKnownProducedPath?: (
+      targetPath: string,
+      targetIdentity: Pick<ApprovedExportSource, "device" | "inode">,
+    ) => boolean;
+  } = {},
+): Promise<void> {
+  const resolvedTarget = path.resolve(targetPath);
+  if (!isAbsolutePathWithin(directory, resolvedTarget)) {
+    throw new Error("Export target must stay inside the approved folder.");
+  }
+
+  // Compare both canonical paths and filesystem identity. The identity check
+  // catches case-only aliases on case-insensitive filesystems (notably macOS)
+  // where a textual path comparison is insufficient.
+  let targetRealPath: string | null = null;
+  let targetIdentity: Pick<ApprovedExportSource, "device" | "inode"> = {};
+  try {
+    targetRealPath = await fs.realpath(resolvedTarget);
+    const targetStat = await fs.stat(targetRealPath);
+    targetIdentity = statIdentity(targetStat);
+  } catch (error) {
+    if (!isNodeError(error, "ENOENT")) {
+      throw error;
+    }
+  }
+
+  let matchingSource: ApprovedExportSource | null = null;
+  for (const source of sources) {
+    if (
+      pathsEqual(source.path, resolvedTarget) ||
+      (targetRealPath !== null && pathsEqual(source.path, targetRealPath)) ||
+      sameFileIdentity(source, targetIdentity)
+    ) {
+      matchingSource = source;
+    }
+
+    // A missing target cannot have an inode yet. Resolve its parent and retain
+    // the exact source path check above so a raced case-only alias is still
+    // rejected when it becomes visible before the write.
+    try {
+      const targetParent = await fs.realpath(path.dirname(resolvedTarget));
+      if (
+        pathsEqual(targetParent, source.directory) &&
+        pathsEqual(path.basename(resolvedTarget), source.basename)
+      ) {
+        matchingSource = source;
+      }
+    } catch (error) {
+      if (!isNodeError(error, "ENOENT")) {
+        throw error;
+      }
+    }
+  }
+
+  if (!matchingSource) {
+    return;
+  }
+  const selected = options.selectedSources?.has(normalizedPathKey(matchingSource.path)) ?? false;
+  const knownProduced = options.isKnownProducedPath?.(resolvedTarget, targetIdentity) ?? false;
+  if (selected || !knownProduced) {
+    throw new Error("Export cannot overwrite a source photo.");
+  }
+}
+
+async function assertExistingTargetIsSafe(targetPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(targetPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error("Refusing to write through a symbolic-link export target.");
+    }
+    if (!stat.isFile()) {
+      throw new Error("Export target is not a regular file.");
+    }
+    return true;
+  } catch (error) {
+    if (isNodeError(error, "ENOENT")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function writeTempAndRename(
+  targetPath: string,
+  contents: Buffer,
+): Promise<void> {
+  const temporaryPath = path.join(
+    path.dirname(targetPath),
+    `.${path.basename(targetPath)}.${randomUUID()}.tmp`,
+  );
+  try {
+    await fs.writeFile(temporaryPath, contents, { mode: 0o600, flag: "wx" });
+    await fs.rename(temporaryPath, targetPath);
+  } finally {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+async function claimTarget(targetPath: string): Promise<fs.FileHandle | null> {
+  try {
+    return await fs.open(targetPath, "wx", 0o600);
+  } catch (error) {
+    if (isNodeError(error, "EEXIST")) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function chooseRenameTarget(
+  targetPath: string,
+): Promise<{ path: string; claim: fs.FileHandle }> {
+  const extension = path.extname(targetPath);
+  const base = targetPath.slice(0, -extension.length);
+  for (let attempt = 0; attempt < MAX_RENAME_ATTEMPTS; attempt += 1) {
+    const candidate = attempt === 0 ? targetPath : `${base}-${attempt + 1}${extension}`;
+    const claim = await claimTarget(candidate);
+    if (claim) {
+      return { path: candidate, claim };
+    }
+  }
+  throw new Error("Could not find an available export filename.");
+}
+
+async function removeClaimIfOwned(
+  targetPath: string,
+  claimIdentity: Pick<ApprovedExportSource, "device" | "inode">,
+): Promise<void> {
+  try {
+    const current = await fs.stat(targetPath);
+    if (
+      (claimIdentity.device === undefined || claimIdentity.inode === undefined) ||
+      sameFileIdentity(claimIdentity, statIdentity(current))
+    ) {
+      await fs.unlink(targetPath);
+    }
+  } catch {
+    // The claim may already have been replaced or cleaned up.
+  }
+}
+
+async function writeClaimedTarget(
+  targetPath: string,
+  claim: fs.FileHandle,
+  contents: Buffer,
+): Promise<void> {
+  let claimIdentity: Pick<ApprovedExportSource, "device" | "inode"> = {};
+  try {
+    try {
+      claimIdentity = statIdentity(await claim.stat());
+    } finally {
+      await claim.close();
+    }
+    await writeTempAndRename(targetPath, contents);
+  } catch (error) {
+    await removeClaimIfOwned(targetPath, claimIdentity);
+    throw error;
+  }
+}
+
+async function encodePixels(
+  raw: { buffer: Buffer; width: number; height: number },
+  format: ExportFormatDescriptor,
+  options: ExportEncodeOptions,
+): Promise<Buffer> {
+  const sharp = await loadSharp();
+  const normalized = normalizeFormatOptions(format, options, raw.width, raw.height);
+  let image = sharp(raw.buffer, {
+    raw: { width: raw.width, height: raw.height, channels: 4 },
+  }).removeAlpha();
+  if (normalized.resize) {
+    image = image.resize({
+      ...normalized.resize,
+      fit: normalized.resize.width && normalized.resize.height ? "inside" : "cover",
+      kernel: "lanczos3",
+    });
+  }
+
+  switch (format.id) {
+    case "jpeg":
+      return image.jpeg({
+        quality: normalized.quality,
+        mozjpeg: true,
+      }).toBuffer();
+    case "png":
+      return image.png().toBuffer();
+    case "webp":
+      return image.webp({
+        quality: normalized.quality,
+        lossless: normalized.lossless,
+      }).toBuffer();
+    case "avif":
+      return image.avif({ quality: normalized.quality }).toBuffer();
+    case "tiff":
+      return image.tiff({ compression: "lzw", predictor: "horizontal" }).toBuffer();
+    default:
+      throw new Error(`Unsupported export format: ${format.id}`);
+  }
+}
+
+function getSharpCapability(
+  sharp: SharpFactory,
+  formatId: string,
+): boolean {
+  const formats = (sharp as unknown as {
+    format?: Record<
+      string,
+      { output?: boolean | { buffer?: boolean } }
+    >;
+  }).format;
+  const sharpFormatId = formatId === "avif" ? "heif" : formatId;
+  const output = formats?.[sharpFormatId]?.output;
+  return output === true || (typeof output === "object" && output.buffer === true);
+}
+
+export type ShowExportItemInFolder = (exportedPath: string) => void;
+
+export interface ExportServiceOptions {
+  /** Main-owned registry used to recognize outputs across app restarts. */
+  provenancePath?: string;
+}
+
+interface ExportProvenanceRecord {
+  path: string;
+  device?: number;
+  inode?: number;
+}
+
+interface ExportDestination {
+  directory: string;
+  format: ExportFormatId;
+  selectedPath?: string;
+  selectedSources: Set<string>;
+  sources: ApprovedExportSource[];
+  producedPaths: Set<string>;
+  expiresAt: number;
+  finalizeGraceAt: number | null;
+  closing: boolean;
+  inFlight: number;
+  idleWaiters: Set<() => void>;
+  finalizePromise: Promise<ExportFinalizeResult> | null;
+}
+
+interface RevealCapability {
+  directory: string;
+  exportedPath: string;
+  expiresAt: number;
+}
+
+export function createExportService(
+  dialog: ExportDialog,
+  showItemInFolder: ShowExportItemInFolder = () => undefined,
+  serviceOptions: ExportServiceOptions = {},
+) {
+  const destinations = new Map<string, ExportDestination>();
+  const revealCapabilities = new Map<string, RevealCapability>();
+  const knownProducedPaths = new Map<string, ExportProvenanceRecord>();
+  const provenancePath = serviceOptions.provenancePath;
+  let provenanceReady: Promise<void> | null = null;
+  let provenanceWriteChain = Promise.resolve();
+
+  function provenanceKey(value: string): string {
+    return normalizedPathKey(value);
+  }
+
+  function isValidProvenanceRecord(value: unknown): value is ExportProvenanceRecord {
+    if (typeof value === "string") {
+      return isNodePath(value) && path.isAbsolute(value);
+    }
+    if (typeof value !== "object" || value === null || !("path" in value)) {
+      return false;
+    }
+    const record = value as Record<string, unknown>;
+    return (
+      isNodePath(record.path) &&
+      path.isAbsolute(record.path) &&
+      (record.device === undefined ||
+        (typeof record.device === "number" && Number.isFinite(record.device))) &&
+      (record.inode === undefined ||
+        (typeof record.inode === "number" && Number.isFinite(record.inode)))
+    );
+  }
+
+  async function loadProvenance(): Promise<void> {
+    if (!provenancePath || !isNodePath(provenancePath) || !path.isAbsolute(provenancePath)) {
+      return;
+    }
+    try {
+      const raw = JSON.parse(await fs.readFile(provenancePath, "utf8")) as unknown;
+      const records = Array.isArray(raw)
+        ? raw
+        : typeof raw === "object" && raw !== null && "outputs" in raw &&
+            Array.isArray((raw as { outputs?: unknown }).outputs)
+          ? (raw as { outputs: unknown[] }).outputs
+          : [];
+      for (const value of records.slice(-MAX_PROVENANCE_RECORDS)) {
+        if (!isValidProvenanceRecord(value)) {
+          continue;
+        }
+        const record = typeof value === "string"
+          ? { path: path.resolve(value) }
+          : {
+              path: path.resolve(value.path),
+              ...(value.device === undefined ? {} : { device: value.device }),
+              ...(value.inode === undefined ? {} : { inode: value.inode }),
+            };
+        knownProducedPaths.set(provenanceKey(record.path), record);
+      }
+    } catch {
+      // A missing or damaged registry must not make exporting unavailable.
+    }
+  }
+
+  function ensureProvenanceReady(): Promise<void> {
+    provenanceReady ??= loadProvenance();
+    return provenanceReady;
+  }
+
+  async function persistProvenance(): Promise<void> {
+    if (!provenancePath || !isNodePath(provenancePath) || !path.isAbsolute(provenancePath)) {
+      return;
+    }
+    const records = [...knownProducedPaths.values()].slice(-MAX_PROVENANCE_RECORDS);
+    await fs.mkdir(path.dirname(provenancePath), { recursive: true });
+    await writeTempAndRename(
+      provenancePath,
+      Buffer.from(JSON.stringify({ version: 1, outputs: records }), "utf8"),
+    );
+  }
+
+  async function rememberProducedPath(targetPath: string): Promise<void> {
+    const resolvedPath = path.resolve(targetPath);
+    let identity: Pick<ApprovedExportSource, "device" | "inode"> = {};
+    try {
+      identity = statIdentity(await fs.stat(resolvedPath));
+    } catch {
+      // Without a stable identity, this output cannot authorize replacing a
+      // scanned source.
+    }
+    const key = provenanceKey(resolvedPath);
+    if (identity.device === undefined || identity.inode === undefined) {
+      // A path without a stable filesystem identity must never authorize a
+      // replacement of a scanned source.
+      knownProducedPaths.delete(key);
+      if (provenancePath) {
+        await ensureProvenanceReady();
+        const write = provenanceWriteChain.then(
+          () => persistProvenance(),
+          () => persistProvenance(),
+        );
+        provenanceWriteChain = write.catch(() => undefined);
+        await write.catch(() => undefined);
+      }
+      return;
+    }
+    knownProducedPaths.set(key, {
+      path: resolvedPath,
+      ...identity,
+    });
+    if (!provenancePath) {
+      return;
+    }
+    await ensureProvenanceReady();
+    const write = provenanceWriteChain.then(
+      () => persistProvenance(),
+      () => persistProvenance(),
+    );
+    provenanceWriteChain = write.catch(() => undefined);
+    await write.catch(() => undefined);
+  }
+
+  function isKnownProducedPath(
+    targetPath: string,
+    targetIdentity: Pick<ApprovedExportSource, "device" | "inode">,
+  ): boolean {
+    const record = knownProducedPaths.get(provenanceKey(targetPath));
+    if (
+      !record ||
+      record.device === undefined ||
+      record.inode === undefined ||
+      targetIdentity.device === undefined ||
+      targetIdentity.inode === undefined ||
+      !Number.isFinite(record.device) ||
+      !Number.isFinite(record.inode) ||
+      !Number.isFinite(targetIdentity.device) ||
+      !Number.isFinite(targetIdentity.inode)
+    ) {
+      return false;
+    }
+    return sameFileIdentity(record, targetIdentity);
+  }
+
+  function pruneExpiredCapabilities(now = Date.now()): void {
+    for (const [token, destination] of destinations) {
+      if (destination.inFlight > 0 || destination.closing || destination.expiresAt > now) {
+        continue;
+      }
+      // Keep a completed destination briefly after expiry so a delayed
+      // finalize can still return the output it already wrote.
+      if (destination.producedPaths.size > 0) {
+        destination.finalizeGraceAt ??= now + DESTINATION_FINALIZE_GRACE_MS;
+        if (destination.finalizeGraceAt > now) {
+          continue;
+        }
+      }
+      destinations.delete(token);
+    }
+    for (const [token, capability] of revealCapabilities) {
+      if (capability.expiresAt <= now) {
+        revealCapabilities.delete(token);
+      }
+    }
+  }
+
+  function limitMapSize<K, V>(map: Map<K, V>, maxSize: number): void {
+    while (map.size > maxSize) {
+      let removable: K | undefined;
+      for (const [key, value] of map) {
+        if (
+          map !== destinations ||
+          (value as ExportDestination).inFlight === 0 &&
+            !(value as ExportDestination).closing
+        ) {
+          removable = key;
+          break;
+        }
+      }
+      if (removable === undefined) {
+        return;
+      }
+      map.delete(removable);
+    }
+  }
+
+  function assertDestinationToken(token: string): ExportDestination {
+    if (typeof token !== "string" || token.length < 16) {
+      throw new Error("Invalid export destination token.");
+    }
+    pruneExpiredCapabilities();
+    const destination = destinations.get(token);
+    if (
+      !destination ||
+      destination.closing ||
+      destination.expiresAt <= Date.now()
+    ) {
+      throw new Error("Export destination is no longer approved.");
+    }
+    return destination;
+  }
+
+  function touchDestination(destination: ExportDestination): void {
+    destination.expiresAt = Date.now() + DESTINATION_IDLE_TTL_MS;
+    destination.finalizeGraceAt = null;
+  }
+
+  function beginEncode(token: string): ExportDestination {
+    const destination = assertDestinationToken(token);
+    destination.inFlight += 1;
+    touchDestination(destination);
+    return destination;
+  }
+
+  function endEncode(destination: ExportDestination): void {
+    destination.inFlight = Math.max(0, destination.inFlight - 1);
+    if (destination.inFlight !== 0) {
+      return;
+    }
+    const waiters = [...destination.idleWaiters];
+    destination.idleWaiters.clear();
+    for (const resolve of waiters) {
+      resolve();
+    }
+  }
+
+  function waitForEncodes(destination: ExportDestination): Promise<void> {
+    if (destination.inFlight === 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      destination.idleWaiters.add(resolve);
+    });
+  }
+
+  function destinationSourceKey(source: ApprovedExportSource): string {
+    return provenanceKey(source.path);
+  }
+
+  async function resolveSelectedSources(
+    requested: ExportDestinationRequest["sources"],
+    sources: readonly ApprovedExportSource[],
+  ): Promise<Set<string>> {
+    const selected = new Set<string>();
+    if (!requested) {
+      return selected;
+    }
+    for (const item of requested) {
+      if (
+        typeof item !== "object" ||
+        item === null ||
+        !isNodePath(item.rootPath) ||
+        !path.isAbsolute(item.rootPath) ||
+        !isNodePath(item.relativePath) ||
+        path.isAbsolute(item.relativePath)
+      ) {
+        throw new Error("Selected export source is invalid.");
+      }
+      const root = await fs.realpath(item.rootPath);
+      const candidate = path.resolve(root, item.relativePath);
+      if (!isWithinRoot(root, candidate)) {
+        throw new Error("Selected export source must stay inside the approved library.");
+      }
+      const sourcePath = await fs.realpath(candidate);
+      const approved = sources.find((source) => pathsEqual(source.path, sourcePath));
+      if (!approved) {
+        throw new Error("Selected export source is not in the approved library scan.");
+      }
+      selected.add(destinationSourceKey(approved));
+    }
+    return selected;
+  }
+
+  async function getExportFormats(): Promise<ExportFormatDescriptor[]> {
+    const sharp = await loadSharp();
+    return FORMAT_DEFINITIONS.filter((format) =>
+      getSharpCapability(sharp, format.id),
+    ).map((format) => ({
+      ...format,
+      extensions: [...format.extensions],
+    }));
+  }
+
+  async function chooseExportDestination(
+    request: ExportDestinationRequest,
+    sources: ApprovedExportSource[],
+  ): Promise<{ token: string } | null> {
+    pruneExpiredCapabilities();
+    if (
+      typeof request !== "object" ||
+      request === null ||
+      !Number.isInteger(request.count) ||
+      request.count <= 0 ||
+      !Array.isArray(sources)
+    ) {
+      throw new Error("Export destination request is invalid.");
+    }
+    await ensureProvenanceReady();
+    const selectedSources = await resolveSelectedSources(request.sources, sources);
+    const availableFormats = await getExportFormats();
+    const format = availableFormats.find((candidate) => candidate.id === request.format);
+    if (!format) {
+      throw new Error(`Export format is unavailable: ${String(request.format)}`);
+    }
+
+    if (request.count === 1) {
+      const suggestedBase = sanitizeFilenamePart(
+        stripKnownExtension(request.suggestedFilename),
+        "Suggested filename",
+      );
+      const result = await dialog.showSaveDialog({
+        title: "Export edited photo",
+        defaultPath: `${suggestedBase}${getExtensionForFormat(format)}`,
+        filters: [{
+          name: format.label,
+          extensions: [...format.extensions],
+        }],
+      });
+      if (result.canceled || !result.filePath) {
+        return null;
+      }
+
+      if (!isNodePath(result.filePath) || !path.isAbsolute(result.filePath)) {
+        throw new Error("The selected export path is invalid.");
+      }
+      const selectedPath = path.resolve(result.filePath);
+      const directory = await assertDirectory(path.dirname(selectedPath));
+      const selectedFilename = toSelectedDestinationFilename(
+        path.basename(selectedPath),
+        format,
+      );
+      const approvedSelectedPath = path.resolve(directory, selectedFilename);
+      if (!isAbsolutePathWithin(directory, approvedSelectedPath)) {
+        throw new Error("Export target must stay inside the approved folder.");
+      }
+      const token = randomUUID();
+      destinations.set(token, {
+        directory,
+        format: format.id,
+        selectedPath: approvedSelectedPath,
+        selectedSources,
+        sources: [...sources],
+        producedPaths: new Set(),
+        expiresAt: Date.now() + DESTINATION_IDLE_TTL_MS,
+        finalizeGraceAt: null,
+        closing: false,
+        inFlight: 0,
+        idleWaiters: new Set(),
+        finalizePromise: null,
+      });
+      limitMapSize(destinations, MAX_DESTINATIONS);
+      return { token };
+    }
+
+    const result = await dialog.showOpenDialog({
+      title: "Choose export folder",
+      properties: ["openDirectory"],
+    });
+    if (result.canceled || result.filePaths.length === 0) {
+      return null;
+    }
+    const directory = await assertDirectory(result.filePaths[0]!);
+    const token = randomUUID();
+    destinations.set(token, {
+      directory,
+      format: format.id,
+      selectedSources,
+      sources: [...sources],
+      producedPaths: new Set(),
+      expiresAt: Date.now() + DESTINATION_IDLE_TTL_MS,
+      finalizeGraceAt: null,
+      closing: false,
+      inFlight: 0,
+      idleWaiters: new Set(),
+      finalizePromise: null,
+    });
+    limitMapSize(destinations, MAX_DESTINATIONS);
+    return { token };
+  }
+
+  async function encodeAndSaveExport(
+    token: string,
+    basename: string,
+    pixels: ExportPixels,
+    options: ExportEncodeOptions,
+  ): Promise<ExportResult> {
+    if (typeof options !== "object" || options === null) {
+      throw new Error("Export options are required.");
+    }
+    const destination = beginEncode(token);
+    try {
+      if (options.format !== destination.format) {
+        throw new Error("Export format does not match the selected destination.");
+      }
+      const currentDirectory = await assertDirectory(destination.directory);
+      if (!pathsEqual(currentDirectory, destination.directory)) {
+        throw new Error("Export destination changed after it was approved.");
+      }
+      const raw = normalizePixels(pixels, options);
+      const formats = await getExportFormats();
+      const format = formats.find((candidate) => candidate.id === options.format);
+      if (!format) {
+        throw new Error(`Export format is unavailable: ${String(options.format)}`);
+      }
+
+      const targetPath = destination.selectedPath
+        ? destination.selectedPath
+        : toDestinationPath(
+            currentDirectory,
+            basename,
+            format,
+            options.filenameSuffix ?? options.suffix ?? DEFAULT_EXPORT_SUFFIX,
+          );
+      const resolvedTargetPath = path.resolve(targetPath);
+      const safeTargetOptions = {
+        selectedSources: destination.selectedSources,
+        isKnownProducedPath,
+      };
+      await assertSafeTarget(
+        currentDirectory,
+        resolvedTargetPath,
+        destination.sources,
+        safeTargetOptions,
+      );
+
+      const encoded = await encodePixels(raw, format, options);
+      const conflict = options.conflict ?? "rename";
+
+      if (conflict === "skip") {
+        await assertSafeTarget(
+          currentDirectory,
+          resolvedTargetPath,
+          destination.sources,
+          safeTargetOptions,
+        );
+        const claim = await claimTarget(resolvedTargetPath);
+        if (!claim) {
+          return { status: "skipped", path: resolvedTargetPath };
+        }
+        await writeClaimedTarget(resolvedTargetPath, claim, encoded);
+        destination.producedPaths.add(resolvedTargetPath);
+        await rememberProducedPath(resolvedTargetPath);
+        return { status: "exported", path: resolvedTargetPath };
+      }
+
+      if (conflict === "rename") {
+        const target = await chooseRenameTarget(resolvedTargetPath);
+        let handedOffClaim = false;
+        try {
+          await assertSafeTarget(
+            currentDirectory,
+            target.path,
+            destination.sources,
+            safeTargetOptions,
+          );
+          handedOffClaim = true;
+          await writeClaimedTarget(target.path, target.claim, encoded);
+        } finally {
+          if (!handedOffClaim) {
+            let claimIdentity: Pick<ApprovedExportSource, "device" | "inode"> = {};
+            try {
+              claimIdentity = statIdentity(await target.claim.stat());
+            } finally {
+              await target.claim.close().catch(() => undefined);
+            }
+            await removeClaimIfOwned(target.path, claimIdentity);
+          }
+        }
+        destination.producedPaths.add(target.path);
+        await rememberProducedPath(target.path);
+        return { status: "exported", path: target.path };
+      }
+
+      if (conflict !== "replace") {
+        throw new Error("Unsupported export conflict behavior.");
+      }
+      await assertSafeTarget(
+        currentDirectory,
+        resolvedTargetPath,
+        destination.sources,
+        safeTargetOptions,
+      );
+      await assertExistingTargetIsSafe(resolvedTargetPath);
+      await writeTempAndRename(resolvedTargetPath, encoded);
+      // Do not re-check the token after rename. A destination may expire while
+      // the write is in flight, but the successful output must be tracked.
+      destination.producedPaths.add(resolvedTargetPath);
+      await rememberProducedPath(resolvedTargetPath);
+      return { status: "exported", path: resolvedTargetPath };
+    } finally {
+      if (!destination.closing) {
+        touchDestination(destination);
+      }
+      endEncode(destination);
+    }
+  }
+
+  function finalizeExport(token: string): Promise<ExportFinalizeResult> {
+    if (typeof token !== "string" || token.length < 16) {
+      throw new Error("Invalid export destination token.");
+    }
+    pruneExpiredCapabilities();
+    const destination = destinations.get(token);
+    if (!destination) {
+      throw new Error("Export destination is no longer approved.");
+    }
+    if (destination.finalizePromise) {
+      return destination.finalizePromise;
+    }
+    destination.closing = true;
+    touchDestination(destination);
+    const finalization = (async (): Promise<ExportFinalizeResult> => {
+      await waitForEncodes(destination);
+      destinations.delete(token);
+
+      const outputPath = [...destination.producedPaths].at(-1) ?? null;
+      if (!outputPath) {
+        return { revealToken: null, outputPath: null };
+      }
+
+      const revealToken = randomUUID();
+      revealCapabilities.set(revealToken, {
+        directory: destination.directory,
+        exportedPath: outputPath,
+        expiresAt: Date.now() + REVEAL_IDLE_TTL_MS,
+      });
+      pruneExpiredCapabilities();
+      limitMapSize(revealCapabilities, MAX_REVEAL_CAPABILITIES);
+      return { revealToken, outputPath };
+    })();
+    destination.finalizePromise = finalization;
+    return finalization;
+  }
+
+  function showInFolder(revealToken: string): void {
+    if (typeof revealToken !== "string" || revealToken.length < 16) {
+      throw new Error("Invalid export reveal capability.");
+    }
+    pruneExpiredCapabilities();
+    const capability = revealCapabilities.get(revealToken);
+    if (!capability) {
+      throw new Error("Export reveal capability is no longer valid.");
+    }
+    if (!isAbsolutePathWithin(capability.directory, capability.exportedPath)) {
+      throw new Error("The requested file was not produced by this export.");
+    }
+    // Reveal capabilities are deliberately one-shot. Removing it before the
+    // shell call also prevents concurrent renderer calls from duplicating it.
+    revealCapabilities.delete(revealToken);
+    showItemInFolder(capability.exportedPath);
+  }
+
+  return {
+    getExportFormats,
+    chooseExportDestination,
+    encodeAndSaveExport,
+    finalizeExport,
+    showInFolder,
+  };
+}
+
+export { MAX_EXPORT_PIXELS };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,11 @@
-import { app, BrowserWindow, dialog, ipcMain, type IpcMainInvokeEvent } from "electron";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  shell,
+  type IpcMainInvokeEvent,
+} from "electron";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -17,6 +24,13 @@ import {
   type NefDecodeRequest,
   type NefDecoderCommand,
 } from "./nef-decoder-service";
+import {
+  createExportService,
+  resolveApprovedExportSources,
+  type ExportEncodeOptions,
+  type ExportDestinationRequest,
+  type ExportPixelPayload,
+} from "./export-service";
 import { createSettingsStore } from "./settings";
 import { getAppRoot, getOutDir, startStaticServer } from "./static-server";
 
@@ -217,6 +231,11 @@ function registerIpcHandlers(): void {
     helper: getNefDecoderCommand(),
     tempRoot: app.getPath("temp"),
   });
+  const exportService = createExportService(dialog, (exportedPath) => {
+    shell.showItemInFolder(exportedPath);
+  }, {
+    provenancePath: path.join(app.getPath("userData"), "export-provenance.json"),
+  });
 
   ipcMain.handle("darkroom:pick-folder", async (event) => {
     assertTrustedRenderer(event);
@@ -390,25 +409,68 @@ function registerIpcHandlers(): void {
     },
   );
 
+  ipcMain.handle("darkroom:get-export-formats", async (event) => {
+    assertTrustedRenderer(event);
+    return exportService.getExportFormats();
+  });
+
   ipcMain.handle(
-    "darkroom:save-export",
-    async (event, suggestedName: string, data: ArrayBuffer) => {
+    "darkroom:choose-export-destination",
+    async (event, request: ExportDestinationRequest) => {
       assertTrustedRenderer(event);
-      if (data.byteLength > 512 * 1024 * 1024) {
-        throw new Error("Export is too large.");
+      if (
+        typeof request !== "object" ||
+        request === null ||
+        !Number.isInteger(request.count) ||
+        request.count <= 0
+      ) {
+        throw new Error("Export destination request is invalid.");
       }
-      const result = await dialog.showSaveDialog({
-        title: "Export edited photo",
-        defaultPath: path.basename(suggestedName),
-        filters: [{ name: "JPEG", extensions: ["jpg", "jpeg"] }],
-      });
+      const sources = await resolveApprovedExportSources(activeLibraryRoot);
+      return exportService.chooseExportDestination(request, sources);
+    },
+  );
 
-      if (result.canceled || !result.filePath) {
-        return null;
-      }
+  ipcMain.handle(
+    "darkroom:encode-and-save-export",
+    async (
+      event,
+      token: string,
+      basename: string,
+      pixels: ArrayBuffer | Uint8Array | ExportPixelPayload,
+      options: ExportEncodeOptions,
+    ) => {
+      assertTrustedRenderer(event);
+      return exportService.encodeAndSaveExport(token, basename, pixels, options);
+    },
+  );
 
-      await fs.writeFile(result.filePath, Buffer.from(new Uint8Array(data)));
-      return result.filePath;
+  ipcMain.handle("darkroom:get-export-options", async (event) => {
+    assertTrustedRenderer(event);
+    return settingsStore.getExportOptions();
+  });
+
+  ipcMain.handle(
+    "darkroom:set-export-options",
+    async (event, options) => {
+      assertTrustedRenderer(event);
+      await settingsStore.setExportOptions(options);
+    },
+  );
+
+  ipcMain.handle(
+    "darkroom:finalize-export",
+    async (event, token: string) => {
+      assertTrustedRenderer(event);
+      return exportService.finalizeExport(token);
+    },
+  );
+
+  ipcMain.handle(
+    "darkroom:show-in-folder",
+    async (event, revealToken: string) => {
+      assertTrustedRenderer(event);
+      exportService.showInFolder(revealToken);
     },
   );
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,6 +1,18 @@
 import { contextBridge, ipcRenderer } from "electron";
 import type { PhotoCatalog } from "../lib/catalog/types";
 import type { NefDecodeRequest, NefDecodeResult } from "./nef-decoder-service";
+import type {
+  ExportDestinationRequest,
+  ExportEncodeOptions,
+  ExportFinalizeResult,
+  ExportFormatDescriptor,
+  ExportPixelPayload,
+  ExportResult,
+} from "./export-service";
+import type {
+  ExportOptionsSettings,
+  ExportOptionsSettingsInput,
+} from "./settings";
 
 interface ScannedFile {
   name: string;
@@ -84,8 +96,45 @@ const darkroom = {
     );
   },
 
-  saveExport(suggestedName: string, data: ArrayBuffer): Promise<string | null> {
-    return ipcRenderer.invoke("darkroom:save-export", suggestedName, data);
+  getExportFormats(): Promise<ExportFormatDescriptor[]> {
+    return ipcRenderer.invoke("darkroom:get-export-formats");
+  },
+
+  chooseExportDestination(
+    request: ExportDestinationRequest,
+  ): Promise<{ token: string } | null> {
+    return ipcRenderer.invoke("darkroom:choose-export-destination", request);
+  },
+
+  encodeAndSaveExport(
+    token: string,
+    basename: string,
+    pixels: ArrayBuffer | Uint8Array | ExportPixelPayload,
+    options: ExportEncodeOptions,
+  ): Promise<ExportResult> {
+    return ipcRenderer.invoke(
+      "darkroom:encode-and-save-export",
+      token,
+      basename,
+      pixels,
+      options,
+    );
+  },
+
+  finalizeExport(token: string): Promise<ExportFinalizeResult> {
+    return ipcRenderer.invoke("darkroom:finalize-export", token);
+  },
+
+  getExportOptions(): Promise<ExportOptionsSettings> {
+    return ipcRenderer.invoke("darkroom:get-export-options");
+  },
+
+  setExportOptions(options: ExportOptionsSettingsInput): Promise<void> {
+    return ipcRenderer.invoke("darkroom:set-export-options", options);
+  },
+
+  showInFolder(revealToken: string): Promise<void> {
+    return ipcRenderer.invoke("darkroom:show-in-folder", revealToken);
   },
 };
 

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -1,13 +1,142 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  DEFAULT_EXPORT_SUFFIX,
+  type ExportConflictBehavior,
+  type ExportFormatId,
+  type ExportSizeOptions,
+} from "../lib/export/types";
+
+export interface ExportOptionsSettings {
+  format: ExportFormatId;
+  quality: number;
+  lossless: boolean;
+  size: ExportSizeOptions;
+  suffix: string;
+  conflict: ExportConflictBehavior;
+}
 
 export interface AppSettings {
   lastFolderPath: string | null;
+  exportOptions: ExportOptionsSettings;
 }
+
+export type ExportOptionsSettingsInput = Partial<ExportOptionsSettings>;
+
+const DEFAULT_EXPORT_OPTIONS: ExportOptionsSettings = {
+  format: "jpeg",
+  quality: 90,
+  lossless: false,
+  size: { mode: "original" },
+  suffix: DEFAULT_EXPORT_SUFFIX,
+  conflict: "rename",
+};
 
 const DEFAULT_SETTINGS: AppSettings = {
   lastFolderPath: null,
+  exportOptions: DEFAULT_EXPORT_OPTIONS,
 };
+
+const MAX_EXPORT_EDGE = 100_000;
+const MAX_SUFFIX_LENGTH = 200;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFormat(value: unknown): value is ExportFormatId {
+  return value === "jpeg" || value === "png" || value === "webp" || value === "avif" || value === "tiff";
+}
+
+function isConflict(value: unknown): value is ExportConflictBehavior {
+  return value === "rename" || value === "skip" || value === "replace";
+}
+
+function positiveInteger(value: unknown, maximum: number): value is number {
+  return Number.isInteger(value) && Number(value) > 0 && Number(value) <= maximum;
+}
+
+function normalizeSize(value: unknown): ExportSizeOptions {
+  if (!isRecord(value) || typeof value.mode !== "string") {
+    return { ...DEFAULT_EXPORT_OPTIONS.size };
+  }
+  if (value.mode === "original") {
+    return { mode: "original" };
+  }
+  if (value.mode === "long-edge" || value.mode === "longEdge") {
+    const pixels = value.pixels ?? value.longEdge;
+    if (!positiveInteger(pixels, MAX_EXPORT_EDGE)) {
+      return { ...DEFAULT_EXPORT_OPTIONS.size };
+    }
+    return {
+      mode: "long-edge",
+      pixels,
+      ...(typeof value.neverUpscale === "boolean"
+        ? { neverUpscale: value.neverUpscale }
+        : {}),
+    };
+  }
+  if (value.mode === "fit") {
+    if (!positiveInteger(value.width, MAX_EXPORT_EDGE) || !positiveInteger(value.height, MAX_EXPORT_EDGE)) {
+      return { ...DEFAULT_EXPORT_OPTIONS.size };
+    }
+    return {
+      mode: "fit",
+      width: value.width,
+      height: value.height,
+      ...(typeof value.neverUpscale === "boolean"
+        ? { neverUpscale: value.neverUpscale }
+        : {}),
+    };
+  }
+  return { ...DEFAULT_EXPORT_OPTIONS.size };
+}
+
+function normalizeSuffix(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    value.length > MAX_SUFFIX_LENGTH ||
+    value.includes("\0") ||
+    value.includes("/") ||
+    value.includes("\\") ||
+    value.includes("..")
+  ) {
+    return DEFAULT_EXPORT_SUFFIX;
+  }
+  return value;
+}
+
+function normalizeExportOptions(value: unknown): ExportOptionsSettings {
+  const input = isRecord(value) ? value : {};
+  const format = isFormat(input.format)
+    ? input.format
+    : DEFAULT_EXPORT_OPTIONS.format;
+  const quality = Number.isInteger(input.quality) && Number(input.quality) >= 1 && Number(input.quality) <= 100
+    ? Number(input.quality)
+    : DEFAULT_EXPORT_OPTIONS.quality;
+  return {
+    format,
+    quality,
+    lossless: typeof input.lossless === "boolean"
+      ? input.lossless
+      : DEFAULT_EXPORT_OPTIONS.lossless,
+    size: normalizeSize(input.size),
+    suffix: normalizeSuffix(input.suffix),
+    conflict: isConflict(input.conflict)
+      ? input.conflict
+      : DEFAULT_EXPORT_OPTIONS.conflict,
+  };
+}
+
+function normalizeSettings(value: unknown): AppSettings {
+  const input = isRecord(value) ? value : {};
+  return {
+    lastFolderPath: typeof input.lastFolderPath === "string"
+      ? input.lastFolderPath
+      : null,
+    exportOptions: normalizeExportOptions(input.exportOptions),
+  };
+}
 
 export function createSettingsStore(userDataPath: string) {
   const settingsPath = path.join(userDataPath, "settings.json");
@@ -15,30 +144,38 @@ export function createSettingsStore(userDataPath: string) {
   async function read(): Promise<AppSettings> {
     try {
       const raw = await fs.readFile(settingsPath, "utf8");
-      const parsed = JSON.parse(raw) as Partial<AppSettings>;
-      return {
-        ...DEFAULT_SETTINGS,
-        ...parsed,
-      };
+      return normalizeSettings(JSON.parse(raw) as unknown);
     } catch {
-      return { ...DEFAULT_SETTINGS };
+      return normalizeSettings(DEFAULT_SETTINGS);
     }
   }
 
   async function write(settings: AppSettings): Promise<void> {
     await fs.mkdir(path.dirname(settingsPath), { recursive: true });
-    await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), "utf8");
+    await fs.writeFile(settingsPath, JSON.stringify(normalizeSettings(settings), null, 2), "utf8");
   }
 
   return {
     async getLastFolder(): Promise<string | null> {
-      const settings = await read();
-      return settings.lastFolderPath;
+      return (await read()).lastFolderPath;
     },
 
     async setLastFolder(folderPath: string | null): Promise<void> {
       const settings = await read();
       settings.lastFolderPath = folderPath;
+      await write(settings);
+    },
+
+    async getExportOptions(): Promise<ExportOptionsSettings> {
+      return (await read()).exportOptions;
+    },
+
+    async setExportOptions(options: ExportOptionsSettingsInput): Promise<void> {
+      const settings = await read();
+      settings.exportOptions = normalizeExportOptions({
+        ...settings.exportOptions,
+        ...(isRecord(options) ? options : {}),
+      });
       await write(settings);
     },
   };

--- a/hooks/useLibraryContextMenu.tsx
+++ b/hooks/useLibraryContextMenu.tsx
@@ -35,7 +35,10 @@ function getActionTargets(
   return [entryId];
 }
 
-export function useLibraryContextMenu(visibleOrder: string[]) {
+export function useLibraryContextMenu(
+  visibleOrder: string[],
+  onExport?: (entryIds: string[]) => void,
+) {
   const router = useRouter();
   const menuRef = useRef<HTMLDivElement>(null);
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
@@ -207,6 +210,15 @@ export function useLibraryContextMenu(visibleOrder: string[]) {
               }}
             >
               Open in Develop
+            </ContextMenuItem>
+
+            <ContextMenuItem
+              onClick={() => {
+                onExport?.(actionTargets);
+                closeMenu();
+              }}
+            >
+              Export selected…
             </ContextMenuItem>
 
             <ContextMenuSeparator />

--- a/lib/develop/renderer.ts
+++ b/lib/develop/renderer.ts
@@ -1,6 +1,7 @@
 import type { DevelopImage } from "@/lib/cache/develop-image-cache";
 import { clampCropRect } from "@/lib/develop/crop-geometry";
 import type { DevelopSettings } from "@/lib/develop/types";
+import type { RawExportRenderResult } from "@/lib/export/types";
 import { MIXER_COLORS } from "@/lib/develop/plugins/mixer";
 import {
   createCurveLut,
@@ -668,20 +669,32 @@ export class DevelopRenderer {
     this.gl.deleteProgram(this.integerProgram);
   }
 
-  toBlob(type = "image/jpeg", quality = 0.92): Promise<Blob> {
-    return new Promise((resolve, reject) => {
-      this.canvas.toBlob(
-        (blob) => {
-          if (!blob) {
-            reject(new Error("Could not export edited image."));
-            return;
-          }
-          resolve(blob);
-        },
-        type,
-        quality,
-      );
-    });
+  readPixels(): Uint8Array {
+    const width = this.canvas.width;
+    const height = this.canvas.height;
+    if (width < 1 || height < 1) {
+      throw new Error("Could not read an empty export.");
+    }
+
+    const pixels = new Uint8Array(width * height * 4);
+    this.gl.readPixels(0, 0, width, height, this.gl.RGBA, this.gl.UNSIGNED_BYTE, pixels);
+    const error = this.gl.getError();
+    if (error !== this.gl.NO_ERROR) {
+      throw new Error("Could not read edited image pixels.");
+    }
+
+    // WebGL's readback starts at the bottom row; encoders expect top-to-bottom rows.
+    const row = new Uint8Array(width * 4);
+    const rowLength = row.length;
+    for (let y = 0; y < Math.floor(height / 2); y += 1) {
+      const topOffset = y * rowLength;
+      const bottomOffset = (height - y - 1) * rowLength;
+      row.set(pixels.subarray(topOffset, topOffset + rowLength));
+      pixels.copyWithin(topOffset, bottomOffset, bottomOffset + rowLength);
+      pixels.set(row, bottomOffset);
+    }
+
+    return pixels;
   }
 
   private uniformMixer(settings: DevelopSettings): void {
@@ -758,23 +771,45 @@ function exportSize(image: DevelopImage, settings: DevelopSettings): {
   };
 }
 
-export async function exportDevelopJpeg(
+export type RenderDevelopExportResult = RawExportRenderResult;
+
+/**
+ * Render a developed image at its full cropped resolution and return raw RGBA.
+ * Pass a renderer to reuse its WebGL context across a batch.
+ */
+export async function renderDevelopExport(
   image: DevelopImage,
   settings: DevelopSettings,
-): Promise<Blob> {
+  renderer?: DevelopRenderer,
+): Promise<RenderDevelopExportResult> {
   const { width, height } = exportSize(image, settings);
   if (width * height > MAX_EXPORT_PIXELS) {
     throw new Error("This edit exceeds the 50 megapixel export limit.");
   }
 
-  const canvas = document.createElement("canvas");
-  const renderer = new DevelopRenderer(canvas, true);
+  const ownsRenderer = !renderer;
+  const activeRenderer = renderer ?? new DevelopRenderer(
+    document.createElement("canvas"),
+    true,
+  );
   try {
-    await renderer.setImage(image);
-    renderer.resize(width, height);
-    renderer.render(settings, false, "export");
-    return await renderer.toBlob();
+    await activeRenderer.setImage(image);
+    activeRenderer.resize(width, height);
+    activeRenderer.render(settings, false, "export");
+    const embeddedPreview = image.metadata.decoderProvenance === "embedded";
+    return {
+      pixels: activeRenderer.readPixels(),
+      width,
+      height,
+      provenance: embeddedPreview ? "embedded-preview" : "decoded",
+      embeddedPreview,
+      ...(embeddedPreview
+        ? { warning: "RAW export uses its embedded preview." }
+        : {}),
+    };
   } finally {
-    renderer.dispose();
+    if (ownsRenderer) {
+      activeRenderer.dispose();
+    }
   }
 }

--- a/lib/export/runner.ts
+++ b/lib/export/runner.ts
@@ -1,0 +1,255 @@
+import type { EntryMetadata } from "@/lib/catalog/types";
+import {
+  disposeDevelopImage,
+  loadDevelopExportImage,
+  type DevelopImage,
+} from "@/lib/cache/develop-image-cache";
+import {
+  DevelopRenderer,
+  renderDevelopExport,
+} from "@/lib/develop/renderer";
+import { readDevelopSidecar } from "@/lib/develop/sidecar";
+import { getDarkroomAPI } from "@/lib/fs/platform";
+import type { LibraryEntry } from "@/lib/fs/types";
+import { useDevelopStore } from "@/stores/develop-store";
+import { resolveDevelopSettings } from "./settings";
+import { DEFAULT_EXPORT_SUFFIX } from "./types";
+import type {
+  ExportConflictBehavior,
+  ExportFileResult,
+  ExportFormatId,
+  ExportJobOptions,
+  ExportRevealCapability,
+  ExportSizeOptions,
+  RawExportRenderResult,
+} from "./types";
+
+export type ExportPhase = "decoding" | "rendering" | "encoding";
+
+export interface ExportProgress {
+  phase: ExportPhase;
+  index: number;
+  total: number;
+  entry: LibraryEntry;
+}
+
+export interface ExportBatchSummary {
+  results: ExportFileResult[];
+  exported: number;
+  skipped: number;
+  failed: number;
+  warnings: string[];
+  cancelled: boolean;
+  revealCapability: ExportRevealCapability | null;
+  lastOutputPath: string | null;
+}
+
+export interface ExportRunnerOptions {
+  entries: LibraryEntry[];
+  metadata: Record<string, EntryMetadata>;
+  rootPath: string | null;
+  destinationToken: string;
+  options: Omit<ExportJobOptions, "destinationToken">;
+  onProgress?: (progress: ExportProgress) => void;
+  isCancelled?: () => boolean;
+}
+
+interface EncodeOptions {
+  format: ExportFormatId;
+  size:
+    | { mode: "original" }
+    | { mode: "long-edge"; pixels: number; neverUpscale?: boolean }
+    | { mode: "fit"; width: number; height: number; neverUpscale?: boolean };
+  quality?: number;
+  lossless?: boolean;
+  suffix: string;
+  conflict: ExportConflictBehavior;
+}
+
+function toEncodeSize(size: ExportSizeOptions): EncodeOptions["size"] {
+  if (size.mode === "long-edge" || size.mode === "longEdge") {
+    const pixels = Number(size.longEdge ?? size.pixels);
+    if (!Number.isInteger(pixels) || pixels < 1) {
+      throw new Error("Long edge must be a positive whole number.");
+    }
+    return {
+      mode: "long-edge",
+      pixels,
+      neverUpscale: size.neverUpscale,
+    };
+  }
+  if (size.mode === "fit") {
+    if (!Number.isInteger(size.width) || !Number.isInteger(size.height)) {
+      throw new Error("Fit dimensions must be positive whole numbers.");
+    }
+    return {
+      mode: "fit",
+      width: size.width,
+      height: size.height,
+      neverUpscale: size.neverUpscale,
+    };
+  }
+  return { mode: "original" };
+}
+
+function sourceBasename(entry: LibraryEntry): string {
+  return entry.name.replace(/\.[^.]+$/, "");
+}
+
+function getMetadata(
+  metadata: Record<string, EntryMetadata>,
+  entry: LibraryEntry,
+): EntryMetadata {
+  return (
+    metadata[entry.id] ?? {
+      pick: "none",
+      rating: 0,
+      colorLabel: null,
+      updatedAt: entry.lastModified,
+    }
+  );
+}
+
+async function resolveSettings(
+  entry: LibraryEntry,
+  metadata: EntryMetadata,
+  rootPath: string | null,
+): Promise<ReturnType<typeof resolveDevelopSettings>> {
+  const current = useDevelopStore.getState();
+  if (current.activeEntryId === entry.id) {
+    return structuredClone(current.settings);
+  }
+
+  const sidecar = rootPath
+    ? await readDevelopSidecar(rootPath, entry.relativePath)
+    : null;
+  return resolveDevelopSettings(sidecar, metadata);
+}
+
+function asErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Export failed.";
+}
+
+function toEncodeOptions(
+  options: ExportRunnerOptions["options"],
+): EncodeOptions {
+  return {
+    format: options.format,
+    size: toEncodeSize(options.size),
+    quality: options.quality,
+    lossless: options.lossless,
+    suffix: options.suffix ?? DEFAULT_EXPORT_SUFFIX,
+    conflict: options.conflict,
+  };
+}
+
+export async function runExportBatch(
+  runnerOptions: ExportRunnerOptions,
+): Promise<ExportBatchSummary> {
+  const {
+    entries,
+    metadata,
+    rootPath,
+    destinationToken,
+    options,
+    onProgress,
+    isCancelled = () => false,
+  } = runnerOptions;
+  const api = getDarkroomAPI();
+  const results: ExportFileResult[] = [];
+  const warnings: string[] = [];
+  let renderer: DevelopRenderer | null = null;
+  let lastOutputPath: string | null = null;
+  let cancelled = false;
+  let revealCapability: ExportRevealCapability | null = null;
+
+  try {
+    for (let index = 0; index < entries.length; index += 1) {
+      if (isCancelled()) {
+        cancelled = true;
+        break;
+      }
+
+      const entry = entries[index]!;
+      const progress = (phase: ExportPhase) =>
+        onProgress?.({ phase, index, total: entries.length, entry });
+      progress("decoding");
+
+      let exportImage: DevelopImage | null = null;
+      let pixels: RawExportRenderResult | null = null;
+      try {
+        const entryMetadata = getMetadata(metadata, entry);
+        const settings = await resolveSettings(entry, entryMetadata, rootPath);
+        exportImage = await loadDevelopExportImage(entry);
+
+        progress("rendering");
+        renderer ??= new DevelopRenderer(document.createElement("canvas"), true);
+        pixels = await renderDevelopExport(exportImage, settings, renderer);
+
+        progress("encoding");
+        const encoded = await api.encodeAndSaveExport(
+          destinationToken,
+          sourceBasename(entry),
+          {
+            pixels: pixels.pixels,
+            width: pixels.width,
+            height: pixels.height,
+          },
+          toEncodeOptions(options),
+        );
+        if (encoded.status === "exported") {
+          lastOutputPath = encoded.path ?? lastOutputPath;
+        }
+        const embeddedWarning =
+          "warning" in pixels && pixels.warning
+            ? pixels.warning
+            : undefined;
+        const warning = embeddedWarning ?? encoded.warning;
+        if (warning) {
+          warnings.push(`${entry.name}: ${warning}`);
+        }
+        results.push({
+          entryId: entry.id,
+          sourceName: entry.name,
+          outputName: encoded.path,
+          status: encoded.status === "skipped" ? "skipped" : warning ? "warning" : "success",
+          ...(warning ? { warning } : {}),
+        });
+      } catch (error) {
+        results.push({
+          entryId: entry.id,
+          sourceName: entry.name,
+          status: "error",
+          error: asErrorMessage(error),
+        });
+      } finally {
+        pixels = null;
+        if (exportImage) {
+          disposeDevelopImage(exportImage);
+          exportImage = null;
+        }
+      }
+    }
+  } finally {
+    try {
+      renderer?.dispose();
+    } finally {
+      const finalized = await api.finalizeExport(destinationToken);
+      revealCapability = finalized.revealToken;
+      lastOutputPath = finalized.outputPath ?? lastOutputPath;
+    }
+  }
+
+  return {
+    results,
+    exported: results.filter(
+      (result) => result.status === "success" || result.status === "warning",
+    ).length,
+    skipped: results.filter((result) => result.status === "skipped").length,
+    failed: results.filter((result) => result.status === "error").length,
+    warnings,
+    cancelled,
+    revealCapability,
+    lastOutputPath,
+  };
+}

--- a/lib/export/settings.ts
+++ b/lib/export/settings.ts
@@ -1,0 +1,23 @@
+import type { EntryMetadata } from "@/lib/catalog/types";
+import { createDevelopSettings } from "@/lib/develop/registry";
+import type { DevelopSettings } from "@/lib/develop/types";
+import type { DevelopSidecar } from "@/lib/develop/sidecar";
+
+/**
+ * Resolve the settings that belong to an entry at export time.
+ *
+ * Sidecars are authoritative only when they are newer than the catalog
+ * metadata. The active Develop entry is handled by the export runner before
+ * calling this function so an edit that is still waiting for its debounced
+ * sidecar write is not lost.
+ */
+export function resolveDevelopSettings(
+  sidecar: Pick<DevelopSidecar, "settings" | "lastModified"> | null,
+  metadata: Pick<EntryMetadata, "develop" | "updatedAt">,
+): DevelopSettings {
+  if (sidecar && sidecar.lastModified > metadata.updatedAt) {
+    return createDevelopSettings(sidecar.settings);
+  }
+
+  return createDevelopSettings(metadata.develop);
+}

--- a/lib/export/types.ts
+++ b/lib/export/types.ts
@@ -1,0 +1,145 @@
+/** Format identifiers understood by the export encoder. */
+export const EXPORT_FORMAT_IDS = [
+  "jpeg",
+  "png",
+  "webp",
+  "avif",
+  "tiff",
+] as const;
+
+export type ExportFormatId = (typeof EXPORT_FORMAT_IDS)[number];
+
+export interface ExportFormatDescriptor {
+  id: ExportFormatId;
+  label: string;
+  extensions: string[];
+  supportsQuality: boolean;
+  supportsLossless: boolean;
+  defaultQuality?: number;
+}
+
+/** The request used to let the native save dialog choose a destination. */
+export interface ExportDestinationRequest {
+  count: number;
+  format: ExportFormatId;
+  suggestedFilename: string;
+  sources: Array<{
+    rootPath: string;
+    relativePath: string;
+  }>;
+}
+
+export interface ExportDestination {
+  token: string;
+}
+
+/** Opaque, short-lived permission to reveal the last output in the file browser. */
+export type ExportRevealCapability = string;
+
+/** Options remembered between export sessions. */
+export interface ExportPreferences {
+  format: ExportFormatId;
+  quality: number;
+  lossless: boolean;
+  size: ExportSizeOptions;
+  suffix: string;
+  conflict: ExportConflictBehavior;
+}
+
+export type ExportSizeMode = "original" | "long-edge" | "longEdge" | "fit";
+
+/** Size controls for the encoder's resize step. */
+export type ExportSizeOptions =
+  | { mode: "original" }
+  | {
+      mode: "long-edge" | "longEdge";
+      /** Target long edge in pixels. */
+      pixels?: number;
+      /** Alias accepted by renderer-side callers. */
+      longEdge?: number;
+      /** Defaults to true. */
+      neverUpscale?: boolean;
+    }
+  | {
+      mode: "fit";
+      /** Target width, used when mode is "fit". */
+      width: number;
+      /** Target height, used when mode is "fit". */
+      height: number;
+      /** Defaults to true. */
+      neverUpscale?: boolean;
+    };
+
+export type ExportConflictBehavior = "rename" | "skip" | "replace";
+
+export const DEFAULT_EXPORT_SUFFIX = "-darkroom";
+
+export const DEFAULT_EXPORT_PREFERENCES: ExportPreferences = {
+  format: "jpeg",
+  quality: 90,
+  lossless: false,
+  size: { mode: "original" },
+  suffix: DEFAULT_EXPORT_SUFFIX,
+  conflict: "rename",
+};
+
+export interface ExportJobOptions {
+  format: ExportFormatId;
+  size: ExportSizeOptions;
+  quality?: number;
+  lossless?: boolean;
+  suffix?: string;
+  filenameSuffix?: string;
+  conflict: ExportConflictBehavior;
+  destinationToken: string;
+}
+
+export interface ExportEncodeOptions {
+  format: ExportFormatId;
+  size?: ExportSizeOptions;
+  quality?: number;
+  lossless?: boolean;
+  suffix?: string;
+  filenameSuffix?: string;
+  conflict?: ExportConflictBehavior;
+  /** Legacy scalar dimensions accepted by the encoder boundary. */
+  width?: number;
+  height?: number;
+  neverUpscale?: boolean;
+}
+
+export interface ExportPixelPayload {
+  pixels: ArrayBuffer | Uint8Array;
+  width: number;
+  height: number;
+}
+
+export type ExportPixels = ArrayBuffer | Uint8Array | ExportPixelPayload;
+
+export interface ExportEncodeResult {
+  status: "exported" | "skipped";
+  path?: string;
+  warning?: string;
+}
+
+export type ExportFileStatus = "success" | "skipped" | "warning" | "error";
+
+export interface ExportFileResult {
+  entryId: string;
+  sourceName?: string;
+  outputName?: string;
+  status: ExportFileStatus;
+  warning?: string;
+  error?: string;
+}
+
+export type ExportRenderProvenance = "decoded" | "embedded-preview";
+
+export interface RawExportRenderResult {
+  pixels: Uint8Array;
+  width: number;
+  height: number;
+  provenance: ExportRenderProvenance;
+  embeddedPreview: boolean;
+  warning?: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "16.2.10",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "sharp": "^0.34.5",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -1599,7 +1600,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4895,7 +4895,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -9585,7 +9584,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -9629,7 +9627,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "16.2.10",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "sharp": "^0.34.5",
     "zustand": "^5.0.14"
   },
   "devDependencies": {
@@ -49,7 +50,15 @@
     "files": [
       "electron-dist/**/*",
       "out/**/*",
-      "package.json"
+      "package.json",
+      "node_modules/sharp/**/*",
+      "node_modules/@img/**/*",
+      "node_modules/detect-libc/**/*",
+      "node_modules/semver/**/*"
+    ],
+    "asarUnpack": [
+      "node_modules/sharp/**/*",
+      "node_modules/@img/**/*"
     ],
     "directories": {
       "output": "release"

--- a/scripts/package-release.mjs
+++ b/scripts/package-release.mjs
@@ -1,7 +1,177 @@
 import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+
+const rootDir = process.cwd();
+const sharpPackagePath = path.join(rootDir, "node_modules/sharp/package.json");
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const builder = path.join(
+  rootDir,
+  "node_modules/.bin",
+  process.platform === "win32" ? "electron-builder.cmd" : "electron-builder",
+);
+
+const targetSpecs = [
+  {
+    id: "mac-arm64",
+    platform: "darwin",
+    arch: "arm64",
+    args: ["--mac", "--arm64"],
+    packages: ["@img/sharp-darwin-arm64", "@img/sharp-libvips-darwin-arm64"],
+  },
+  {
+    id: "win-x64",
+    platform: "win32",
+    arch: "x64",
+    args: ["--win", "--x64"],
+    packages: ["@img/sharp-win32-x64"],
+  },
+  {
+    id: "linux-x64",
+    platform: "linux",
+    arch: "x64",
+    args: ["--linux", "--x64"],
+    packages: ["@img/sharp-linux-x64", "@img/sharp-libvips-linux-x64"],
+  },
+];
+
+const platformFlags = new Set([
+  "--mac",
+  "--macos",
+  "-m",
+  "--win",
+  "--windows",
+  "-w",
+  "--linux",
+  "-l",
+  "--arm64",
+  "--x64",
+  "--ia32",
+  "--armv7l",
+  "--universal",
+]);
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    env: process.env,
+    stdio: "inherit",
+    ...options,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status ?? 1}.`);
+  }
+}
+
+function readJson(filePath) {
+  return fs.readFile(filePath, "utf8").then((raw) => JSON.parse(raw));
+}
+
+function packagePath(packageName) {
+  return path.join(rootDir, "node_modules", ...packageName.split("/"));
+}
+
+async function packageVersion(packageName) {
+  try {
+    const packageJson = await readJson(path.join(packagePath(packageName), "package.json"));
+    return typeof packageJson.version === "string" ? packageJson.version : null;
+  } catch {
+    return null;
+  }
+}
+
+async function packInto(packageName, version, stagingRoot) {
+  const destination = path.join(stagingRoot, "npm-pack");
+  await fs.mkdir(destination, { recursive: true });
+  const result = spawnSync(npmCommand, [
+    "pack",
+    "--silent",
+    "--pack-destination",
+    destination,
+    `${packageName}@${version}`,
+  ], {
+    cwd: rootDir,
+    env: process.env,
+    encoding: "utf8",
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(`npm pack failed for ${packageName}@${version}.`);
+  }
+  const archiveName = result.stdout.trim().split(/\r?\n/).at(-1);
+  if (!archiveName) {
+    throw new Error(`npm pack returned no archive for ${packageName}@${version}.`);
+  }
+  const archivePath = path.isAbsolute(archiveName)
+    ? archiveName
+    : path.join(destination, archiveName);
+  const unpacked = path.join(stagingRoot, packageName.replaceAll("/", "-"));
+  await fs.mkdir(unpacked, { recursive: true });
+  run("tar", ["-xzf", archivePath, "-C", unpacked]);
+  return path.join(unpacked, "package");
+}
+
+async function ensureTargetPackages(spec, sharpPackage, stagingRoot) {
+  const copied = [];
+  try {
+    for (const packageName of spec.packages) {
+      const version = sharpPackage.optionalDependencies?.[packageName];
+      if (typeof version !== "string") {
+        throw new Error(`Sharp does not declare ${packageName} as an optional dependency.`);
+      }
+      if (await packageVersion(packageName) === version) {
+        continue;
+      }
+      if (await packageVersion(packageName) !== null) {
+        throw new Error(
+          `${packageName} is installed at an unexpected version; refusing to overwrite it during release staging.`,
+        );
+      }
+      const source = await packInto(packageName, version, stagingRoot);
+      const destination = packagePath(packageName);
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.cp(source, destination, { recursive: true });
+      copied.push(destination);
+    }
+  } catch (error) {
+    await restoreCopiedPackages(copied);
+    throw error;
+  }
+  return copied;
+}
+
+async function restoreCopiedPackages(copied) {
+  for (const packagePathToRemove of copied.reverse()) {
+    await fs.rm(packagePathToRemove, { recursive: true, force: true });
+  }
+}
+
+function selectedTargets(args) {
+  const requested = new Set();
+  if (args.some((arg) => arg === "--mac" || arg === "--macos" || arg === "-m")) {
+    requested.add("mac-arm64");
+  }
+  if (args.some((arg) => arg === "--win" || arg === "--windows" || arg === "-w")) {
+    requested.add("win-x64");
+  }
+  if (args.some((arg) => arg === "--linux" || arg === "-l")) {
+    requested.add("linux-x64");
+  }
+  return requested.size === 0
+    ? targetSpecs
+    : targetSpecs.filter((spec) => requested.has(spec.id));
+}
+
+function forwardedArgs(args) {
+  return args.filter((arg) => !platformFlags.has(arg));
+}
 
 if (process.platform === "darwin") {
   const sdkRoot = path.resolve(
@@ -26,14 +196,25 @@ if (process.platform === "darwin") {
   if (missing.length) {
     throw new Error(`Nikon NEF release runtime is incomplete:\n${missing.join("\n")}`);
   }
-  process.env.DARKROOM_NEF_SDK_FROM = path.relative(process.cwd(), sdkRoot);
+  process.env.DARKROOM_NEF_SDK_FROM = path.relative(rootDir, sdkRoot);
 }
 
-const builder = path.join(
-  process.cwd(),
-  "node_modules/.bin",
-  process.platform === "win32" ? "electron-builder.cmd" : "electron-builder",
-);
-const result = spawnSync(builder, process.argv.slice(2), { env: process.env, stdio: "inherit" });
-if (result.error) throw result.error;
-process.exit(result.status ?? 1);
+const releaseArgs = process.argv.slice(2);
+const targets = selectedTargets(releaseArgs);
+const sharpPackage = await readJson(sharpPackagePath);
+const stagingRoot = await fs.mkdtemp(path.join(os.tmpdir(), "darkroom-sharp-"));
+const commonArgs = forwardedArgs(releaseArgs);
+
+try {
+  for (const target of targets) {
+    const copied = await ensureTargetPackages(target, sharpPackage, stagingRoot);
+    try {
+      console.log(`Packaging ${target.id} with matching Sharp optional dependencies.`);
+      run(builder, [...commonArgs, ...target.args]);
+    } finally {
+      await restoreCopiedPackages(copied);
+    }
+  }
+} finally {
+  await fs.rm(stagingRoot, { recursive: true, force: true });
+}

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1,5 +1,17 @@
 import type { PhotoCatalog } from "../lib/catalog/types";
 import type { NefDecodeRequest, NefDecodeResult } from "../electron/nef-decoder-service";
+import type {
+  ExportDestinationRequest,
+  ExportEncodeOptions,
+  ExportFinalizeResult,
+  ExportFormatDescriptor,
+  ExportPixelPayload,
+  ExportResult,
+} from "../electron/export-service";
+import type {
+  ExportOptionsSettings,
+  ExportOptionsSettingsInput,
+} from "../electron/settings";
 
 export interface ScannedFile {
   name: string;
@@ -34,7 +46,20 @@ export interface DarkroomAPI {
     relativePath: string,
     contents: string,
   ): Promise<void>;
-  saveExport(suggestedName: string, data: ArrayBuffer): Promise<string | null>;
+  getExportFormats(): Promise<ExportFormatDescriptor[]>;
+  chooseExportDestination(
+    request: ExportDestinationRequest,
+  ): Promise<{ token: string } | null>;
+  encodeAndSaveExport(
+    token: string,
+    basename: string,
+    pixels: ArrayBuffer | Uint8Array | ExportPixelPayload,
+    options: ExportEncodeOptions,
+  ): Promise<ExportResult>;
+  finalizeExport(token: string): Promise<ExportFinalizeResult>;
+  getExportOptions(): Promise<ExportOptionsSettings>;
+  setExportOptions(options: ExportOptionsSettingsInput): Promise<void>;
+  showInFolder(revealToken: string): Promise<void>;
 }
 
 declare global {


### PR DESCRIPTION
## Summary

- Add configurable export dialog for selected photos and develop-view exports.
- Support JPEG, PNG, and WebP formats, resizing, quality, lossless output, filename suffixes, and conflict handling.
- Add Electron export services, destination selection, progress reporting, cancellation, and reveal-in-folder support.
- Persist export preferences and resolve develop settings consistently during export.

## Testing

- Not run.