### PR TITLE
Install catalog v3 with stable asset migration

### DIFF
--- a/electron/catalog-migration-snapshot.ts
+++ b/electron/catalog-migration-snapshot.ts
@@ -1,0 +1,272 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  MigrationRawSource,
+  MigrationSourceDescriptor,
+} from "../lib/catalog/legacy-migration.ts";
+
+export interface MigrationSourcePaths {
+  catalogPath: string;
+  settingsPath?: string;
+}
+
+export type RawMigrationSnapshot = MigrationSourceDescriptor;
+
+export interface RecoveryEvidenceFile {
+  name: "catalog.json" | "settings.json";
+  path: string;
+  sha256: string;
+  byteLength: number;
+}
+
+export interface RecoveryEvidence {
+  directory: string;
+  files: RecoveryEvidenceFile[];
+}
+
+export interface RecheckedMigrationSource {
+  unchanged: boolean;
+  catalog: MigrationRawSource;
+  settings?: MigrationRawSource;
+}
+
+function isNodeError(value: unknown, code: string): boolean {
+  return typeof value === "object" && value !== null && "code" in value && value.code === code;
+}
+
+function requireAbsoluteNormalizedPath(value: string, name: string): string {
+  if (value.length === 0 || value.includes("\0") || !path.isAbsolute(value) || path.normalize(value) !== value) {
+    throw new Error(`${name} must be absolute, normalized, and NUL-free.`);
+  }
+  return value;
+}
+
+function requireMigrationId(value: string): string {
+  if (
+    value.length === 0 ||
+    value === "." ||
+    value === ".." ||
+    value.includes("\0") ||
+    value.includes(":") ||
+    value.includes("/") ||
+    value.includes("\\")
+  ) {
+    throw new Error("migrationId must be one safe path segment.");
+  }
+  return value;
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function cloneBytes(bytes: Uint8Array): Uint8Array {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy;
+}
+
+async function readRawSourceFile(
+  sourcePath: string,
+  optional: boolean,
+): Promise<MigrationRawSource | undefined> {
+  requireAbsoluteNormalizedPath(sourcePath, "source path");
+  let bytes: Buffer;
+  try {
+    bytes = await fs.readFile(sourcePath);
+  } catch (error) {
+    if (optional && isNodeError(error, "ENOENT")) {
+      return undefined;
+    }
+    throw error;
+  }
+  const copy = cloneBytes(bytes);
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(copy);
+  } catch {
+    text = "";
+  }
+  return {
+    path: sourcePath,
+    bytes: copy,
+    text,
+    sha256: sha256(copy),
+  };
+}
+
+export async function readMigrationSources(
+  paths: MigrationSourcePaths,
+): Promise<RawMigrationSnapshot> {
+  const catalog = await readRawSourceFile(paths.catalogPath, false);
+  if (!catalog) {
+    throw new Error("Catalog source is missing.");
+  }
+  const settings = paths.settingsPath
+    ? await readRawSourceFile(paths.settingsPath, true)
+    : undefined;
+  return settings ? { catalog, settings } : { catalog };
+}
+
+function isInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative.length > 0 && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function recoveryDirectory(userDataPath: string, migrationId: string): string {
+  const normalizedUserDataPath = requireAbsoluteNormalizedPath(userDataPath, "userDataPath");
+  const safeMigrationId = requireMigrationId(migrationId);
+  const root = path.join(normalizedUserDataPath, "catalog-migration-recovery");
+  const directory = path.join(root, safeMigrationId);
+  if (!isInside(root, directory)) {
+    throw new Error("Recovery directory escaped its parent.");
+  }
+  return directory;
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  try {
+    const handle = await fs.open(directory, "r");
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    if (
+      isNodeError(error, "EINVAL") ||
+      isNodeError(error, "ENOTSUP") ||
+      isNodeError(error, "EISDIR") ||
+      isNodeError(error, "EPERM")
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function readExistingHash(filePath: string): Promise<string | null> {
+  try {
+    return sha256(await fs.readFile(filePath));
+  } catch (error) {
+    if (isNodeError(error, "ENOENT")) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeExclusiveTemp(
+  directory: string,
+  finalPath: string,
+  bytes: Uint8Array,
+): Promise<string> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const temporaryPath = path.join(directory, `.${path.basename(finalPath)}.${randomUUID()}.tmp`);
+    let handle: fs.FileHandle | undefined;
+    try {
+      handle = await fs.open(temporaryPath, "wx", 0o600);
+      await handle.writeFile(bytes);
+      await handle.sync();
+      await handle.close();
+      return temporaryPath;
+    } catch (error) {
+      await handle?.close().catch(() => undefined);
+      await fs.unlink(temporaryPath).catch(() => undefined);
+      if (isNodeError(error, "EEXIST")) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error("Could not create an exclusive recovery temporary file.");
+}
+
+async function installEvidenceFile(
+  directory: string,
+  name: "catalog.json" | "settings.json",
+  source: MigrationRawSource,
+): Promise<RecoveryEvidenceFile> {
+  if (sha256(source.bytes) !== source.sha256) {
+    throw new Error(`Recovery evidence "${name}" has a mismatched source hash.`);
+  }
+  const finalPath = path.join(directory, name);
+  const existingHash = await readExistingHash(finalPath);
+  if (existingHash !== null) {
+    if (existingHash !== source.sha256) {
+      throw new Error(`Recovery evidence "${name}" already contains different bytes.`);
+    }
+    return {
+      name,
+      path: finalPath,
+      sha256: existingHash,
+      byteLength: source.bytes.byteLength,
+    };
+  }
+
+  const temporaryPath = await writeExclusiveTemp(directory, finalPath, source.bytes);
+  try {
+    await fs.link(temporaryPath, finalPath);
+  } catch (error) {
+    const racedHash = await readExistingHash(finalPath);
+    await fs.unlink(temporaryPath).catch(() => undefined);
+    if (isNodeError(error, "EEXIST") && racedHash === source.sha256) {
+      return {
+        name,
+        path: finalPath,
+        sha256: racedHash,
+        byteLength: source.bytes.byteLength,
+      };
+    }
+    if (isNodeError(error, "EEXIST") && racedHash !== null) {
+      throw new Error(`Recovery evidence "${name}" already contains different bytes.`);
+    }
+    throw error;
+  }
+  await fs.unlink(temporaryPath);
+  await syncDirectory(directory);
+  return {
+    name,
+    path: finalPath,
+    sha256: source.sha256,
+    byteLength: source.bytes.byteLength,
+  };
+}
+
+export async function copyMigrationRecoveryEvidence(
+  userDataPath: string,
+  migrationId: string,
+  snapshot: RawMigrationSnapshot,
+): Promise<RecoveryEvidence> {
+  const directory = recoveryDirectory(userDataPath, migrationId);
+  await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+  await syncDirectory(path.dirname(directory));
+  const files = [await installEvidenceFile(directory, "catalog.json", snapshot.catalog)];
+  if (snapshot.settings) {
+    files.push(await installEvidenceFile(directory, "settings.json", snapshot.settings));
+  }
+  await syncDirectory(directory);
+  return { directory, files };
+}
+
+export async function recheckMigrationSources(
+  snapshot: RawMigrationSnapshot,
+  paths: Pick<MigrationSourcePaths, "settingsPath"> = {},
+): Promise<RecheckedMigrationSource> {
+  const catalog = await readRawSourceFile(snapshot.catalog.path, false);
+  if (!catalog) {
+    throw new Error("Catalog source is missing during migration recheck.");
+  }
+  const settingsPath = paths.settingsPath ?? snapshot.settings?.path;
+  if (snapshot.settings !== undefined && settingsPath !== snapshot.settings.path) {
+    throw new Error("Settings source path changed during migration recheck.");
+  }
+  const settings = settingsPath
+    ? await readRawSourceFile(settingsPath, true)
+    : undefined;
+  const unchanged = catalog.sha256 === snapshot.catalog.sha256 &&
+    ((snapshot.settings === undefined && settings === undefined) ||
+      (snapshot.settings !== undefined && settings !== undefined && settings.sha256 === snapshot.settings.sha256));
+  return settings ? { unchanged, catalog, settings } : { unchanged, catalog };
+}

--- a/electron/catalog-registry.ts
+++ b/electron/catalog-registry.ts
@@ -207,6 +207,16 @@ function serialize<T>(queue: { current: Promise<void> }, operation: () => Promis
   return next;
 }
 
+const registryQueues = new Map<string, { current: Promise<void> }>();
+
+function registryQueue(filePath: string): { current: Promise<void> } {
+  const existing = registryQueues.get(filePath);
+  if (existing) return existing;
+  const created = { current: Promise.resolve() };
+  registryQueues.set(filePath, created);
+  return created;
+}
+
 export interface CatalogRegistryStore {
   readonly filePath: string;
   read(): Promise<CatalogRegistryDocument>;
@@ -217,7 +227,7 @@ export interface CatalogRegistryStore {
 
 export function createCatalogRegistryStore(userDataPath: string): CatalogRegistryStore {
   const filePath = path.join(path.resolve(userDataPath), CATALOG_REGISTRY_FILENAME);
-  const queue = { current: Promise.resolve() };
+  const queue = registryQueue(filePath);
   return {
     filePath,
     read: () => serialize(queue, () => readFile(filePath)),

--- a/electron/catalog-v3-migration.ts
+++ b/electron/catalog-v3-migration.ts
@@ -1,0 +1,1128 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import {
+  copyMigrationRecoveryEvidence,
+  readMigrationSources,
+  recheckMigrationSources,
+  type RecoveryEvidence,
+} from "./catalog-migration-snapshot.ts";
+import {
+  createCatalogRegistryStore,
+  type CatalogRegistryEntry,
+} from "./catalog-registry.ts";
+import {
+  createCatalogWorkerClient,
+  type CatalogWorkerClient,
+} from "./catalog-worker-client.ts";
+import {
+  prepareLegacyMigration,
+  type CompleteOnlineScan,
+  type LegacyCatalogParser,
+  type LegacyMigrationPlan,
+  type XmpEvidence,
+} from "../lib/catalog/legacy-migration.ts";
+import {
+  parseCatalogId,
+  parseOperationId,
+  parseRootId,
+  type CatalogId,
+  type OperationId,
+  type RootId,
+} from "../lib/catalog/ids.ts";
+import {
+  CATALOG_V3_APPLICATION_ID,
+  CATALOG_V3_SCHEMA_VERSION,
+  type CatalogV3AssetCandidate,
+  type CatalogV3ExpectedCounts,
+  type CatalogV3FingerprintCoverage,
+  type CatalogV3MetadataInput,
+  type CatalogV3RootInput,
+  type CatalogV3Summary,
+  type CatalogV3ValidationReport,
+} from "../lib/catalog/v3.ts";
+import { catalogV3ExpectedStateSha256 } from "./catalog-v3-state.ts";
+
+const ENVELOPE_VERSION = 1;
+const ASSET_BATCH_SIZE = 250;
+const ALBUM_MEMBERSHIP_CHUNK_SIZE = 249;
+const ARCHIVE_CHUNK_SIZE = 250;
+
+export type CatalogV3MigrationEnvelopePhase =
+  | "source-snapshotted"
+  | "database-building"
+  | "database-ready"
+  | "database-installed"
+  | "registry-activated";
+
+export interface CatalogV3MigrationInstallerInput {
+  readonly userDataPath: string;
+  readonly workerPath: string;
+  readonly catalogPath: string;
+  readonly settingsPath?: string;
+  readonly catalogId: CatalogId;
+  readonly rootId: RootId;
+  readonly migrationId: OperationId;
+  readonly displayName: string;
+  readonly appVersion: string;
+  readonly parseCatalog: LegacyCatalogParser;
+  readonly onlineScan?: CompleteOnlineScan;
+  readonly xmpByRelativePath?: Readonly<Record<string, XmpEvidence>>;
+  readonly afterFirstAssetBatch?: () => void | Promise<void>;
+  readonly beforeSourceRecheck?: () => void | Promise<void>;
+  readonly afterFinalDatabaseLink?: () => void | Promise<void>;
+  readonly beforeRegistryActivation?: () => void | Promise<void>;
+  readonly afterRegistryActivation?: () => void | Promise<void>;
+}
+
+export interface CatalogV3MigrationEnvelope {
+  readonly version: 1;
+  readonly phase: CatalogV3MigrationEnvelopePhase;
+  readonly catalogId: CatalogId;
+  readonly rootId: RootId;
+  readonly migrationId: OperationId;
+  readonly displayName: string;
+  readonly appVersion: string;
+  readonly planSha256: string;
+  readonly sources: {
+    readonly catalog: {
+      readonly path: string;
+      readonly sha256: string;
+      readonly byteLength: number;
+    };
+    readonly settings?: {
+      readonly path: string;
+      readonly sha256: string;
+      readonly byteLength: number;
+    };
+  };
+  readonly recoveryEvidence: RecoveryEvidence;
+  readonly stagingDatabasePath: string;
+  readonly finalDatabasePath: string;
+  readonly validationReport?: CatalogV3ValidationReport;
+}
+
+export interface CatalogV3MigrationInstallerResult {
+  readonly envelopePath: string;
+  readonly phase: "registry-activated";
+  readonly databasePath: string;
+  readonly recoveryEvidence: RecoveryEvidence;
+  readonly validationReport: CatalogV3ValidationReport;
+  readonly before: LegacyMigrationPlan["counts"];
+  readonly after: CatalogV3Summary["counts"];
+  readonly fingerprintCoverage: CatalogV3FingerprintCoverage;
+  readonly limitations: readonly string[];
+  readonly registryEntry: CatalogRegistryEntry;
+}
+
+type RecordValue = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(value: unknown, code: string): boolean {
+  return typeof value === "object" && value !== null && "code" in value && value.code === code;
+}
+
+function requireAbsoluteNormalizedPath(value: string, label: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.includes("\0") ||
+    !path.isAbsolute(value) ||
+    path.normalize(value) !== value
+  ) {
+    throw new Error(`${label} must be an absolute normalized path.`);
+  }
+  return value;
+}
+
+function requireNonemptyString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\0")) {
+    throw new Error(`${label} must be a nonempty NUL-free string.`);
+  }
+  return value;
+}
+
+function requireHash(value: unknown, label: string): string {
+  const hash = requireNonemptyString(value, label);
+  if (!/^[0-9a-f]{64}$/.test(hash)) {
+    throw new Error(`${label} must be a lowercase SHA-256 hash.`);
+  }
+  return hash;
+}
+
+function requireNonnegativeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a nonnegative integer.`);
+  }
+  return value;
+}
+
+function requireStringArray(value: unknown, label: string): readonly string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array.`);
+  }
+  return value.map((item, index) => requireNonemptyString(item, `${label}[${index}]`));
+}
+
+function ensureInside(parent: string, child: string, label: string): string {
+  const relative = path.relative(parent, child);
+  if (relative.length === 0 || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${label} escaped its parent directory.`);
+  }
+  return child;
+}
+
+function pathsFor(input: CatalogV3MigrationInstallerInput): {
+  readonly envelopePath: string;
+  readonly stagingDatabasePath: string;
+  readonly finalDatabasePath: string;
+} {
+  const userDataPath = requireAbsoluteNormalizedPath(input.userDataPath, "userDataPath");
+  const catalogId = parseCatalogId(input.catalogId);
+  const migrationId = parseOperationId(input.migrationId);
+  const migrationDirectory = path.join(userDataPath, "catalog-migrations");
+  const catalogDirectory = path.join(userDataPath, "catalogs-v3");
+  const envelopePath = ensureInside(
+    migrationDirectory,
+    path.join(migrationDirectory, `${migrationId}.json`),
+    "Migration envelope",
+  );
+  const stagingDatabasePath = ensureInside(
+    catalogDirectory,
+    path.join(catalogDirectory, `.${catalogId}.${migrationId}.sqlite.tmp`),
+    "Staging database",
+  );
+  const finalDatabasePath = ensureInside(
+    catalogDirectory,
+    path.join(catalogDirectory, `${catalogId}.sqlite`),
+    "Final database",
+  );
+  return { envelopePath, stagingDatabasePath, finalDatabasePath };
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch (error) {
+    if (isNodeError(error, "ENOENT")) return false;
+    throw error;
+  }
+}
+
+async function syncDirectory(directoryPath: string): Promise<void> {
+  if (process.platform === "win32") return;
+  let handle: FileHandle | undefined;
+  try {
+    handle = await fs.open(directoryPath, "r");
+    await handle.sync();
+  } catch (error) {
+    if (!isNodeError(error, "EINVAL") && !isNodeError(error, "ENOTSUP") && !isNodeError(error, "ENOSYS")) {
+      throw error;
+    }
+  } finally {
+    await handle?.close();
+  }
+}
+
+async function syncFile(filePath: string): Promise<void> {
+  const handle = await fs.open(filePath, "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeJsonAtomically(filePath: string, value: unknown): Promise<void> {
+  const directory = path.dirname(filePath);
+  await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+  const temporaryPath = path.join(directory, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+  let handle: FileHandle | undefined;
+  try {
+    handle = await fs.open(temporaryPath, "wx", 0o600);
+    await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await fs.rename(temporaryPath, filePath);
+    await syncDirectory(directory);
+  } finally {
+    await handle?.close().catch(() => undefined);
+    await fs.unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+function parseExpectedCounts(value: unknown, label: string): CatalogV3ExpectedCounts {
+  if (!isRecord(value)) throw new Error(`${label} must be an object.`);
+  return {
+    assets: requireNonnegativeInteger(value.assets, `${label}.assets`),
+    metadata: requireNonnegativeInteger(value.metadata, `${label}.metadata`),
+    albums: requireNonnegativeInteger(value.albums, `${label}.albums`),
+    albumAssets: requireNonnegativeInteger(value.albumAssets, `${label}.albumAssets`),
+    archived: requireNonnegativeInteger(value.archived, `${label}.archived`),
+    aliases: requireNonnegativeInteger(value.aliases, `${label}.aliases`),
+    fingerprints: requireNonnegativeInteger(value.fingerprints, `${label}.fingerprints`),
+    present: requireNonnegativeInteger(value.present, `${label}.present`),
+    missing: requireNonnegativeInteger(value.missing, `${label}.missing`),
+  };
+}
+
+function parseFingerprintCoverage(value: unknown, label: string): CatalogV3FingerprintCoverage {
+  if (!isRecord(value)) throw new Error(`${label} must be an object.`);
+  return {
+    total: requireNonnegativeInteger(value.total, `${label}.total`),
+    missing: requireNonnegativeInteger(value.missing, `${label}.missing`),
+    hashing: requireNonnegativeInteger(value.hashing, `${label}.hashing`),
+    valid: requireNonnegativeInteger(value.valid, `${label}.valid`),
+    stale: requireNonnegativeInteger(value.stale, `${label}.stale`),
+    failed: requireNonnegativeInteger(value.failed, `${label}.failed`),
+  };
+}
+
+function parseValidationReport(value: unknown): CatalogV3ValidationReport {
+  if (!isRecord(value)) throw new Error("Migration validation report must be an object.");
+  if (value.clean !== true) throw new Error("Migration validation report must be clean.");
+  if (!isRecord(value.after) || !isRecord(value.relationFailures) || !isRecord(value.integrity)) {
+    throw new Error("Migration validation report is malformed.");
+  }
+  const integrityCheck = requireStringArray(value.integrity.integrityCheck, "validationReport.integrity.integrityCheck");
+  if (!Array.isArray(value.integrity.foreignKeyCheck)) {
+    throw new Error("validationReport.integrity.foreignKeyCheck must be an array.");
+  }
+  const foreignKeyCheck = value.integrity.foreignKeyCheck.map((item, index) => {
+    if (!isRecord(item)) throw new Error(`validationReport.integrity.foreignKeyCheck[${index}] is invalid.`);
+    const rowId = item.rowId;
+    if (rowId !== null && (typeof rowId !== "number" || !Number.isFinite(rowId))) {
+      throw new Error(`validationReport.integrity.foreignKeyCheck[${index}].rowId is invalid.`);
+    }
+    return {
+      table: requireNonemptyString(item.table, `validationReport.integrity.foreignKeyCheck[${index}].table`),
+      rowId,
+      parent: requireNonemptyString(item.parent, `validationReport.integrity.foreignKeyCheck[${index}].parent`),
+      foreignKeyIndex: requireNonnegativeInteger(item.foreignKeyIndex, `validationReport.integrity.foreignKeyCheck[${index}].foreignKeyIndex`),
+    };
+  });
+  const after = {
+    ...parseExpectedCounts(value.after, "validationReport.after"),
+    ambiguous: requireNonnegativeInteger(value.after.ambiguous, "validationReport.after.ambiguous"),
+    unreadable: requireNonnegativeInteger(value.after.unreadable, "validationReport.after.unreadable"),
+  };
+  const report: CatalogV3ValidationReport = {
+    catalogId: parseCatalogId(value.catalogId),
+    migrationId: requireNonemptyString(value.migrationId, "validationReport.migrationId"),
+    clean: true,
+    before: parseExpectedCounts(value.before, "validationReport.before"),
+    after,
+    fingerprintCoverage: parseFingerprintCoverage(value.fingerprintCoverage, "validationReport.fingerprintCoverage"),
+    expectedStateSha256: requireHash(value.expectedStateSha256, "validationReport.expectedStateSha256"),
+    actualStateSha256: requireHash(value.actualStateSha256, "validationReport.actualStateSha256"),
+    relationFailures: {
+      aliases: requireNonnegativeInteger(value.relationFailures.aliases, "validationReport.relationFailures.aliases"),
+      albums: requireNonnegativeInteger(value.relationFailures.albums, "validationReport.relationFailures.albums"),
+      albumAssets: requireNonnegativeInteger(value.relationFailures.albumAssets, "validationReport.relationFailures.albumAssets"),
+      archived: requireNonnegativeInteger(value.relationFailures.archived, "validationReport.relationFailures.archived"),
+    },
+    integrity: { integrityCheck, foreignKeyCheck },
+    applicationId: requireNonnegativeInteger(value.applicationId, "validationReport.applicationId"),
+    schemaVersion: requireNonnegativeInteger(value.schemaVersion, "validationReport.schemaVersion"),
+    userVersion: requireNonnegativeInteger(value.userVersion, "validationReport.userVersion"),
+    limitations: requireStringArray(value.limitations, "validationReport.limitations"),
+    blockingErrors: requireStringArray(value.blockingErrors, "validationReport.blockingErrors"),
+  };
+  const countKeys: readonly (keyof CatalogV3ExpectedCounts)[] = [
+    "assets",
+    "metadata",
+    "albums",
+    "albumAssets",
+    "archived",
+    "aliases",
+    "fingerprints",
+    "present",
+    "missing",
+  ];
+  if (
+    report.applicationId !== CATALOG_V3_APPLICATION_ID ||
+    report.schemaVersion !== CATALOG_V3_SCHEMA_VERSION ||
+    report.userVersion !== CATALOG_V3_SCHEMA_VERSION ||
+    countKeys.some((key) => report.before[key] !== report.after[key]) ||
+    report.after.assets !== report.after.present + report.after.missing + report.after.ambiguous + report.after.unreadable ||
+    report.expectedStateSha256 !== report.actualStateSha256 ||
+    report.fingerprintCoverage.total !== report.after.fingerprints ||
+    report.fingerprintCoverage.missing !== report.after.assets ||
+    report.fingerprintCoverage.hashing !== 0 ||
+    report.fingerprintCoverage.valid !== 0 ||
+    report.fingerprintCoverage.stale !== 0 ||
+    report.fingerprintCoverage.failed !== 0 ||
+    Object.values(report.relationFailures).some((count) => count !== 0) ||
+    report.integrity.integrityCheck.length !== 1 ||
+    report.integrity.integrityCheck[0] !== "ok" ||
+    report.integrity.foreignKeyCheck.length !== 0 ||
+    report.blockingErrors.length !== 0
+  ) {
+    throw new Error("Migration validation report is inconsistent.");
+  }
+  return report;
+}
+
+function parseRecoveryEvidence(value: unknown): RecoveryEvidence {
+  if (!isRecord(value) || !Array.isArray(value.files)) {
+    throw new Error("Migration recovery evidence is invalid.");
+  }
+  const directory = requireAbsoluteNormalizedPath(
+    requireNonemptyString(value.directory, "recoveryEvidence.directory"),
+    "recoveryEvidence.directory",
+  );
+  const names = new Set<string>();
+  const files = value.files.map((item, index) => {
+    if (!isRecord(item)) throw new Error(`recoveryEvidence.files[${index}] is invalid.`);
+    const name: "catalog.json" | "settings.json" = item.name === "catalog.json"
+      ? "catalog.json"
+      : item.name === "settings.json"
+        ? "settings.json"
+        : (() => {
+          throw new Error(`recoveryEvidence.files[${index}].name is invalid.`);
+        })();
+    if (names.has(name)) throw new Error("Migration recovery evidence duplicates a file.");
+    names.add(name);
+    return {
+      name,
+      path: requireAbsoluteNormalizedPath(
+        requireNonemptyString(item.path, `recoveryEvidence.files[${index}].path`),
+        `recoveryEvidence.files[${index}].path`,
+      ),
+      sha256: requireHash(item.sha256, `recoveryEvidence.files[${index}].sha256`),
+      byteLength: requireNonnegativeInteger(item.byteLength, `recoveryEvidence.files[${index}].byteLength`),
+    };
+  });
+  if (!names.has("catalog.json")) throw new Error("Migration recovery evidence is missing catalog.json.");
+  return { directory, files };
+}
+
+function parseEnvelope(value: unknown): CatalogV3MigrationEnvelope {
+  if (!isRecord(value) || value.version !== ENVELOPE_VERSION || !isRecord(value.sources)) {
+    throw new Error("Catalog v3 migration envelope is invalid.");
+  }
+  const phase = value.phase;
+  if (
+    phase !== "source-snapshotted" &&
+    phase !== "database-building" &&
+    phase !== "database-ready" &&
+    phase !== "database-installed" &&
+    phase !== "registry-activated"
+  ) {
+    throw new Error("Catalog v3 migration envelope phase is invalid.");
+  }
+  const parseSource = (source: unknown, label: string) => {
+    if (!isRecord(source)) throw new Error(`${label} is invalid.`);
+    return {
+      path: requireAbsoluteNormalizedPath(requireNonemptyString(source.path, `${label}.path`), `${label}.path`),
+      sha256: requireHash(source.sha256, `${label}.sha256`),
+      byteLength: requireNonnegativeInteger(source.byteLength, `${label}.byteLength`),
+    };
+  };
+  const settings = value.sources.settings === undefined
+    ? undefined
+    : parseSource(value.sources.settings, "sources.settings");
+  const validationReport = value.validationReport === undefined
+    ? undefined
+    : parseValidationReport(value.validationReport);
+  return {
+    version: 1,
+    phase,
+    catalogId: parseCatalogId(value.catalogId),
+    rootId: parseRootId(value.rootId),
+    migrationId: parseOperationId(value.migrationId),
+    displayName: requireNonemptyString(value.displayName, "displayName"),
+    appVersion: requireNonemptyString(value.appVersion, "appVersion"),
+    planSha256: requireHash(value.planSha256, "planSha256"),
+    sources: {
+      catalog: parseSource(value.sources.catalog, "sources.catalog"),
+      ...(settings === undefined ? {} : { settings }),
+    },
+    recoveryEvidence: parseRecoveryEvidence(value.recoveryEvidence),
+    stagingDatabasePath: requireAbsoluteNormalizedPath(
+      requireNonemptyString(value.stagingDatabasePath, "stagingDatabasePath"),
+      "stagingDatabasePath",
+    ),
+    finalDatabasePath: requireAbsoluteNormalizedPath(
+      requireNonemptyString(value.finalDatabasePath, "finalDatabasePath"),
+      "finalDatabasePath",
+    ),
+    ...(validationReport === undefined ? {} : { validationReport }),
+  };
+}
+
+async function readEnvelope(filePath: string): Promise<CatalogV3MigrationEnvelope | null> {
+  try {
+    return parseEnvelope(JSON.parse(await fs.readFile(filePath, "utf8")));
+  } catch (error) {
+    if (isNodeError(error, "ENOENT")) return null;
+    throw error;
+  }
+}
+
+function sourceFromSnapshot(snapshot: Awaited<ReturnType<typeof readMigrationSources>>): CatalogV3MigrationEnvelope["sources"] {
+  return {
+    catalog: {
+      path: snapshot.catalog.path,
+      sha256: snapshot.catalog.sha256,
+      byteLength: snapshot.catalog.bytes.byteLength,
+    },
+    ...(snapshot.settings === undefined
+      ? {}
+      : {
+        settings: {
+          path: snapshot.settings.path,
+          sha256: snapshot.settings.sha256,
+          byteLength: snapshot.settings.bytes.byteLength,
+        },
+      }),
+  };
+}
+
+function createEnvelope(
+  input: CatalogV3MigrationInstallerInput,
+  paths: ReturnType<typeof pathsFor>,
+  snapshot: Awaited<ReturnType<typeof readMigrationSources>>,
+  recoveryEvidence: RecoveryEvidence,
+  planSha256: string,
+): CatalogV3MigrationEnvelope {
+  return {
+    version: 1,
+    phase: "source-snapshotted",
+    catalogId: parseCatalogId(input.catalogId),
+    rootId: parseRootId(input.rootId),
+    migrationId: parseOperationId(input.migrationId),
+    displayName: requireNonemptyString(input.displayName, "displayName"),
+    appVersion: requireNonemptyString(input.appVersion, "appVersion"),
+    planSha256: requireHash(planSha256, "planSha256"),
+    sources: sourceFromSnapshot(snapshot),
+    recoveryEvidence,
+    stagingDatabasePath: paths.stagingDatabasePath,
+    finalDatabasePath: paths.finalDatabasePath,
+  };
+}
+
+function assertSameEnvelope(
+  existing: CatalogV3MigrationEnvelope,
+  expected: CatalogV3MigrationEnvelope,
+): CatalogV3MigrationEnvelope {
+  if (
+    existing.catalogId !== expected.catalogId ||
+    existing.rootId !== expected.rootId ||
+    existing.migrationId !== expected.migrationId ||
+    existing.displayName !== expected.displayName ||
+    existing.appVersion !== expected.appVersion ||
+    existing.planSha256 !== expected.planSha256 ||
+    existing.stagingDatabasePath !== expected.stagingDatabasePath ||
+    existing.finalDatabasePath !== expected.finalDatabasePath ||
+    existing.sources.catalog.path !== expected.sources.catalog.path ||
+    existing.sources.catalog.sha256 !== expected.sources.catalog.sha256 ||
+    existing.sources.catalog.byteLength !== expected.sources.catalog.byteLength ||
+    existing.sources.settings?.path !== expected.sources.settings?.path ||
+    existing.sources.settings?.sha256 !== expected.sources.settings?.sha256 ||
+    existing.sources.settings?.byteLength !== expected.sources.settings?.byteLength ||
+    existing.recoveryEvidence.directory !== expected.recoveryEvidence.directory
+  ) {
+    throw new Error("Catalog v3 migration envelope conflicts with this migration input.");
+  }
+  return existing;
+}
+
+function envelopeAtPhase(
+  envelope: CatalogV3MigrationEnvelope,
+  phase: CatalogV3MigrationEnvelopePhase,
+  validationReport?: CatalogV3ValidationReport,
+): CatalogV3MigrationEnvelope {
+  return {
+    ...envelope,
+    phase,
+    ...(validationReport === undefined ? {} : { validationReport }),
+  };
+}
+
+function extensionFormat(relativePath: string): string {
+  const extension = path.posix.extname(relativePath).slice(1).toLowerCase();
+  return extension.length > 0 ? extension : "unknown";
+}
+
+function rootLabel(rootPath: string): string {
+  const segments = rootPath.replaceAll("\\", "/").split("/").filter((segment) => segment.length > 0);
+  return segments.at(-1) ?? rootPath;
+}
+
+function serializeDevelop(value: unknown): string | null {
+  if (value === undefined) return null;
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) throw new Error("Legacy Develop metadata is not serializable.");
+  return serialized;
+}
+
+function metadataForCandidate(candidate: LegacyMigrationPlan["candidates"][number]): CatalogV3MetadataInput {
+  const metadata = candidate.metadata;
+  const rawXmp = candidate.xmp.state === "preserved" ? candidate.xmp.contents ?? null : null;
+  if (rawXmp !== null) {
+    const digest = createHash("sha256").update(rawXmp, "utf8").digest("hex");
+    if (digest !== candidate.xmp.sha256) {
+      throw new Error(`XMP evidence hash does not match ${candidate.relativePath}.`);
+    }
+  }
+  return {
+    archive: candidate.sourceFlags.archive,
+    pick: metadata?.pick ?? "none",
+    rating: metadata?.rating ?? 0,
+    colorLabel: metadata?.colorLabel ?? null,
+    developJson: serializeDevelop(metadata?.develop),
+    developUpdatedAt: metadata?.developUpdatedAt ?? 0,
+    updatedAt: metadata?.updatedAt ?? 0,
+    title: null,
+    caption: null,
+    copyright: null,
+    keywordsJson: "[]",
+    rawXmp,
+    xmpState: candidate.xmp.state,
+    xmpMtime: candidate.xmp.modifiedAt ?? null,
+    xmpSha256: candidate.xmp.sha256 ?? null,
+  };
+}
+
+function candidateForV3(
+  candidate: LegacyMigrationPlan["candidates"][number],
+  rootId: RootId,
+): CatalogV3AssetCandidate {
+  const observation = candidate.observation;
+  return {
+    rootId,
+    relativePath: candidate.relativePath,
+    observation: observation === null
+      ? null
+      : {
+        byteLength: observation.byteLength,
+        modifiedAt: observation.modifiedAt,
+        observedAt: observation.observedAt,
+        localFileId: observation.localFileId,
+      },
+    health: candidate.health,
+    formatId: observation?.formatId ?? extensionFormat(candidate.relativePath),
+    cameraMake: null,
+    cameraModel: null,
+    lensModel: null,
+    legacyIds: [candidate.legacyIdAlias],
+    metadata: metadataForCandidate(candidate),
+    fingerprint: {
+      status: "missing",
+      sha256: null,
+      observedAt: observation?.observedAt ?? null,
+      observedByteLength: observation?.byteLength ?? null,
+      observedModifiedAt: observation?.modifiedAt ?? null,
+      localFileId: observation?.localFileId ?? null,
+    },
+  };
+}
+
+function candidatesForPlan(plan: LegacyMigrationPlan, rootId: RootId): readonly CatalogV3AssetCandidate[] {
+  return plan.candidates.map((candidate) => candidateForV3(candidate, rootId));
+}
+
+function expectedCounts(plan: LegacyMigrationPlan): CatalogV3ExpectedCounts {
+  return {
+    assets: plan.counts.expectedTotalAssets,
+    metadata: plan.counts.expectedTotalAssets,
+    albums: plan.counts.albums,
+    albumAssets: plan.counts.albumMemberships,
+    archived: plan.counts.archiveReferences,
+    aliases: plan.counts.expectedAliases,
+    fingerprints: plan.counts.expectedTotalAssets,
+    present: plan.counts.expectedPresentAssets,
+    missing: plan.counts.expectedMissingAssets,
+  };
+}
+
+function migrationPlanSha256(plan: LegacyMigrationPlan): string {
+  const serialized = JSON.stringify({
+    rawCatalogVersion: plan.rawCatalogVersion,
+    rootPath: plan.catalog.rootPath,
+    scan: plan.scan,
+    candidates: plan.candidates,
+    albums: plan.albums,
+    archivedEntryIds: plan.archivedEntryIds,
+    counts: plan.counts,
+  });
+  return createHash("sha256").update(serialized, "utf8").digest("hex");
+}
+
+async function rootForPlan(plan: LegacyMigrationPlan, rootId: RootId): Promise<CatalogV3RootInput> {
+  const online = plan.scan === "online";
+  let canonicalPath: string | null = null;
+  if (online) {
+    canonicalPath = await fs.realpath(plan.catalog.rootPath);
+    const rootStat = await fs.stat(canonicalPath);
+    if (!rootStat.isDirectory()) {
+      throw new Error("Online migration root must be a directory.");
+    }
+  }
+  return {
+    rootId,
+    label: rootLabel(plan.catalog.rootPath),
+    configuredPath: plan.catalog.rootPath,
+    canonicalPath,
+    health: online ? "online" as const : "missing" as const,
+    scanState: online ? "complete" as const : "unknown" as const,
+    watchState: "disabled" as const,
+  };
+}
+
+async function closeWorker(worker: CatalogWorkerClient | undefined): Promise<void> {
+  if (!worker) return;
+  try {
+    await worker.close();
+    await worker.shutdown();
+  } catch {
+    await worker.forceTerminate().catch(() => undefined);
+  }
+}
+
+async function openWorker(workerPath: string, databasePath: string): Promise<CatalogWorkerClient> {
+  const worker = createCatalogWorkerClient({
+    workerPath: requireAbsoluteNormalizedPath(workerPath, "workerPath"),
+    requestTimeoutMs: 20_000,
+  });
+  try {
+    await worker.open(databasePath);
+    return worker;
+  } catch (error) {
+    await worker.forceTerminate().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function importPlan(
+  worker: CatalogWorkerClient,
+  plan: LegacyMigrationPlan,
+  candidates: readonly CatalogV3AssetCandidate[],
+  input: CatalogV3MigrationInstallerInput,
+): Promise<void> {
+  const catalogId = parseCatalogId(input.catalogId);
+  const migrationId = parseOperationId(input.migrationId);
+  let batchWritten = false;
+  for (let start = 0; start < candidates.length; start += ASSET_BATCH_SIZE) {
+    await worker.writeV3AssetBatch({
+      catalogId,
+      migrationId,
+      assets: candidates.slice(start, start + ASSET_BATCH_SIZE),
+    });
+    if (!batchWritten) {
+      batchWritten = true;
+      await input.afterFirstAssetBatch?.();
+    }
+  }
+
+  let relationRequestCount = 0;
+  for (const [albumPosition, album] of plan.albums.entries()) {
+    if (album.entryIds.length === 0) {
+      await worker.writeV3RelationsBatch({
+        catalogId,
+        migrationId,
+        albums: [{ ...album, position: albumPosition, positionOffset: 0 }],
+        archiveLegacyIds: [],
+      });
+      relationRequestCount += 1;
+      continue;
+    }
+    for (let start = 0; start < album.entryIds.length; start += ALBUM_MEMBERSHIP_CHUNK_SIZE) {
+      await worker.writeV3RelationsBatch({
+        catalogId,
+        migrationId,
+        albums: [{
+          id: album.id,
+          name: album.name,
+          createdAt: album.createdAt,
+          updatedAt: album.updatedAt,
+          position: albumPosition,
+          positionOffset: start,
+          entryIds: album.entryIds.slice(start, start + ALBUM_MEMBERSHIP_CHUNK_SIZE),
+        }],
+        archiveLegacyIds: [],
+      });
+      relationRequestCount += 1;
+    }
+  }
+  for (let start = 0; start < plan.archivedEntryIds.length; start += ARCHIVE_CHUNK_SIZE) {
+    await worker.writeV3RelationsBatch({
+      catalogId,
+      migrationId,
+      albums: [],
+      archiveLegacyIds: plan.archivedEntryIds.slice(start, start + ARCHIVE_CHUNK_SIZE),
+    });
+    relationRequestCount += 1;
+  }
+  if (relationRequestCount === 0) {
+    await worker.writeV3RelationsBatch({ catalogId, migrationId, albums: [], archiveLegacyIds: [] });
+  }
+}
+
+function assertSummary(
+  summary: CatalogV3Summary,
+  envelope: CatalogV3MigrationEnvelope,
+  expected: CatalogV3ExpectedCounts,
+  expectedStateSha256: string,
+  expectedRoot: CatalogV3RootInput,
+): void {
+  const migration = summary.migration;
+  if (
+    summary.catalogId !== envelope.catalogId ||
+    summary.displayName !== envelope.displayName ||
+    summary.appVersion !== envelope.appVersion ||
+    summary.migrationId !== envelope.migrationId ||
+    summary.installState !== "ready" ||
+    summary.migrationPhase !== "validated" ||
+    migration.migrationId !== envelope.migrationId ||
+    migration.sourceVersion !== summary.sourceVersion ||
+    migration.catalogPath !== envelope.sources.catalog.path ||
+    migration.catalogSha256 !== envelope.sources.catalog.sha256 ||
+    migration.settingsPath !== (envelope.sources.settings?.path ?? null) ||
+    migration.settingsSha256 !== (envelope.sources.settings?.sha256 ?? null) ||
+    migration.rootAvailable !== (expectedRoot.health === "online") ||
+    JSON.stringify(migration.expectedCounts) !== JSON.stringify(expected) ||
+    migration.expectedStateSha256 !== expectedStateSha256 ||
+    JSON.stringify(summary.root) !== JSON.stringify(expectedRoot) ||
+    summary.counts.assets !== expected.assets ||
+    summary.counts.metadata !== expected.metadata ||
+    summary.counts.albums !== expected.albums ||
+    summary.counts.albumAssets !== expected.albumAssets ||
+    summary.counts.archived !== expected.archived ||
+    summary.counts.aliases !== expected.aliases ||
+    summary.counts.fingerprints !== expected.fingerprints ||
+    summary.counts.present !== expected.present ||
+    summary.counts.missing !== expected.missing
+  ) {
+    throw new Error("Catalog v3 installed database does not match the migration envelope.");
+  }
+}
+
+async function verifyFinalDatabase(
+  input: CatalogV3MigrationInstallerInput,
+  envelope: CatalogV3MigrationEnvelope,
+  expected: CatalogV3ExpectedCounts,
+  expectedStateSha256: string,
+  expectedRoot: CatalogV3RootInput,
+): Promise<CatalogV3Summary> {
+  let worker: CatalogWorkerClient | undefined;
+  try {
+    worker = await openWorker(input.workerPath, envelope.finalDatabasePath);
+    const validation = await worker.validateV3(envelope.catalogId, envelope.migrationId);
+    if (
+      !validation.report.clean ||
+      validation.report.expectedStateSha256 !== expectedStateSha256 ||
+      validation.report.actualStateSha256 !== expectedStateSha256
+    ) {
+      throw new Error("Catalog v3 final database no longer matches the frozen migration state.");
+    }
+    const summary = await worker.v3Summary(envelope.catalogId);
+    assertSummary(summary, envelope, expected, expectedStateSha256, expectedRoot);
+    const integrity = await worker.integrityCheck();
+    if (integrity.integrityCheck.length !== 1 || integrity.integrityCheck[0] !== "ok" || integrity.foreignKeyCheck.length > 0) {
+      throw new Error("Catalog v3 final database integrity verification failed.");
+    }
+    const seal = await worker.sealV3ForInstall(envelope.catalogId, envelope.migrationId);
+    if (seal.busy !== 0 || seal.journalMode !== "delete") {
+      throw new Error("Catalog v3 final database did not reseal cleanly after verification.");
+    }
+    return summary;
+  } finally {
+    await closeWorker(worker);
+  }
+}
+
+async function publishStagingDatabase(
+  envelope: CatalogV3MigrationEnvelope,
+  afterLink?: () => void | Promise<void>,
+): Promise<void> {
+  await fs.mkdir(path.dirname(envelope.finalDatabasePath), { recursive: true, mode: 0o700 });
+  await syncFile(envelope.stagingDatabasePath);
+  try {
+    await fs.link(envelope.stagingDatabasePath, envelope.finalDatabasePath);
+  } catch (error) {
+    if (isNodeError(error, "EEXIST")) {
+      throw new Error("Catalog v3 final database already exists and will not be overwritten.");
+    }
+    throw error;
+  }
+  await syncDirectory(path.dirname(envelope.finalDatabasePath));
+  await afterLink?.();
+  try {
+    await fs.unlink(envelope.stagingDatabasePath);
+  } catch (error) {
+    throw new Error(
+      `Catalog v3 final database was published but staging cleanup failed: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+  }
+  await syncDirectory(path.dirname(envelope.finalDatabasePath));
+}
+
+async function recoverLinkedPublish(envelope: CatalogV3MigrationEnvelope): Promise<void> {
+  if (envelope.phase !== "database-ready" || envelope.validationReport?.clean !== true) {
+    throw new Error("Catalog v3 migration has both staging and final databases. Manual recovery is required.");
+  }
+  const [stagingStat, finalStat] = await Promise.all([
+    fs.stat(envelope.stagingDatabasePath),
+    fs.stat(envelope.finalDatabasePath),
+  ]);
+  if (stagingStat.dev !== finalStat.dev || stagingStat.ino !== finalStat.ino) {
+    throw new Error("Catalog v3 staging and final databases differ. Manual recovery is required.");
+  }
+  await fs.unlink(envelope.stagingDatabasePath);
+  await syncDirectory(path.dirname(envelope.finalDatabasePath));
+}
+
+async function assertMigrationSourcesUnchanged(
+  input: CatalogV3MigrationInstallerInput,
+  snapshot: Awaited<ReturnType<typeof readMigrationSources>>,
+): Promise<void> {
+  const rechecked = await recheckMigrationSources(
+    snapshot,
+    input.settingsPath === undefined ? {} : { settingsPath: input.settingsPath },
+  );
+  if (!rechecked.unchanged) {
+    throw new Error("Legacy migration sources changed before activation. The registry was not updated.");
+  }
+}
+
+function limitationsFor(plan: LegacyMigrationPlan, report: CatalogV3ValidationReport): readonly string[] {
+  const limitations = [...report.limitations];
+  if (plan.scan === "offline" && plan.rawCatalogVersion === 2) {
+    limitations.push("offline-v2-incomplete-inventory");
+  }
+  if (plan.scan === "offline") {
+    limitations.push("offline-xmp-state-unknown");
+  }
+  return [...new Set(limitations)];
+}
+
+async function activateRegistry(
+  input: CatalogV3MigrationInstallerInput,
+  envelope: CatalogV3MigrationEnvelope,
+): Promise<CatalogRegistryEntry> {
+  const store = createCatalogRegistryStore(input.userDataPath);
+  const document = await store.read();
+  const databasePath = await fs.realpath(envelope.finalDatabasePath);
+  for (const catalog of document.catalogs) {
+    if (catalog.catalogId === envelope.catalogId && catalog.databasePath !== databasePath) {
+      throw new Error("Catalog registry already maps this catalog ID to a different database.");
+    }
+    if (catalog.catalogId !== envelope.catalogId && catalog.databasePath === databasePath) {
+      throw new Error("Catalog registry already maps this database to a different catalog.");
+    }
+  }
+  const existing = document.catalogs.find((catalog) => catalog.catalogId === envelope.catalogId);
+  const entry: CatalogRegistryEntry = existing !== undefined &&
+    existing.displayName === envelope.displayName &&
+    existing.databasePath === databasePath &&
+    existing.health === "healthy"
+    ? existing
+    : {
+      catalogId: envelope.catalogId,
+      displayName: envelope.displayName,
+      databasePath,
+      health: "healthy",
+      lastOpenedAt: Date.now(),
+    };
+  await store.upsert(entry);
+  return entry;
+}
+
+/**
+ * Installs a fully validated v3 catalog. Main startup deliberately does not call this yet.
+ */
+export async function installCatalogV3Migration(
+  input: CatalogV3MigrationInstallerInput,
+): Promise<CatalogV3MigrationInstallerResult> {
+  requireAbsoluteNormalizedPath(input.catalogPath, "catalogPath");
+  if (input.settingsPath !== undefined) requireAbsoluteNormalizedPath(input.settingsPath, "settingsPath");
+  requireAbsoluteNormalizedPath(input.userDataPath, "userDataPath");
+  requireAbsoluteNormalizedPath(input.workerPath, "workerPath");
+  const paths = pathsFor(input);
+  const snapshot = await readMigrationSources({
+    catalogPath: input.catalogPath,
+    ...(input.settingsPath === undefined ? {} : { settingsPath: input.settingsPath }),
+  });
+  const recoveryEvidence = await copyMigrationRecoveryEvidence(
+    input.userDataPath,
+    input.migrationId,
+    snapshot,
+  );
+  let rawCatalog: unknown;
+  try {
+    rawCatalog = JSON.parse(snapshot.catalog.text);
+  } catch {
+    throw new Error("Legacy catalog is not valid JSON. Recovery evidence was preserved.");
+  }
+  const plan = prepareLegacyMigration({
+    catalog: rawCatalog,
+    source: snapshot,
+    parseCatalog: input.parseCatalog,
+    ...(input.onlineScan === undefined ? {} : { onlineScan: input.onlineScan }),
+    ...(input.xmpByRelativePath === undefined ? {} : { xmpByRelativePath: input.xmpByRelativePath }),
+  });
+  const expected = expectedCounts(plan);
+  const rootId = parseRootId(input.rootId);
+  const candidates = candidatesForPlan(plan, rootId);
+  const expectedStateSha256 = catalogV3ExpectedStateSha256({
+    assets: candidates,
+    albums: plan.albums.map((album, position) => ({ ...album, position })),
+    archiveLegacyIds: plan.archivedEntryIds,
+  });
+  const expectedEnvelope = createEnvelope(
+    input,
+    paths,
+    snapshot,
+    recoveryEvidence,
+    migrationPlanSha256(plan),
+  );
+  let envelope = await readEnvelope(paths.envelopePath);
+  if (envelope === null) {
+    envelope = expectedEnvelope;
+    await writeJsonAtomically(paths.envelopePath, envelope);
+  } else {
+    envelope = assertSameEnvelope(envelope, expectedEnvelope);
+  }
+  const expectedRoot = await rootForPlan(plan, envelope.rootId);
+
+  const stagingExists = await exists(envelope.stagingDatabasePath);
+  const finalExists = await exists(envelope.finalDatabasePath);
+  if (stagingExists && finalExists) {
+    await recoverLinkedPublish(envelope);
+  }
+
+  let report = envelope.validationReport;
+  let summary: CatalogV3Summary;
+  if (finalExists) {
+    if (
+      envelope.phase !== "database-ready" &&
+      envelope.phase !== "database-installed" &&
+      envelope.phase !== "registry-activated"
+    ) {
+      throw new Error("Catalog v3 final database exists without a ready migration envelope.");
+    }
+    if (report === undefined) throw new Error("Catalog v3 final database has no clean validation report.");
+    summary = await verifyFinalDatabase(input, envelope, expected, expectedStateSha256, expectedRoot);
+    if (envelope.phase === "database-ready") {
+      envelope = envelopeAtPhase(envelope, "database-installed", report);
+      await writeJsonAtomically(paths.envelopePath, envelope);
+    }
+  } else {
+    if (envelope.phase === "database-installed" || envelope.phase === "registry-activated") {
+      throw new Error("Catalog v3 migration envelope claims an installed database that is missing.");
+    }
+    if (envelope.phase === "source-snapshotted") {
+      envelope = envelopeAtPhase(envelope, "database-building");
+      await writeJsonAtomically(paths.envelopePath, envelope);
+    }
+    let worker: CatalogWorkerClient | undefined;
+    let stagedWorkerCompleted = false;
+    try {
+      await fs.mkdir(path.dirname(envelope.stagingDatabasePath), { recursive: true, mode: 0o700 });
+      worker = await openWorker(input.workerPath, envelope.stagingDatabasePath);
+      await worker.installV3({
+        catalogId: envelope.catalogId,
+        displayName: envelope.displayName,
+        appVersion: envelope.appVersion,
+        root: expectedRoot,
+        migration: {
+          migrationId: envelope.migrationId,
+          sourceVersion: plan.rawCatalogVersion,
+          catalogPath: snapshot.catalog.path,
+          settingsPath: snapshot.settings?.path ?? null,
+          catalogSha256: snapshot.catalog.sha256,
+          settingsSha256: snapshot.settings?.sha256 ?? null,
+          rootAvailable: plan.scan === "online",
+          expectedCounts: expected,
+          expectedStateSha256,
+        },
+      });
+      const current = await worker.v3Summary(envelope.catalogId);
+      if (current.migrationPhase === "failed") {
+        throw new Error("Catalog v3 staging database has a failed migration and cannot be replayed.");
+      }
+      if (
+        current.migrationPhase === "created" ||
+        current.migrationPhase === "copying-assets" ||
+        current.migrationPhase === "copying-relations"
+      ) {
+        await importPlan(worker, plan, candidates, input);
+        await worker.finishV3Copy(envelope.catalogId, envelope.migrationId);
+      }
+      let validated = await worker.v3Summary(envelope.catalogId);
+      if (validated.migrationPhase === "copied" || validated.migrationPhase === "validating" || validated.migrationPhase === "validated") {
+        const validation = await worker.validateV3(envelope.catalogId, envelope.migrationId);
+        if (!validation.report.clean) {
+          throw new Error(`Catalog v3 validation failed: ${validation.report.blockingErrors.join(" ")}`);
+        }
+        report = validation.report;
+        validated = await worker.v3Summary(envelope.catalogId);
+      }
+      if (validated.installState !== "ready") {
+        if (report === undefined || !report.clean) {
+          throw new Error("Catalog v3 staging database has no clean validation report.");
+        }
+        await input.beforeSourceRecheck?.();
+        await assertMigrationSourcesUnchanged(input, snapshot);
+        await worker.prepareV3Activation(envelope.catalogId, envelope.migrationId);
+      }
+      if (report === undefined || !report.clean) {
+        throw new Error("Catalog v3 staging database has no clean validation report.");
+      }
+      const seal = await worker.sealV3ForInstall(envelope.catalogId, envelope.migrationId);
+      if (seal.busy !== 0 || seal.journalMode !== "delete") {
+        throw new Error("Catalog v3 staging database did not seal cleanly.");
+      }
+      envelope = envelopeAtPhase(envelope, "database-ready", report);
+      await writeJsonAtomically(paths.envelopePath, envelope);
+      stagedWorkerCompleted = true;
+    } finally {
+      if (stagedWorkerCompleted) {
+        await closeWorker(worker);
+      } else {
+        await worker?.forceTerminate().catch(() => undefined);
+      }
+    }
+    if (await exists(`${envelope.stagingDatabasePath}-wal`) || await exists(`${envelope.stagingDatabasePath}-shm`)) {
+      throw new Error("Catalog v3 staging database still has WAL state after sealing.");
+    }
+    await assertMigrationSourcesUnchanged(input, snapshot);
+    await publishStagingDatabase(envelope, input.afterFinalDatabaseLink);
+    envelope = envelopeAtPhase(envelope, "database-installed", report);
+    await writeJsonAtomically(paths.envelopePath, envelope);
+    summary = await verifyFinalDatabase(input, envelope, expected, expectedStateSha256, expectedRoot);
+  }
+
+  if (report === undefined || !report.clean) {
+    throw new Error("Catalog v3 migration has no clean validation report.");
+  }
+  if (envelope.phase !== "registry-activated") {
+    await assertMigrationSourcesUnchanged(input, snapshot);
+  }
+  await input.beforeRegistryActivation?.();
+  const registryEntry = await activateRegistry(input, envelope);
+  await input.afterRegistryActivation?.();
+  if (envelope.phase !== "registry-activated") {
+    envelope = envelopeAtPhase(envelope, "registry-activated", report);
+    await writeJsonAtomically(paths.envelopePath, envelope);
+  }
+  return {
+    envelopePath: paths.envelopePath,
+    phase: "registry-activated",
+    databasePath: envelope.finalDatabasePath,
+    recoveryEvidence: envelope.recoveryEvidence,
+    validationReport: report,
+    before: plan.counts,
+    after: summary.counts,
+    fingerprintCoverage: summary.fingerprintCoverage,
+    limitations: limitationsFor(plan, report),
+    registryEntry,
+  };
+}

--- a/electron/catalog-v3-repository.ts
+++ b/electron/catalog-v3-repository.ts
@@ -1,0 +1,1940 @@
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+import {
+  createAssetId,
+  parseAssetId,
+  parseCatalogId,
+  parseRootId,
+  type AssetId,
+  type CatalogId,
+  type RootId,
+} from "../lib/catalog/ids.ts";
+import {
+  CATALOG_V3_MAX_ASSET_BATCH,
+  parseCatalogV3AlbumAssetPageInput,
+  parseCatalogV3AlbumPageInput,
+  parseCatalogV3AssetBatchInput,
+  parseCatalogV3AssetPageInput,
+  parseCatalogV3ExpectedCounts,
+  parseCatalogV3InstallInput,
+  parseCatalogV3RelationsBatchInput,
+  type CatalogV3ActivationResult,
+  type CatalogV3AlbumAssetPage,
+  type CatalogV3AlbumAssetPageInput,
+  type CatalogV3AlbumAssetSnapshot,
+  type CatalogV3AlbumPageInput,
+  type CatalogV3AlbumSnapshot,
+  type CatalogV3AlbumSnapshotResult,
+  type CatalogV3AssetBatchInput,
+  type CatalogV3AssetBatchResult,
+  type CatalogV3AssetCandidate,
+  type CatalogV3AssetMapping,
+  type CatalogV3AssetMetadata,
+  type CatalogV3AssetPage,
+  type CatalogV3AssetPageInput,
+  type CatalogV3AssetSnapshot,
+  type CatalogV3Counts,
+  type CatalogV3ExpectedCounts,
+  type CatalogV3FinishCopyResult,
+  type CatalogV3FingerprintCoverage,
+  type CatalogV3FingerprintInput,
+  type CatalogV3InstallInput,
+  type CatalogV3InstallResult,
+  type CatalogV3IntegrityResult,
+  type CatalogV3MigrationInput,
+  type CatalogV3MigrationPhase,
+  type CatalogV3MetadataInput,
+  type CatalogV3RelationsBatchInput,
+  type CatalogV3RelationsBatchResult,
+  type CatalogV3RootInput,
+  type CatalogV3SealForInstallResult,
+  type CatalogV3Summary,
+  type CatalogV3ValidationReport,
+  type CatalogV3ValidationResult,
+  type CatalogV3XmpState,
+} from "../lib/catalog/v3.ts";
+import type { ColorLabel, PickStatus, StarRating } from "../lib/catalog/types.ts";
+import {
+  installCatalogV3Schema,
+  isCatalogV3DatabaseEmpty,
+  verifyCatalogV3Schema,
+} from "./catalog-v3-schema.ts";
+import {
+  CatalogV3StateDigest,
+  CATALOG_V3_DEFAULT_METADATA,
+  type CatalogV3StateLocation,
+} from "./catalog-v3-state.ts";
+
+type Row = Record<string, unknown>;
+
+interface CatalogRow {
+  readonly catalogId: CatalogId;
+  readonly displayName: string;
+  readonly appVersion: string;
+  readonly installState: "staging" | "ready";
+  readonly revision: number;
+}
+
+interface MigrationRow extends CatalogV3MigrationInput {
+  readonly phase: CatalogV3MigrationPhase;
+  readonly validationReportJson: string | null;
+  readonly errorMessage: string | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+interface ExistingAsset {
+  readonly assetId: AssetId;
+  readonly rootId: RootId;
+  readonly relativePath: string;
+  readonly observedByteLength: number | null;
+  readonly observedModifiedAt: number | null;
+  readonly observedAt: number | null;
+  readonly localFileId: string | null;
+  readonly revision: number;
+  readonly health: CatalogV3AssetCandidate["health"];
+  readonly formatId: string;
+  readonly cameraMake: string | null;
+  readonly cameraModel: string | null;
+  readonly lensModel: string | null;
+}
+
+type ExistingMetadata = CatalogV3AssetMetadata;
+
+interface ExistingFingerprint {
+  readonly fingerprintId: string;
+  readonly status: CatalogV3FingerprintInput["status"];
+  readonly sha256: string | null;
+  readonly observedAt: number | null;
+  readonly observedByteLength: number | null;
+  readonly observedModifiedAt: number | null;
+  readonly localFileId: string | null;
+}
+
+interface LegacyAlias {
+  readonly assetId: AssetId;
+  readonly rootId: RootId;
+  readonly relativePath: string;
+}
+
+interface Cursor {
+  readonly relativePath: string;
+  readonly assetId: AssetId;
+}
+
+const ASSET_SNAPSHOT_SELECT = `
+  SELECT
+    a.catalog_id AS catalogId,
+    a.asset_id AS assetId,
+    a.root_id AS rootId,
+    a.relative_path AS relativePath,
+    a.observed_byte_length AS observedByteLength,
+    a.observed_modified_at AS observedModifiedAt,
+    a.observed_at AS observedAt,
+    a.local_file_id AS localFileId,
+    a.revision AS assetRevision,
+    a.health,
+    a.format_id AS formatId,
+    a.camera_make AS cameraMake,
+    a.camera_model AS cameraModel,
+    a.lens_model AS lensModel,
+    f.fingerprint_id AS fingerprintId,
+    f.status AS fingerprintStatus,
+    f.sha256 AS fingerprintSha256,
+    f.observed_at AS fingerprintObservedAt,
+    f.observed_byte_length AS fingerprintObservedByteLength,
+    f.observed_modified_at AS fingerprintObservedModifiedAt,
+    f.local_file_id AS fingerprintLocalFileId,
+    m.archive,
+    m.pick,
+    m.rating,
+    m.color_label AS colorLabel,
+    m.develop_json AS developJson,
+    m.develop_updated_at AS developUpdatedAt,
+    m.updated_at AS updatedAt,
+    m.title,
+    m.caption,
+    m.copyright,
+    m.keywords_json AS keywordsJson,
+    m.raw_xmp AS rawXmp,
+    m.xmp_state AS xmpState,
+    m.xmp_mtime AS xmpMtime,
+    m.xmp_sha256 AS xmpSha256
+  FROM assets AS a
+  JOIN asset_metadata AS m ON m.catalog_id = a.catalog_id AND m.asset_id = a.asset_id
+  JOIN fingerprints AS f ON f.catalog_id = a.catalog_id AND f.asset_id = a.asset_id
+`;
+
+function isRow(value: unknown): value is Row {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function value(row: Row, key: string): unknown {
+  return Reflect.get(row, key);
+}
+
+function stringValue(row: Row, key: string): string {
+  const item = value(row, key);
+  if (typeof item !== "string") throw new Error(`Catalog v3 ${key} result is invalid.`);
+  return item;
+}
+
+function nullableStringValue(row: Row, key: string): string | null {
+  const item = value(row, key);
+  if (item === null) return null;
+  return typeof item === "string" ? item : (() => {
+    throw new Error(`Catalog v3 ${key} result is invalid.`);
+  })();
+}
+
+function numberValue(row: Row, key: string): number {
+  const item = value(row, key);
+  if (typeof item !== "number" || !Number.isFinite(item)) {
+    throw new Error(`Catalog v3 ${key} result is invalid.`);
+  }
+  return item;
+}
+
+function integerValue(row: Row, key: string): number {
+  const item = numberValue(row, key);
+  if (!Number.isInteger(item)) throw new Error(`Catalog v3 ${key} result is invalid.`);
+  return item;
+}
+
+function nullableNumberValue(row: Row, key: string): number | null {
+  const item = value(row, key);
+  if (item === null) return null;
+  return typeof item === "number" && Number.isFinite(item)
+    ? item
+    : (() => {
+      throw new Error(`Catalog v3 ${key} result is invalid.`);
+    })();
+}
+
+function booleanInteger(valueToParse: boolean): number {
+  return valueToParse ? 1 : 0;
+}
+
+function boolFromInteger(row: Row, key: string): boolean {
+  const item = integerValue(row, key);
+  if (item !== 0 && item !== 1) throw new Error(`Catalog v3 ${key} result is invalid.`);
+  return item === 1;
+}
+
+function jsonString(valueToSerialize: unknown, key: string): string {
+  const serialized = JSON.stringify(valueToSerialize);
+  if (serialized === undefined) throw new Error(`Catalog v3 ${key} must be JSON.`);
+  return serialized;
+}
+
+function sameNullableNumber(left: number | null, right: number | null): boolean {
+  return left === right || (left !== left && right !== right);
+}
+
+function assertNonnegativeInteger(valueToCheck: number, key: string): void {
+  if (!Number.isInteger(valueToCheck) || valueToCheck < 0) {
+    throw new Error(`Catalog v3 ${key} is invalid.`);
+  }
+}
+
+function assertRelativePath(relativePath: string): void {
+  if (
+    relativePath.length === 0 ||
+    relativePath.includes("\u0000") ||
+    relativePath.includes("\\") ||
+    relativePath.startsWith("/") ||
+    relativePath.split("/").some((part) => part.length === 0 || part === "." || part === "..") ||
+    /^[A-Za-z]:[\\/]/.test(relativePath)
+  ) {
+    throw new Error("Catalog v3 relative path is unsafe.");
+  }
+}
+
+function assertHash(valueToCheck: string | null, key: string): void {
+  if (valueToCheck !== null && !/^[0-9a-f]{64}$/.test(valueToCheck)) {
+    throw new Error(`Catalog v3 ${key} is invalid.`);
+  }
+}
+
+function metadataFromCandidate(candidate: CatalogV3AssetCandidate): CatalogV3AssetMetadata {
+  return candidate.metadata ?? CATALOG_V3_DEFAULT_METADATA;
+}
+
+function fingerprintFromCandidate(candidate: CatalogV3AssetCandidate): CatalogV3FingerprintInput {
+  const observation = candidate.observation;
+  return candidate.fingerprint ?? {
+    status: "missing",
+    sha256: null,
+    observedAt: observation?.observedAt ?? null,
+    observedByteLength: observation?.byteLength ?? null,
+    observedModifiedAt: observation?.modifiedAt ?? null,
+    localFileId: observation?.localFileId ?? null,
+  };
+}
+
+function parseCatalogRow(row: unknown): CatalogRow {
+  if (!isRow(row)) throw new Error("Catalog v3 catalog row is missing.");
+  const installState = stringValue(row, "installState");
+  if (installState !== "staging" && installState !== "ready") {
+    throw new Error("Catalog v3 install state is invalid.");
+  }
+  return {
+    catalogId: parseCatalogId(stringValue(row, "catalogId")),
+    displayName: stringValue(row, "displayName"),
+    appVersion: stringValue(row, "appVersion"),
+    installState,
+    revision: integerValue(row, "revision"),
+  };
+}
+
+function parseMigrationPhase(valueToParse: string): CatalogV3MigrationPhase {
+  if (
+    valueToParse !== "created" &&
+    valueToParse !== "copying-assets" &&
+    valueToParse !== "copying-relations" &&
+    valueToParse !== "copied" &&
+    valueToParse !== "validating" &&
+    valueToParse !== "validated" &&
+    valueToParse !== "failed"
+  ) {
+    throw new Error("Catalog v3 migration phase is invalid.");
+  }
+  return valueToParse;
+}
+
+function parseExpectedCountsJson(valueToParse: string): CatalogV3ExpectedCounts {
+  try {
+    return parseCatalogV3ExpectedCounts(JSON.parse(valueToParse));
+  } catch (error) {
+    throw new Error(
+      error instanceof Error ? error.message : "Catalog v3 expected counts are invalid.",
+    );
+  }
+}
+
+function parseMigrationRow(row: unknown): MigrationRow {
+  if (!isRow(row)) throw new Error("Catalog v3 migration row is missing.");
+  const sourceVersion = integerValue(row, "sourceVersion");
+  if (sourceVersion !== 1 && sourceVersion !== 2) throw new Error("Catalog v3 source version is invalid.");
+  const catalogSha256 = stringValue(row, "catalogSha256");
+  const settingsSha256 = nullableStringValue(row, "settingsSha256");
+  const expectedStateSha256 = stringValue(row, "expectedStateSha256");
+  assertHash(catalogSha256, "catalogSha256");
+  assertHash(settingsSha256, "settingsSha256");
+  assertHash(expectedStateSha256, "expectedStateSha256");
+  const catalogPath = stringValue(row, "catalogPath");
+  const settingsPath = nullableStringValue(row, "settingsPath");
+  if ((settingsPath === null) !== (settingsSha256 === null)) {
+    throw new Error("Catalog v3 settings path and hash must be paired.");
+  }
+  return {
+    migrationId: stringValue(row, "migrationId"),
+    sourceVersion,
+    catalogPath,
+    settingsPath,
+    catalogSha256,
+    settingsSha256,
+    rootAvailable: boolFromInteger(row, "rootAvailable"),
+    expectedCounts: parseExpectedCountsJson(stringValue(row, "expectedCountsJson")),
+    expectedStateSha256,
+    phase: parseMigrationPhase(stringValue(row, "phase")),
+    validationReportJson: nullableStringValue(row, "validationReportJson"),
+    errorMessage: nullableStringValue(row, "errorMessage"),
+    createdAt: numberValue(row, "createdAt"),
+    updatedAt: numberValue(row, "updatedAt"),
+  };
+}
+
+function parseExistingAsset(row: unknown): ExistingAsset {
+  if (!isRow(row)) throw new Error("Catalog v3 asset row is missing.");
+  const health = stringValue(row, "health");
+  if (health !== "present" && health !== "missing" && health !== "ambiguous" && health !== "unreadable") {
+    throw new Error("Catalog v3 asset health is invalid.");
+  }
+  return {
+    assetId: parseAssetId(stringValue(row, "assetId")),
+    rootId: parseRootId(stringValue(row, "rootId")),
+    relativePath: stringValue(row, "relativePath"),
+    observedByteLength: nullableNumberValue(row, "observedByteLength"),
+    observedModifiedAt: nullableNumberValue(row, "observedModifiedAt"),
+    observedAt: nullableNumberValue(row, "observedAt"),
+    localFileId: nullableStringValue(row, "localFileId"),
+    revision: integerValue(row, "revision"),
+    health,
+    formatId: stringValue(row, "formatId"),
+    cameraMake: nullableStringValue(row, "cameraMake"),
+    cameraModel: nullableStringValue(row, "cameraModel"),
+    lensModel: nullableStringValue(row, "lensModel"),
+  };
+}
+
+function parseExistingMetadata(row: unknown): ExistingMetadata {
+  if (!isRow(row)) throw new Error("Catalog v3 metadata row is missing.");
+  const pick = stringValue(row, "pick");
+  const rating = integerValue(row, "rating");
+  const colorLabel = nullableStringValue(row, "colorLabel");
+  const xmpState = stringValue(row, "xmpState");
+  if (pick !== "none" && pick !== "pick" && pick !== "reject") throw new Error("Catalog v3 pick is invalid.");
+  if (rating < 0 || rating > 5) throw new Error("Catalog v3 rating is invalid.");
+  if (colorLabel !== null && !["red", "yellow", "green", "blue", "purple"].includes(colorLabel)) {
+    throw new Error("Catalog v3 color label is invalid.");
+  }
+  if (xmpState !== "unknown" && xmpState !== "absent" && xmpState !== "preserved" && xmpState !== "malformed") {
+    throw new Error("Catalog v3 XMP state is invalid.");
+  }
+  return {
+    archive: boolFromInteger(row, "archive"),
+    pick: pick as PickStatus,
+    rating: rating as StarRating,
+    colorLabel: colorLabel as ColorLabel,
+    developJson: nullableStringValue(row, "developJson"),
+    developUpdatedAt: numberValue(row, "developUpdatedAt"),
+    updatedAt: numberValue(row, "updatedAt"),
+    title: nullableStringValue(row, "title"),
+    caption: nullableStringValue(row, "caption"),
+    copyright: nullableStringValue(row, "copyright"),
+    keywordsJson: stringValue(row, "keywordsJson"),
+    rawXmp: nullableStringValue(row, "rawXmp"),
+    xmpState: xmpState as CatalogV3XmpState,
+    xmpMtime: nullableNumberValue(row, "xmpMtime"),
+    xmpSha256: nullableStringValue(row, "xmpSha256"),
+  };
+}
+
+function parseExistingFingerprint(row: unknown): ExistingFingerprint {
+  if (!isRow(row)) throw new Error("Catalog v3 fingerprint row is missing.");
+  const status = stringValue(row, "status");
+  if (status !== "missing" && status !== "hashing" && status !== "valid" && status !== "stale" && status !== "failed") {
+    throw new Error("Catalog v3 fingerprint status is invalid.");
+  }
+  return {
+    fingerprintId: stringValue(row, "fingerprintId"),
+    status,
+    sha256: nullableStringValue(row, "sha256"),
+    observedAt: nullableNumberValue(row, "observedAt"),
+    observedByteLength: nullableNumberValue(row, "observedByteLength"),
+    observedModifiedAt: nullableNumberValue(row, "observedModifiedAt"),
+    localFileId: nullableStringValue(row, "localFileId"),
+  };
+}
+
+function parseAssetSnapshotRow(row: unknown): CatalogV3AssetSnapshot {
+  if (!isRow(row)) throw new Error("Catalog v3 snapshot asset is missing its rows.");
+  const health = stringValue(row, "health");
+  const fingerprintStatus = stringValue(row, "fingerprintStatus");
+  const xmpState = stringValue(row, "xmpState");
+  if (![
+    "present",
+    "missing",
+    "ambiguous",
+    "unreadable",
+  ].includes(health) || ![
+    "missing",
+    "hashing",
+    "valid",
+    "stale",
+    "failed",
+  ].includes(fingerprintStatus) || ![
+    "unknown",
+    "absent",
+    "preserved",
+    "malformed",
+  ].includes(xmpState)) {
+    throw new Error("Catalog v3 snapshot enum is invalid.");
+  }
+  return {
+    catalogId: parseCatalogId(stringValue(row, "catalogId")),
+    assetId: parseAssetId(stringValue(row, "assetId")),
+    rootId: parseRootId(stringValue(row, "rootId")),
+    relativePath: stringValue(row, "relativePath"),
+    observation: nullableNumberValue(row, "observedAt") === null &&
+        nullableNumberValue(row, "observedByteLength") === null &&
+        nullableNumberValue(row, "observedModifiedAt") === null &&
+        nullableStringValue(row, "localFileId") === null
+      ? null
+      : {
+        byteLength: nullableNumberValue(row, "observedByteLength"),
+        modifiedAt: nullableNumberValue(row, "observedModifiedAt"),
+        observedAt: numberValue(row, "observedAt"),
+        localFileId: nullableStringValue(row, "localFileId"),
+      },
+    revision: integerValue(row, "assetRevision"),
+    health: health as CatalogV3AssetSnapshot["health"],
+    formatId: stringValue(row, "formatId"),
+    cameraMake: nullableStringValue(row, "cameraMake"),
+    cameraModel: nullableStringValue(row, "cameraModel"),
+    lensModel: nullableStringValue(row, "lensModel"),
+    fingerprintId: stringValue(row, "fingerprintId"),
+    fingerprintStatus: fingerprintStatus as CatalogV3AssetSnapshot["fingerprintStatus"],
+    fingerprintSha256: nullableStringValue(row, "fingerprintSha256"),
+    fingerprintObservedAt: nullableNumberValue(row, "fingerprintObservedAt"),
+    fingerprintObservedByteLength: nullableNumberValue(row, "fingerprintObservedByteLength"),
+    fingerprintObservedModifiedAt: nullableNumberValue(row, "fingerprintObservedModifiedAt"),
+    fingerprintLocalFileId: nullableStringValue(row, "fingerprintLocalFileId"),
+    metadata: {
+      archive: boolFromInteger(row, "archive"),
+      pick: stringValue(row, "pick") as CatalogV3AssetMetadata["pick"],
+      rating: integerValue(row, "rating") as CatalogV3AssetMetadata["rating"],
+      colorLabel: nullableStringValue(row, "colorLabel") as CatalogV3AssetMetadata["colorLabel"],
+      developJson: nullableStringValue(row, "developJson"),
+      developUpdatedAt: numberValue(row, "developUpdatedAt"),
+      updatedAt: numberValue(row, "updatedAt"),
+      title: nullableStringValue(row, "title"),
+      caption: nullableStringValue(row, "caption"),
+      copyright: nullableStringValue(row, "copyright"),
+      keywordsJson: stringValue(row, "keywordsJson"),
+      rawXmp: nullableStringValue(row, "rawXmp"),
+      xmpState: xmpState as CatalogV3XmpState,
+      xmpMtime: nullableNumberValue(row, "xmpMtime"),
+      xmpSha256: nullableStringValue(row, "xmpSha256"),
+    },
+  };
+}
+
+function metadataValues(metadata: CatalogV3AssetMetadata): readonly SQLInputValue[] {
+  return [
+    booleanInteger(metadata.archive),
+    metadata.pick,
+    metadata.rating,
+    metadata.colorLabel,
+    metadata.developJson,
+    metadata.developUpdatedAt,
+    metadata.updatedAt,
+    metadata.title,
+    metadata.caption,
+    metadata.copyright,
+    metadata.keywordsJson,
+    metadata.rawXmp,
+    metadata.xmpState,
+    metadata.xmpMtime,
+    metadata.xmpSha256,
+  ];
+}
+
+function metadataEqual(left: ExistingMetadata, right: CatalogV3AssetMetadata): boolean {
+  return left.archive === right.archive &&
+    left.pick === right.pick &&
+    left.rating === right.rating &&
+    left.colorLabel === right.colorLabel &&
+    left.developJson === right.developJson &&
+    left.developUpdatedAt === right.developUpdatedAt &&
+    left.updatedAt === right.updatedAt &&
+    left.title === right.title &&
+    left.caption === right.caption &&
+    left.copyright === right.copyright &&
+    left.keywordsJson === right.keywordsJson &&
+    left.rawXmp === right.rawXmp &&
+    left.xmpState === right.xmpState &&
+    sameNullableNumber(left.xmpMtime, right.xmpMtime) &&
+    left.xmpSha256 === right.xmpSha256;
+}
+
+function observationEqual(left: ExistingAsset, right: CatalogV3AssetCandidate): boolean {
+  const observation = right.observation;
+  return sameNullableNumber(left.observedByteLength, observation?.byteLength ?? null) &&
+    sameNullableNumber(left.observedModifiedAt, observation?.modifiedAt ?? null) &&
+    sameNullableNumber(left.observedAt, observation?.observedAt ?? null) &&
+    left.localFileId === (observation?.localFileId ?? null) &&
+    left.health === right.health &&
+    left.formatId === right.formatId &&
+    left.cameraMake === right.cameraMake &&
+    left.cameraModel === right.cameraModel &&
+    left.lensModel === right.lensModel;
+}
+
+function fingerprintEqual(left: ExistingFingerprint, right: CatalogV3FingerprintInput): boolean {
+  return left.status === right.status &&
+    left.sha256 === right.sha256 &&
+    left.observedAt === (right.observedAt ?? null) &&
+    left.observedByteLength === (right.observedByteLength ?? null) &&
+    left.observedModifiedAt === (right.observedModifiedAt ?? null) &&
+    left.localFileId === (right.localFileId ?? null);
+}
+
+function encodeCursor(cursor: Cursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function decodeCursor(valueToDecode: string): Cursor {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(valueToDecode, "base64url").toString("utf8"));
+  } catch {
+    throw new Error("Catalog v3 asset cursor is invalid.");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Catalog v3 asset cursor is invalid.");
+  }
+  const relativePath = Reflect.get(parsed, "relativePath");
+  const assetId = parseAssetId(Reflect.get(parsed, "assetId"));
+  if (typeof relativePath !== "string") throw new Error("Catalog v3 asset cursor is invalid.");
+  assertRelativePath(relativePath);
+  return { relativePath, assetId };
+}
+
+function phaseAllowsAssetCopy(phase: CatalogV3MigrationPhase): boolean {
+  return phase === "created" || phase === "copying-assets" || phase === "copying-relations";
+}
+
+function phaseAllowsRelationsCopy(phase: CatalogV3MigrationPhase): boolean {
+  return phase === "created" || phase === "copying-assets" || phase === "copying-relations" || phase === "copied";
+}
+
+function migrationKey(catalogId: CatalogId, migrationId: string): readonly [CatalogId, string] {
+  return [catalogId, migrationId];
+}
+
+export class CatalogV3Repository {
+  private readonly database: DatabaseSync;
+
+  constructor(database: DatabaseSync) {
+    this.database = database;
+  }
+
+  private schema(): void {
+    verifyCatalogV3Schema(this.database);
+  }
+
+  private transaction<T>(operation: () => T): T {
+    let inTransaction = false;
+    try {
+      this.database.exec("BEGIN IMMEDIATE;");
+      inTransaction = true;
+      const result = operation();
+      this.database.exec("COMMIT;");
+      inTransaction = false;
+      return result;
+    } catch (error) {
+      if (inTransaction) {
+        try {
+          this.database.exec("ROLLBACK;");
+        } catch {
+          // Preserve the original database error.
+        }
+      }
+      throw error;
+    }
+  }
+
+  private catalog(catalogId: CatalogId): CatalogRow {
+    const row = this.database.prepare(`
+      SELECT
+        catalog_id AS catalogId,
+        display_name AS displayName,
+        app_version AS appVersion,
+        install_state AS installState,
+        revision
+      FROM catalog_meta
+      WHERE catalog_id = ?
+    `).get(catalogId);
+    return parseCatalogRow(row);
+  }
+
+  private migration(catalogId: CatalogId, migrationId: string): MigrationRow {
+    const row = this.database.prepare(`
+      SELECT
+        migration_id AS migrationId,
+        source_version AS sourceVersion,
+        catalog_path AS catalogPath,
+        settings_path AS settingsPath,
+        catalog_sha256 AS catalogSha256,
+        settings_sha256 AS settingsSha256,
+        root_available AS rootAvailable,
+        expected_counts_json AS expectedCountsJson,
+        expected_state_sha256 AS expectedStateSha256,
+        phase,
+        validation_report_json AS validationReportJson,
+        error_message AS errorMessage,
+        created_at AS createdAt,
+        updated_at AS updatedAt
+      FROM migration_runs
+      WHERE catalog_id = ? AND migration_id = ?
+    `).get(...migrationKey(catalogId, migrationId));
+    return parseMigrationRow(row);
+  }
+
+  private requireMigration(
+    catalogId: CatalogId,
+    migrationId: string,
+    phaseCheck: (phase: CatalogV3MigrationPhase) => boolean,
+  ): MigrationRow {
+    this.catalog(catalogId);
+    const migration = this.migration(catalogId, migrationId);
+    if (!phaseCheck(migration.phase)) {
+      throw new Error(`Catalog v3 migration phase ${migration.phase} does not allow this operation.`);
+    }
+    return migration;
+  }
+
+  private revision(catalogId: CatalogId): number {
+    return this.catalog(catalogId).revision;
+  }
+
+  private bumpRevision(catalogId: CatalogId, now: number): number {
+    const result = this.database.prepare(`
+      UPDATE catalog_meta
+      SET revision = revision + 1, updated_at = ?
+      WHERE catalog_id = ?
+    `).run(now, catalogId);
+    if (result.changes !== 1) throw new Error("Catalog v3 revision update failed.");
+    return this.revision(catalogId);
+  }
+
+  install(input: CatalogV3InstallInput): CatalogV3InstallResult {
+    const validated = parseCatalogV3InstallInput(input);
+    if (isCatalogV3DatabaseEmpty(this.database)) {
+      installCatalogV3Schema(this.database);
+    } else {
+      this.schema();
+    }
+    const now = validated.now ?? Date.now();
+    const existing = this.database.prepare(`
+      SELECT catalog_id AS catalogId, display_name AS displayName, app_version AS appVersion,
+             install_state AS installState, revision
+      FROM catalog_meta WHERE catalog_id = ?
+    `).get(validated.catalogId);
+    if (existing !== undefined) {
+      const catalog = parseCatalogRow(existing);
+      const migration = this.migration(validated.catalogId, validated.migration.migrationId);
+      if (catalog.displayName !== validated.displayName || catalog.appVersion !== validated.appVersion) {
+        throw new Error("Catalog v3 install conflicts with the existing catalog identity.");
+      }
+      if (migration.sourceVersion !== validated.migration.sourceVersion ||
+          migration.catalogPath !== validated.migration.catalogPath ||
+          migration.settingsPath !== validated.migration.settingsPath ||
+          migration.catalogSha256 !== validated.migration.catalogSha256 ||
+          migration.settingsSha256 !== validated.migration.settingsSha256 ||
+          migration.rootAvailable !== validated.migration.rootAvailable ||
+          migration.expectedStateSha256 !== validated.migration.expectedStateSha256 ||
+          JSON.stringify(migration.expectedCounts) !== JSON.stringify(validated.migration.expectedCounts)) {
+        throw new Error("Catalog v3 install conflicts with the existing migration source.");
+      }
+      const existingRoot = this.root(validated.catalogId, validated.root.rootId);
+      if (existingRoot.configuredPath !== validated.root.configuredPath ||
+          existingRoot.label !== validated.root.label ||
+          existingRoot.canonicalPath !== validated.root.canonicalPath ||
+          existingRoot.health !== validated.root.health ||
+          existingRoot.scanState !== validated.root.scanState ||
+          existingRoot.watchState !== validated.root.watchState) {
+        throw new Error("Catalog v3 install conflicts with the existing root identity.");
+      }
+      return {
+        catalogId: validated.catalogId,
+        migrationId: validated.migration.migrationId,
+        created: false,
+        installState: catalog.installState,
+        revision: catalog.revision,
+        schemaVersion: 3,
+      };
+    }
+
+    return this.transaction(() => {
+      this.database.prepare(`
+        INSERT INTO catalog_meta (
+          catalog_id, singleton, display_name, schema_version, app_version,
+          install_state, revision, created_at, updated_at
+        ) VALUES (?, 1, ?, 3, ?, 'staging', 0, ?, ?)
+      `).run(
+        validated.catalogId,
+        validated.displayName,
+        validated.appVersion,
+        now,
+        now,
+      );
+      this.database.prepare(`
+        INSERT INTO roots (
+          catalog_id, root_id, label, configured_path, canonical_path,
+          health, scan_state, watch_state, revision
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)
+      `).run(
+        validated.catalogId,
+        validated.root.rootId,
+        validated.root.label,
+        validated.root.configuredPath,
+        validated.root.canonicalPath,
+        validated.root.health,
+        validated.root.scanState,
+        validated.root.watchState,
+      );
+      this.database.prepare(`
+        INSERT INTO migration_runs (
+          catalog_id, migration_id, source_version, catalog_path, settings_path,
+          catalog_sha256, settings_sha256, root_available, expected_counts_json,
+          expected_state_sha256,
+          phase, validation_report_json, error_message, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'created', NULL, NULL, ?, ?)
+      `).run(
+        validated.catalogId,
+        validated.migration.migrationId,
+        validated.migration.sourceVersion,
+        validated.migration.catalogPath,
+        validated.migration.settingsPath,
+        validated.migration.catalogSha256,
+        validated.migration.settingsSha256,
+        booleanInteger(validated.migration.rootAvailable),
+        jsonString(validated.migration.expectedCounts, "expectedCounts"),
+        validated.migration.expectedStateSha256,
+        now,
+        now,
+      );
+      return {
+        catalogId: validated.catalogId,
+        migrationId: validated.migration.migrationId,
+        created: true,
+        installState: "staging",
+        revision: 0,
+        schemaVersion: 3,
+      };
+    });
+  }
+
+  private findAlias(catalogId: CatalogId, migrationId: string, legacyId: string): LegacyAlias | null {
+    const row = this.database.prepare(`
+      SELECT asset_id AS assetId, root_id AS rootId, relative_path AS relativePath
+      FROM migration_aliases
+      WHERE catalog_id = ? AND migration_id = ? AND legacy_id = ?
+    `).get(catalogId, migrationId, legacyId);
+    if (row === undefined) return null;
+    if (!isRow(row)) throw new Error("Catalog v3 alias row is invalid.");
+    return {
+      assetId: parseAssetId(stringValue(row, "assetId")),
+      rootId: parseRootId(stringValue(row, "rootId")),
+      relativePath: stringValue(row, "relativePath"),
+    };
+  }
+
+  private findAssetByPath(catalogId: CatalogId, rootId: RootId, relativePath: string): ExistingAsset | null {
+    const row = this.database.prepare(`
+      SELECT
+        asset_id AS assetId,
+        root_id AS rootId,
+        relative_path AS relativePath,
+        observed_byte_length AS observedByteLength,
+        observed_modified_at AS observedModifiedAt,
+        observed_at AS observedAt,
+        local_file_id AS localFileId,
+        revision,
+        health,
+        format_id AS formatId,
+        camera_make AS cameraMake,
+        camera_model AS cameraModel,
+        lens_model AS lensModel
+      FROM assets
+      WHERE catalog_id = ? AND root_id = ? AND relative_path = ?
+    `).get(catalogId, rootId, relativePath);
+    return row === undefined ? null : parseExistingAsset(row);
+  }
+
+  private findAsset(catalogId: CatalogId, assetId: AssetId): ExistingAsset | null {
+    const row = this.database.prepare(`
+      SELECT
+        asset_id AS assetId,
+        root_id AS rootId,
+        relative_path AS relativePath,
+        observed_byte_length AS observedByteLength,
+        observed_modified_at AS observedModifiedAt,
+        observed_at AS observedAt,
+        local_file_id AS localFileId,
+        revision,
+        health,
+        format_id AS formatId,
+        camera_make AS cameraMake,
+        camera_model AS cameraModel,
+        lens_model AS lensModel
+      FROM assets
+      WHERE catalog_id = ? AND asset_id = ?
+    `).get(catalogId, assetId);
+    return row === undefined ? null : parseExistingAsset(row);
+  }
+
+  private findMetadata(catalogId: CatalogId, assetId: AssetId): ExistingMetadata | null {
+    const row = this.database.prepare(`
+      SELECT
+        archive, pick, rating, color_label AS colorLabel,
+        develop_json AS developJson, develop_updated_at AS developUpdatedAt,
+        updated_at AS updatedAt, title, caption, copyright, keywords_json AS keywordsJson,
+        raw_xmp AS rawXmp, xmp_state AS xmpState, xmp_mtime AS xmpMtime, xmp_sha256 AS xmpSha256
+      FROM asset_metadata
+      WHERE catalog_id = ? AND asset_id = ?
+    `).get(catalogId, assetId);
+    return row === undefined ? null : parseExistingMetadata(row);
+  }
+
+  private findFingerprint(catalogId: CatalogId, assetId: AssetId): ExistingFingerprint | null {
+    const row = this.database.prepare(`
+      SELECT fingerprint_id AS fingerprintId, status, sha256,
+             observed_at AS observedAt, observed_byte_length AS observedByteLength,
+             observed_modified_at AS observedModifiedAt, local_file_id AS localFileId
+      FROM fingerprints
+      WHERE catalog_id = ? AND asset_id = ?
+    `).get(catalogId, assetId);
+    return row === undefined ? null : parseExistingFingerprint(row);
+  }
+
+  private assertCandidate(candidate: CatalogV3AssetCandidate): void {
+    assertRelativePath(candidate.relativePath);
+    if (candidate.formatId.length === 0) throw new Error("Catalog v3 formatId is invalid.");
+    if (candidate.observation !== null) {
+      if (candidate.observation.byteLength !== null) assertNonnegativeInteger(candidate.observation.byteLength, "byteLength");
+      if (candidate.observation.modifiedAt !== null && !Number.isFinite(candidate.observation.modifiedAt)) {
+        throw new Error("Catalog v3 modifiedAt is invalid.");
+      }
+    }
+    for (const legacyId of candidate.legacyIds) {
+      if (legacyId.length === 0) throw new Error("Catalog v3 legacy ID is invalid.");
+    }
+    const metadata = metadataFromCandidate(candidate);
+    if (metadata.developJson !== null) JSON.parse(metadata.developJson);
+    JSON.parse(metadata.keywordsJson);
+    if (metadata.rawXmp !== null && new TextEncoder().encode(metadata.rawXmp).byteLength > 16 * 1024 * 1024) {
+      throw new Error("Catalog v3 raw XMP is too large.");
+    }
+    assertHash(metadata.xmpSha256, "xmpSha256");
+    const fingerprint = fingerprintFromCandidate(candidate);
+    if (fingerprint.status === "valid" && fingerprint.sha256 === null) {
+      throw new Error("Catalog v3 valid fingerprint needs a digest.");
+    }
+    if (fingerprint.status !== "valid" && fingerprint.sha256 !== null) {
+      throw new Error("Catalog v3 non-valid fingerprint cannot have a digest.");
+    }
+    const fingerprintObservedAt = fingerprint.observedAt ?? candidate.observation?.observedAt ?? null;
+    const fingerprintByteLength = fingerprint.observedByteLength ?? candidate.observation?.byteLength ?? null;
+    const fingerprintModifiedAt = fingerprint.observedModifiedAt ?? candidate.observation?.modifiedAt ?? null;
+    const fingerprintLocalFileId = fingerprint.localFileId ?? candidate.observation?.localFileId ?? null;
+    if (fingerprint.status === "valid" &&
+        (fingerprintObservedAt === null || (fingerprintByteLength === null && fingerprintModifiedAt === null && fingerprintLocalFileId === null))) {
+      throw new Error("Catalog v3 valid fingerprint needs observation proof.");
+    }
+    assertHash(fingerprint.sha256, "sha256");
+  }
+
+  private upsertAsset(
+    catalogId: CatalogId,
+    assetId: AssetId,
+    candidate: CatalogV3AssetCandidate,
+  ): { readonly changed: boolean; readonly created: boolean } {
+    const existing = this.findAsset(catalogId, assetId);
+    const observation = candidate.observation;
+    const values = [
+      observation?.byteLength ?? null,
+      observation?.modifiedAt ?? null,
+      observation?.observedAt ?? null,
+      observation?.localFileId ?? null,
+      candidate.health,
+      candidate.formatId,
+      candidate.cameraMake,
+      candidate.cameraModel,
+      candidate.lensModel,
+    ];
+    if (existing === null) {
+      this.database.prepare(`
+        INSERT INTO assets (
+          catalog_id, asset_id, root_id, relative_path,
+          observed_byte_length, observed_modified_at, observed_at, local_file_id, revision, health,
+          format_id, camera_make, camera_model, lens_model
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)
+      `).run(
+        catalogId,
+        assetId,
+        candidate.rootId,
+        candidate.relativePath,
+        ...values,
+      );
+      return { changed: true, created: true };
+    }
+    if (existing.rootId !== candidate.rootId || existing.relativePath !== candidate.relativePath) {
+      throw new Error("Catalog v3 AssetId conflicts with its stored path.");
+    }
+    if (observationEqual(existing, candidate)) return { changed: false, created: false };
+    const result = this.database.prepare(`
+      UPDATE assets
+      SET observed_byte_length = ?, observed_modified_at = ?, observed_at = ?, local_file_id = ?, health = ?,
+          format_id = ?, camera_make = ?, camera_model = ?, lens_model = ?
+      WHERE catalog_id = ? AND asset_id = ?
+    `).run(...values, catalogId, assetId);
+    return { changed: result.changes === 1, created: false };
+  }
+
+  private bumpAssetRevision(catalogId: CatalogId, assetId: AssetId): void {
+    const result = this.database.prepare(`
+      UPDATE assets SET revision = revision + 1
+      WHERE catalog_id = ? AND asset_id = ?
+    `).run(catalogId, assetId);
+    if (result.changes !== 1) throw new Error("Catalog v3 asset revision update failed.");
+  }
+
+  private upsertMetadata(
+    catalogId: CatalogId,
+    assetId: AssetId,
+    metadata: CatalogV3MetadataInput | null,
+  ): boolean {
+    const next = metadata ?? CATALOG_V3_DEFAULT_METADATA;
+    const existing = this.findMetadata(catalogId, assetId);
+    if (existing === null) {
+      this.database.prepare(`
+        INSERT INTO asset_metadata (
+          catalog_id, asset_id, archive, pick, rating, color_label,
+          develop_json, develop_updated_at, updated_at, title, caption, copyright,
+          keywords_json, raw_xmp, xmp_state, xmp_mtime, xmp_sha256
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(catalogId, assetId, ...metadataValues(next));
+      return true;
+    }
+    if (metadata === null || metadataEqual(existing, next)) return false;
+    const result = this.database.prepare(`
+      UPDATE asset_metadata
+      SET archive = ?, pick = ?, rating = ?, color_label = ?, develop_json = ?,
+          develop_updated_at = ?, updated_at = ?, title = ?, caption = ?, copyright = ?,
+          keywords_json = ?, raw_xmp = ?, xmp_state = ?, xmp_mtime = ?, xmp_sha256 = ?
+      WHERE catalog_id = ? AND asset_id = ?
+    `).run(...metadataValues(next), catalogId, assetId);
+    return result.changes === 1;
+  }
+
+  private upsertFingerprint(
+    catalogId: CatalogId,
+    assetId: AssetId,
+    candidate: CatalogV3AssetCandidate,
+    now: number,
+  ): { readonly fingerprintId: string; readonly changed: boolean } {
+    const raw = fingerprintFromCandidate(candidate);
+    const next: CatalogV3FingerprintInput = {
+      status: raw.status,
+      sha256: raw.sha256,
+      observedAt: raw.observedAt ?? candidate.observation?.observedAt ?? null,
+      observedByteLength: raw.observedByteLength ?? candidate.observation?.byteLength ?? null,
+      observedModifiedAt: raw.observedModifiedAt ?? candidate.observation?.modifiedAt ?? null,
+      localFileId: raw.localFileId ?? candidate.observation?.localFileId ?? null,
+    };
+    const existing = this.findFingerprint(catalogId, assetId);
+    if (existing === null) {
+      const fingerprintId = createAssetId();
+      this.database.prepare(`
+        INSERT INTO fingerprints (
+          catalog_id, fingerprint_id, asset_id, status, sha256,
+          observed_at, observed_byte_length, observed_modified_at, local_file_id, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        catalogId,
+        fingerprintId,
+        assetId,
+        next.status,
+        next.sha256,
+        next.observedAt ?? null,
+        next.observedByteLength ?? null,
+        next.observedModifiedAt ?? null,
+        next.localFileId ?? null,
+        now,
+      );
+      return { fingerprintId, changed: true };
+    }
+    if (next.status === "missing" && existing.status !== "missing") {
+      return { fingerprintId: existing.fingerprintId, changed: false };
+    }
+    if (fingerprintEqual(existing, next)) {
+      return { fingerprintId: existing.fingerprintId, changed: false };
+    }
+    this.database.prepare(`
+      UPDATE fingerprints
+      SET status = ?, sha256 = ?, observed_at = ?, observed_byte_length = ?,
+          observed_modified_at = ?, local_file_id = ?, updated_at = ?
+      WHERE catalog_id = ? AND fingerprint_id = ?
+    `).run(
+      next.status,
+      next.sha256,
+      next.observedAt ?? null,
+      next.observedByteLength ?? null,
+      next.observedModifiedAt ?? null,
+      next.localFileId ?? null,
+      now,
+      catalogId,
+      existing.fingerprintId,
+    );
+    return { fingerprintId: existing.fingerprintId, changed: true };
+  }
+
+  private upsertAlias(
+    catalogId: CatalogId,
+    migrationId: string,
+    legacyId: string,
+    candidate: CatalogV3AssetCandidate,
+    assetId: AssetId,
+    now: number,
+  ): boolean {
+    const existing = this.findAlias(catalogId, migrationId, legacyId);
+    if (existing !== null) {
+      if (existing.assetId !== assetId || existing.rootId !== candidate.rootId || existing.relativePath !== candidate.relativePath) {
+        throw new Error("Catalog v3 legacy alias conflicts with its stored path.");
+      }
+      return false;
+    }
+    this.database.prepare(`
+      INSERT INTO migration_aliases (
+        catalog_id, migration_id, legacy_id, root_id, relative_path, asset_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      catalogId,
+      migrationId,
+      legacyId,
+      candidate.rootId,
+      candidate.relativePath,
+      assetId,
+      now,
+    );
+    return true;
+  }
+
+  writeAssetBatch(input: CatalogV3AssetBatchInput): CatalogV3AssetBatchResult {
+    const validated = parseCatalogV3AssetBatchInput(input);
+    if (validated.assets.length > CATALOG_V3_MAX_ASSET_BATCH) {
+      throw new Error("Catalog v3 asset batch exceeds 250 assets.");
+    }
+    this.schema();
+    return this.transaction(() => {
+      const migration = this.requireMigration(validated.catalogId, validated.migrationId, phaseAllowsAssetCopy);
+      const now = Date.now();
+      const paths = new Set<string>();
+      const aliases = new Set<string>();
+      let changed = false;
+      const mappings: CatalogV3AssetMapping[] = [];
+      for (const candidate of validated.assets) {
+        this.assertCandidate(candidate);
+        const pathKey = `${candidate.rootId}\u0000${candidate.relativePath}`;
+        if (paths.has(pathKey)) throw new Error("Catalog v3 asset batch contains a duplicate path.");
+        paths.add(pathKey);
+        for (const legacyId of candidate.legacyIds) {
+          if (aliases.has(legacyId)) throw new Error("Catalog v3 asset batch contains a duplicate legacy ID.");
+          aliases.add(legacyId);
+        }
+
+        let assetId: AssetId | null = null;
+        for (const legacyId of candidate.legacyIds) {
+          const alias = this.findAlias(validated.catalogId, validated.migrationId, legacyId);
+          if (alias === null) continue;
+          if (alias.rootId !== candidate.rootId || alias.relativePath !== candidate.relativePath) {
+            throw new Error("Catalog v3 legacy alias path does not match the retry candidate.");
+          }
+          if (assetId !== null && assetId !== alias.assetId) {
+            throw new Error("Catalog v3 candidate aliases resolve to different assets.");
+          }
+          assetId = alias.assetId;
+        }
+        const pathAsset = this.findAssetByPath(validated.catalogId, candidate.rootId, candidate.relativePath);
+        if (assetId !== null && pathAsset !== null && pathAsset.assetId !== assetId) {
+          throw new Error("Catalog v3 path already belongs to another AssetId.");
+        }
+        if (assetId === null && pathAsset !== null) assetId = pathAsset.assetId;
+        if (assetId === null) assetId = createAssetId();
+        const assetChange = this.upsertAsset(validated.catalogId, assetId, candidate);
+        const metadataChanged = this.upsertMetadata(validated.catalogId, assetId, candidate.metadata);
+        const fingerprint = this.upsertFingerprint(validated.catalogId, assetId, candidate, now);
+        if (!assetChange.created && (assetChange.changed || metadataChanged || fingerprint.changed)) {
+          this.bumpAssetRevision(validated.catalogId, assetId);
+        }
+        changed = assetChange.changed || metadataChanged || fingerprint.changed || changed;
+        for (const legacyId of candidate.legacyIds) {
+          changed = this.upsertAlias(
+            validated.catalogId,
+            validated.migrationId,
+            legacyId,
+            candidate,
+            assetId,
+            now,
+          ) || changed;
+        }
+        mappings.push({
+          legacyIds: candidate.legacyIds,
+          relativePath: candidate.relativePath,
+          assetId,
+          fingerprintId: fingerprint.fingerprintId,
+        });
+      }
+      if (migration.phase === "created") {
+        this.database.prepare(`
+          UPDATE migration_runs SET phase = 'copying-assets', updated_at = ?
+          WHERE catalog_id = ? AND migration_id = ?
+        `).run(now, ...migrationKey(validated.catalogId, validated.migrationId));
+      }
+      const revision = changed ? this.bumpRevision(validated.catalogId, now) : this.revision(validated.catalogId);
+      return {
+        catalogId: validated.catalogId,
+        migrationId: validated.migrationId,
+        revision,
+        assets: mappings,
+      };
+    });
+  }
+
+  private resolveAlias(catalogId: CatalogId, migrationId: string, legacyId: string): AssetId {
+    const alias = this.findAlias(catalogId, migrationId, legacyId);
+    if (alias === null) throw new Error(`Catalog v3 relation references unknown legacy ID ${legacyId}.`);
+    return alias.assetId;
+  }
+
+  writeRelationsBatch(input: CatalogV3RelationsBatchInput): CatalogV3RelationsBatchResult {
+    const validated = parseCatalogV3RelationsBatchInput(input);
+    this.schema();
+    return this.transaction(() => {
+      const migration = this.requireMigration(validated.catalogId, validated.migrationId, phaseAllowsRelationsCopy);
+      const now = Date.now();
+      const albumIds = new Set<string>();
+      const albumPositions = new Set<number>();
+      let changed = false;
+      let albumAssets = 0;
+      const resolvedAlbums = validated.albums.map((album) => {
+        if (albumIds.has(album.id)) throw new Error("Catalog v3 relations contain a duplicate album ID.");
+        albumIds.add(album.id);
+        if (albumPositions.has(album.position)) throw new Error("Catalog v3 relations contain a duplicate album position.");
+        albumPositions.add(album.position);
+        const members = new Set<string>();
+        for (const entryId of album.entryIds) {
+          if (members.has(entryId)) throw new Error("Catalog v3 album contains a duplicate membership.");
+          members.add(entryId);
+        }
+        return {
+          album,
+          assetIds: album.entryIds.map((entryId) => this.resolveAlias(validated.catalogId, validated.migrationId, entryId)),
+        };
+      });
+      for (const resolved of resolvedAlbums) {
+        const existingAlbum = this.database.prepare(`
+          SELECT name, created_at AS createdAt, updated_at AS updatedAt, position
+          FROM albums WHERE catalog_id = ? AND album_id = ?
+        `).get(validated.catalogId, resolved.album.id);
+        if (existingAlbum === undefined) {
+          this.database.prepare(`
+            INSERT INTO albums (catalog_id, album_id, name, created_at, updated_at, position)
+            VALUES (?, ?, ?, ?, ?, ?)
+          `).run(
+            validated.catalogId,
+            resolved.album.id,
+            resolved.album.name,
+            resolved.album.createdAt,
+            resolved.album.updatedAt,
+            resolved.album.position,
+          );
+          changed = true;
+        } else {
+          if (!isRow(existingAlbum) || stringValue(existingAlbum, "name") !== resolved.album.name ||
+              numberValue(existingAlbum, "createdAt") !== resolved.album.createdAt ||
+              numberValue(existingAlbum, "updatedAt") !== resolved.album.updatedAt ||
+              integerValue(existingAlbum, "position") !== resolved.album.position) {
+            throw new Error("Catalog v3 album conflicts with its retry payload.");
+          }
+        }
+        for (const [index, assetId] of resolved.assetIds.entries()) {
+          const position = resolved.album.positionOffset + index;
+          const byPosition = this.database.prepare(`
+            SELECT asset_id AS assetId FROM album_assets
+            WHERE catalog_id = ? AND album_id = ? AND position = ?
+          `).get(validated.catalogId, resolved.album.id, position);
+          const byAsset = this.database.prepare(`
+            SELECT position FROM album_assets
+            WHERE catalog_id = ? AND album_id = ? AND asset_id = ?
+          `).get(validated.catalogId, resolved.album.id, assetId);
+          if (byPosition !== undefined) {
+            if (!isRow(byPosition) || parseAssetId(stringValue(byPosition, "assetId")) !== assetId) {
+              throw new Error("Catalog v3 album position conflicts with its retry payload.");
+            }
+            if (byAsset !== undefined) {
+              const existingPosition = isRow(byAsset) ? integerValue(byAsset, "position") : -1;
+              if (existingPosition !== position) throw new Error("Catalog v3 album membership is duplicated at another position.");
+            }
+            continue;
+          }
+          if (byAsset !== undefined) throw new Error("Catalog v3 album membership is duplicated at another position.");
+          this.database.prepare(`
+            INSERT INTO album_assets (catalog_id, album_id, asset_id, position)
+            VALUES (?, ?, ?, ?)
+          `).run(validated.catalogId, resolved.album.id, assetId, position);
+          changed = true;
+          albumAssets += 1;
+        }
+      }
+      const archiveIds = new Set(validated.archiveLegacyIds);
+      let archived = 0;
+      for (const legacyId of archiveIds) {
+        const assetId = this.resolveAlias(validated.catalogId, validated.migrationId, legacyId);
+        const existing = this.findMetadata(validated.catalogId, assetId);
+        if (existing === null) throw new Error("Catalog v3 archive target has no metadata row.");
+        if (!existing.archive) {
+          this.database.prepare(`
+            UPDATE asset_metadata SET archive = 1
+            WHERE catalog_id = ? AND asset_id = ?
+          `).run(validated.catalogId, assetId);
+          changed = true;
+          archived += 1;
+        }
+      }
+      const nextPhase = migration.phase === "created" || migration.phase === "copying-assets"
+        ? "copying-relations"
+        : migration.phase;
+      if (nextPhase !== migration.phase) {
+        this.database.prepare(`
+          UPDATE migration_runs SET phase = ?, updated_at = ?
+          WHERE catalog_id = ? AND migration_id = ?
+        `).run(nextPhase, now, ...migrationKey(validated.catalogId, validated.migrationId));
+      }
+      const revision = changed ? this.bumpRevision(validated.catalogId, now) : this.revision(validated.catalogId);
+      return {
+        catalogId: validated.catalogId,
+        migrationId: validated.migrationId,
+        revision,
+        albums: resolvedAlbums.length,
+        albumAssets,
+        archived,
+      };
+    });
+  }
+
+  finishCopy(catalogId: CatalogId, migrationId: string): CatalogV3FinishCopyResult {
+    this.schema();
+    return this.transaction(() => {
+      const migration = this.requireMigration(catalogId, migrationId, phaseAllowsRelationsCopy);
+      const now = Date.now();
+      if (migration.phase !== "copied") {
+        this.database.prepare(`
+          UPDATE migration_runs SET phase = 'copied', updated_at = ?
+          WHERE catalog_id = ? AND migration_id = ?
+        `).run(now, ...migrationKey(catalogId, migrationId));
+      }
+      return {
+        catalogId,
+        migrationId,
+        phase: "copied",
+        revision: this.revision(catalogId),
+      };
+    });
+  }
+
+  private counts(catalogId: CatalogId): CatalogV3Counts {
+    const rowFor = (sql: string): Row => {
+      const row = this.database.prepare(sql).get(catalogId);
+      if (!isRow(row)) throw new Error("Catalog v3 count row is invalid.");
+      return row;
+    };
+    const count = (sql: string): number => integerValue(rowFor(sql), "count");
+    const assets = count("SELECT COUNT(*) AS count FROM assets WHERE catalog_id = ?");
+    const metadata = count("SELECT COUNT(*) AS count FROM asset_metadata WHERE catalog_id = ?");
+    const albums = count("SELECT COUNT(*) AS count FROM albums WHERE catalog_id = ?");
+    const albumAssets = count("SELECT COUNT(*) AS count FROM album_assets WHERE catalog_id = ?");
+    const archived = count("SELECT COUNT(*) AS count FROM asset_metadata WHERE catalog_id = ? AND archive = 1");
+    const aliases = count("SELECT COUNT(*) AS count FROM migration_aliases WHERE catalog_id = ?");
+    const fingerprints = count("SELECT COUNT(*) AS count FROM fingerprints WHERE catalog_id = ?");
+    const healthRows = this.database.prepare(`
+      SELECT health, COUNT(*) AS count FROM assets WHERE catalog_id = ? GROUP BY health
+    `).all(catalogId);
+    const healthCounts = { present: 0, missing: 0, ambiguous: 0, unreadable: 0 };
+    for (const row of healthRows) {
+      if (!isRow(row)) throw new Error("Catalog v3 health count row is invalid.");
+      const health = stringValue(row, "health");
+      if (!(health in healthCounts)) throw new Error("Catalog v3 health count is invalid.");
+      healthCounts[health as keyof typeof healthCounts] = integerValue(row, "count");
+    }
+    return {
+      assets,
+      metadata,
+      albums,
+      albumAssets,
+      archived,
+      aliases,
+      fingerprints,
+      ...healthCounts,
+    };
+  }
+
+  private fingerprintCoverage(catalogId: CatalogId): CatalogV3FingerprintCoverage {
+    const rows = this.database.prepare(`
+      SELECT status, COUNT(*) AS count
+      FROM fingerprints WHERE catalog_id = ? GROUP BY status
+    `).all(catalogId);
+    const result: Record<CatalogV3FingerprintInput["status"], number> = {
+      missing: 0,
+      hashing: 0,
+      valid: 0,
+      stale: 0,
+      failed: 0,
+    };
+    for (const row of rows) {
+      if (!isRow(row)) throw new Error("Catalog v3 fingerprint count row is invalid.");
+      const status = stringValue(row, "status");
+      if (!(status in result)) throw new Error("Catalog v3 fingerprint status count is invalid.");
+      result[status as CatalogV3FingerprintInput["status"]] = integerValue(row, "count");
+    }
+    return {
+      total: result.missing + result.hashing + result.valid + result.stale + result.failed,
+      ...result,
+    };
+  }
+
+  private integrity(): CatalogV3IntegrityResult {
+    const integrityRows = this.database.prepare("PRAGMA integrity_check").all();
+    const integrityCheck = integrityRows.map((row) => {
+      if (!isRow(row)) throw new Error("Catalog v3 integrity row is invalid.");
+      return stringValue(row, "integrity_check");
+    });
+    const foreignKeyRows = this.database.prepare("PRAGMA foreign_key_check").all();
+    const foreignKeyCheck = foreignKeyRows.map((row) => {
+      if (!isRow(row)) throw new Error("Catalog v3 foreign-key row is invalid.");
+      return {
+        table: stringValue(row, "table"),
+        rowId: nullableNumberValue(row, "rowid"),
+        parent: stringValue(row, "parent"),
+        foreignKeyIndex: integerValue(row, "fkid"),
+      };
+    });
+    return { integrityCheck, foreignKeyCheck };
+  }
+
+  private root(catalogId: CatalogId, rootId: RootId): CatalogV3RootInput {
+    const row = this.database.prepare(`
+      SELECT root_id AS rootId, label, configured_path AS configuredPath, canonical_path AS canonicalPath,
+             health, scan_state AS scanState, watch_state AS watchState
+      FROM roots WHERE catalog_id = ? AND root_id = ?
+    `).get(catalogId, rootId);
+    if (!isRow(row)) throw new Error("Catalog v3 root row is missing.");
+    const health = stringValue(row, "health");
+    const scanState = stringValue(row, "scanState");
+    const watchState = stringValue(row, "watchState");
+    if (!["online", "missing", "ambiguous", "unreadable"].includes(health) ||
+        !["unknown", "complete", "partial", "failed"].includes(scanState) ||
+        !["disabled", "active", "error"].includes(watchState)) {
+      throw new Error("Catalog v3 root state is invalid.");
+    }
+    return {
+      rootId: parseRootId(stringValue(row, "rootId")),
+      label: stringValue(row, "label"),
+      configuredPath: stringValue(row, "configuredPath"),
+      canonicalPath: nullableStringValue(row, "canonicalPath"),
+      health: health as CatalogV3RootInput["health"],
+      scanState: scanState as CatalogV3RootInput["scanState"],
+      watchState: watchState as CatalogV3RootInput["watchState"],
+    };
+  }
+
+  private migrationStateSha256(catalogId: CatalogId, migrationId: string): string {
+    const digest = new CatalogV3StateDigest();
+    const assetRows = this.database.prepare(`
+      SELECT snapshot.*,
+             COALESCE((
+               SELECT json_group_array(ma.legacy_id ORDER BY ma.legacy_id)
+               FROM migration_aliases AS ma
+               WHERE ma.catalog_id = ?1 AND ma.migration_id = ?2 AND ma.asset_id = snapshot.assetId
+             ), '[]') AS legacyIdsJson
+      FROM (${ASSET_SNAPSHOT_SELECT} WHERE a.catalog_id = ?1) AS snapshot
+      ORDER BY snapshot.rootId, snapshot.relativePath
+    `).iterate(catalogId, migrationId);
+    for (const row of assetRows) {
+      const snapshot = parseAssetSnapshotRow(row);
+      if (snapshot.formatId === null) throw new Error("Catalog v3 state asset format is missing.");
+      if (!isRow(row)) throw new Error("Catalog v3 state asset row is invalid.");
+      const legacyIdsValue: unknown = JSON.parse(stringValue(row, "legacyIdsJson"));
+      if (!Array.isArray(legacyIdsValue) || legacyIdsValue.some((value) => typeof value !== "string")) {
+        throw new Error("Catalog v3 state aliases are invalid.");
+      }
+      digest.addAsset({
+        rootId: snapshot.rootId,
+        relativePath: snapshot.relativePath,
+        observation: snapshot.observation,
+        health: snapshot.health,
+        formatId: snapshot.formatId,
+        cameraMake: snapshot.cameraMake,
+        cameraModel: snapshot.cameraModel,
+        lensModel: snapshot.lensModel,
+        legacyIds: legacyIdsValue,
+        metadata: snapshot.metadata,
+        fingerprint: {
+          status: snapshot.fingerprintStatus,
+          sha256: snapshot.fingerprintSha256,
+          observedAt: snapshot.fingerprintObservedAt,
+          observedByteLength: snapshot.fingerprintObservedByteLength,
+          observedModifiedAt: snapshot.fingerprintObservedModifiedAt,
+          localFileId: snapshot.fingerprintLocalFileId,
+        },
+      });
+    }
+
+    const albumRows = this.database.prepare(`
+      SELECT album_id AS albumId, name, created_at AS createdAt, updated_at AS updatedAt, position
+      FROM albums
+      WHERE catalog_id = ?
+      ORDER BY position
+    `).iterate(catalogId);
+    const memberStatement = this.database.prepare(`
+      SELECT a.root_id AS rootId, a.relative_path AS relativePath
+      FROM album_assets AS aa
+      JOIN assets AS a ON a.catalog_id = aa.catalog_id AND a.asset_id = aa.asset_id
+      WHERE aa.catalog_id = ? AND aa.album_id = ?
+      ORDER BY aa.position
+    `);
+    for (const row of albumRows) {
+      if (!isRow(row)) throw new Error("Catalog v3 state album row is invalid.");
+      const albumId = stringValue(row, "albumId");
+      const members = function* (): Generator<CatalogV3StateLocation> {
+        for (const member of memberStatement.iterate(catalogId, albumId)) {
+          if (!isRow(member)) throw new Error("Catalog v3 state album member row is invalid.");
+          yield {
+            rootId: parseRootId(stringValue(member, "rootId")),
+            relativePath: stringValue(member, "relativePath"),
+          };
+        }
+      };
+      digest.addAlbum({
+        id: albumId,
+        name: stringValue(row, "name"),
+        createdAt: numberValue(row, "createdAt"),
+        updatedAt: numberValue(row, "updatedAt"),
+        position: integerValue(row, "position"),
+      }, members());
+    }
+    return digest.digest();
+  }
+
+  validate(catalogId: CatalogId, migrationId: string): CatalogV3ValidationResult {
+    this.schema();
+    const migration = this.requireMigration(
+      catalogId,
+      migrationId,
+      (phase) => phase === "copied" || phase === "validating" || phase === "validated" || phase === "failed",
+    );
+    const now = Date.now();
+    this.transaction(() => {
+      this.database.prepare(`
+        UPDATE migration_runs SET phase = 'validating', updated_at = ?
+        WHERE catalog_id = ? AND migration_id = ?
+      `).run(now, ...migrationKey(catalogId, migrationId));
+    });
+
+    let report: CatalogV3ValidationReport;
+    try {
+      const before = migration.expectedCounts;
+      const after = this.counts(catalogId);
+      const fingerprintCoverage = this.fingerprintCoverage(catalogId);
+      const expectedStateSha256 = migration.expectedStateSha256;
+      const actualStateSha256 = this.migrationStateSha256(catalogId, migrationId);
+      const integrity = this.integrity();
+      const relationFailures = {
+        aliases: this.relationFailureCount(catalogId, "aliases"),
+        albums: this.relationFailureCount(catalogId, "albums"),
+        albumAssets: this.relationFailureCount(catalogId, "albumAssets"),
+        archived: this.relationFailureCount(catalogId, "archived"),
+      };
+      const blockingErrors: string[] = [];
+      const countKeys: readonly (keyof CatalogV3ExpectedCounts)[] = [
+        "assets",
+        "metadata",
+        "albums",
+        "albumAssets",
+        "archived",
+        "aliases",
+        "fingerprints",
+        "present",
+        "missing",
+      ];
+      for (const key of countKeys) {
+        if (after[key] !== before[key]) {
+          blockingErrors.push(`Count ${key} expected ${before[key]} but found ${after[key]}.`);
+        }
+      }
+      if (integrity.integrityCheck.length !== 1 || integrity.integrityCheck[0] !== "ok") {
+        blockingErrors.push("SQLite integrity check failed.");
+      }
+      if (integrity.foreignKeyCheck.length > 0) blockingErrors.push("SQLite foreign-key check failed.");
+      if (Object.values(relationFailures).some((count) => count > 0)) {
+        blockingErrors.push("Catalog v3 relation checks failed.");
+      }
+      if (actualStateSha256 !== expectedStateSha256) {
+        blockingErrors.push("Catalog v3 migrated state does not match the frozen migration plan.");
+      }
+      if (
+        fingerprintCoverage.missing !== after.assets ||
+        fingerprintCoverage.hashing !== 0 ||
+        fingerprintCoverage.valid !== 0 ||
+        fingerprintCoverage.stale !== 0 ||
+        fingerprintCoverage.failed !== 0
+      ) {
+        blockingErrors.push("Every legacy migration fingerprint must remain missing until post-migration hashing.");
+      }
+      const limitations = after.assets > 0
+        ? ["No asset has a proven digest; duplicate readiness is unavailable."]
+        : [];
+      report = {
+        catalogId,
+        migrationId,
+        clean: blockingErrors.length === 0,
+        before,
+        after,
+        fingerprintCoverage,
+        expectedStateSha256,
+        actualStateSha256,
+        relationFailures,
+        integrity,
+        applicationId: verifyCatalogV3Schema(this.database).applicationId,
+        schemaVersion: 3,
+        userVersion: verifyCatalogV3Schema(this.database).userVersion,
+        limitations,
+        blockingErrors,
+      };
+    } catch (error) {
+      report = {
+        catalogId,
+        migrationId,
+        clean: false,
+        before: migration.expectedCounts,
+        after: this.counts(catalogId),
+        fingerprintCoverage: this.fingerprintCoverage(catalogId),
+        expectedStateSha256: migration.expectedStateSha256,
+        actualStateSha256: "0".repeat(64),
+        relationFailures: { aliases: 0, albums: 0, albumAssets: 0, archived: 0 },
+        integrity: this.integrity(),
+        applicationId: 0,
+        schemaVersion: 3,
+        userVersion: 3,
+        limitations: [],
+        blockingErrors: [error instanceof Error ? error.message : "Catalog v3 validation failed."],
+      };
+    }
+
+    return this.transaction(() => {
+      const phase: CatalogV3MigrationPhase = report.clean ? "validated" : "failed";
+      this.database.prepare(`
+        UPDATE migration_runs
+        SET phase = ?, validation_report_json = ?, error_message = ?, updated_at = ?
+        WHERE catalog_id = ? AND migration_id = ?
+      `).run(
+        phase,
+        jsonString(report, "validationReport"),
+        report.clean ? null : report.blockingErrors.join(" "),
+        Date.now(),
+        ...migrationKey(catalogId, migrationId),
+      );
+      return {
+        catalogId,
+        migrationId,
+        phase,
+        report,
+        revision: this.revision(catalogId),
+      };
+    });
+  }
+
+  private relationFailureCount(catalogId: CatalogId, relation: "aliases" | "albums" | "albumAssets" | "archived"): number {
+    switch (relation) {
+      case "aliases":
+        return this.scalarCount(`
+          SELECT COUNT(*) AS count FROM migration_aliases AS a
+          LEFT JOIN assets AS x ON x.catalog_id = a.catalog_id AND x.asset_id = a.asset_id
+          WHERE a.catalog_id = ? AND (
+            x.asset_id IS NULL
+            OR x.root_id <> a.root_id
+            OR x.relative_path <> a.relative_path
+          )
+        `, catalogId);
+      case "albums":
+        return this.scalarCount(`
+          SELECT COUNT(*) AS count FROM (
+            SELECT a.album_id AS failure
+            FROM albums AS a
+            LEFT JOIN catalog_meta AS c ON c.catalog_id = a.catalog_id
+            WHERE a.catalog_id = ?1 AND c.catalog_id IS NULL
+            UNION ALL
+            SELECT 'album-position-gap' AS failure
+            FROM albums
+            WHERE catalog_id = ?1
+            GROUP BY catalog_id
+            HAVING MIN(position) <> 0 OR MAX(position) <> COUNT(*) - 1
+          )
+        `, catalogId);
+      case "albumAssets":
+        return this.scalarCount(`
+          SELECT COUNT(*) AS count FROM (
+            SELECT aa.album_id
+            FROM album_assets AS aa
+            LEFT JOIN albums AS a ON a.catalog_id = aa.catalog_id AND a.album_id = aa.album_id
+            LEFT JOIN assets AS x ON x.catalog_id = aa.catalog_id AND x.asset_id = aa.asset_id
+            WHERE aa.catalog_id = ?
+            GROUP BY aa.album_id
+            HAVING
+              SUM(CASE WHEN a.album_id IS NULL OR x.asset_id IS NULL THEN 1 ELSE 0 END) > 0
+              OR MIN(aa.position) <> 0
+              OR MAX(aa.position) <> COUNT(*) - 1
+          )
+        `, catalogId);
+      case "archived":
+        return this.scalarCount(`
+          SELECT COUNT(*) AS count FROM asset_metadata AS m
+          LEFT JOIN assets AS a ON a.catalog_id = m.catalog_id AND a.asset_id = m.asset_id
+          WHERE m.catalog_id = ? AND m.archive = 1 AND a.asset_id IS NULL
+        `, catalogId);
+      default: {
+        const _exhaustive: never = relation;
+        throw new Error(`Unknown Catalog v3 relation ${_exhaustive}.`);
+      }
+    }
+  }
+
+  private scalarCount(sql: string, catalogId: CatalogId): number {
+    const row = this.database.prepare(sql).get(catalogId);
+    if (!isRow(row)) throw new Error("Catalog v3 scalar count row is invalid.");
+    return integerValue(row, "count");
+  }
+
+  prepareActivation(catalogId: CatalogId, migrationId: string): CatalogV3ActivationResult {
+    this.schema();
+    return this.transaction(() => {
+      const migration = this.migration(catalogId, migrationId);
+      if (migration.phase !== "validated" || migration.validationReportJson === null) {
+        throw new Error("Catalog v3 migration must have a clean validation before activation.");
+      }
+      let reportValue: unknown;
+      try {
+        reportValue = JSON.parse(migration.validationReportJson);
+      } catch {
+        throw new Error("Catalog v3 validation report is malformed.");
+      }
+      if (typeof reportValue !== "object" || reportValue === null || Reflect.get(reportValue, "clean") !== true) {
+        throw new Error("Catalog v3 validation report is not clean.");
+      }
+      const now = Date.now();
+      this.database.prepare(`
+        UPDATE catalog_meta SET install_state = 'ready', updated_at = ?
+        WHERE catalog_id = ?
+      `).run(now, catalogId);
+      return {
+        catalogId,
+        migrationId,
+        installState: "ready",
+        revision: this.revision(catalogId),
+      };
+    });
+  }
+
+  sealForInstall(catalogId: CatalogId, migrationId: string): CatalogV3SealForInstallResult {
+    this.schema();
+    const catalog = this.catalog(catalogId);
+    if (catalog.installState !== "ready") {
+      throw new Error("Catalog v3 catalog must be ready before sealing for install.");
+    }
+    const migration = this.requireMigration(catalogId, migrationId, (phase) => phase === "validated");
+    if (migration.validationReportJson === null) {
+      throw new Error("Catalog v3 migration must have a clean validation before sealing for install.");
+    }
+    let reportValue: unknown;
+    try {
+      reportValue = JSON.parse(migration.validationReportJson);
+    } catch {
+      throw new Error("Catalog v3 validation report is malformed.");
+    }
+    if (typeof reportValue !== "object" || reportValue === null || Reflect.get(reportValue, "clean") !== true) {
+      throw new Error("Catalog v3 validation report is not clean.");
+    }
+
+    const checkpoint = this.database.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get();
+    if (!isRow(checkpoint)) throw new Error("Catalog v3 WAL checkpoint result is invalid.");
+    const busy = integerValue(checkpoint, "busy");
+    const logFrames = integerValue(checkpoint, "log");
+    const checkpointedFrames = integerValue(checkpoint, "checkpointed");
+    if (busy !== 0) throw new Error("Catalog v3 WAL checkpoint is busy.");
+
+    const journal = this.database.prepare("PRAGMA journal_mode = DELETE").get();
+    if (!isRow(journal) || stringValue(journal, "journal_mode") !== "delete") {
+      throw new Error("Catalog v3 journal mode did not switch to delete.");
+    }
+    return {
+      catalogId,
+      migrationId,
+      busy,
+      logFrames,
+      checkpointedFrames,
+      journalMode: "delete",
+    };
+  }
+
+  summary(catalogId: CatalogId): CatalogV3Summary {
+    this.schema();
+    const catalog = this.catalog(catalogId);
+    const migrationRow = this.database.prepare(`
+      SELECT
+        migration_id AS migrationId, source_version AS sourceVersion,
+        catalog_path AS catalogPath, settings_path AS settingsPath,
+        catalog_sha256 AS catalogSha256, settings_sha256 AS settingsSha256,
+        root_available AS rootAvailable, expected_counts_json AS expectedCountsJson,
+        expected_state_sha256 AS expectedStateSha256,
+        phase, validation_report_json AS validationReportJson, error_message AS errorMessage,
+        created_at AS createdAt, updated_at AS updatedAt
+      FROM migration_runs WHERE catalog_id = ? ORDER BY created_at, migration_id LIMIT 1
+    `).get(catalogId);
+    const migration = parseMigrationRow(migrationRow);
+    const rootRow = this.database.prepare(
+      "SELECT root_id AS rootId FROM roots WHERE catalog_id = ? ORDER BY root_id LIMIT 1",
+    ).get(catalogId);
+    if (!isRow(rootRow)) throw new Error("Catalog v3 root row is missing.");
+    const root = this.root(catalogId, parseRootId(stringValue(rootRow, "rootId")));
+    return {
+      catalogId,
+      displayName: catalog.displayName,
+      appVersion: catalog.appVersion,
+      installState: catalog.installState,
+      revision: catalog.revision,
+      migrationId: migration.migrationId,
+      migrationPhase: migration.phase,
+      sourceVersion: migration.sourceVersion,
+      migration: {
+        migrationId: migration.migrationId,
+        sourceVersion: migration.sourceVersion,
+        catalogPath: migration.catalogPath,
+        settingsPath: migration.settingsPath,
+        catalogSha256: migration.catalogSha256,
+        settingsSha256: migration.settingsSha256,
+        rootAvailable: migration.rootAvailable,
+        expectedCounts: migration.expectedCounts,
+        expectedStateSha256: migration.expectedStateSha256,
+      },
+      root,
+      counts: this.counts(catalogId),
+      fingerprintCoverage: this.fingerprintCoverage(catalogId),
+    };
+  }
+
+  private assetSnapshot(catalogId: CatalogId, assetId: AssetId): CatalogV3AssetSnapshot {
+    const row = this.database.prepare(`${ASSET_SNAPSHOT_SELECT}
+      WHERE a.catalog_id = ? AND a.asset_id = ?
+    `).get(catalogId, assetId);
+    return parseAssetSnapshotRow(row);
+  }
+
+  assetPage(input: CatalogV3AssetPageInput): CatalogV3AssetPage {
+    const validated = parseCatalogV3AssetPageInput(input);
+    this.schema();
+    const currentRevision = this.revision(validated.catalogId);
+    if (validated.expectedRevision !== null && validated.expectedRevision !== currentRevision) {
+      throw new Error(`Catalog v3 snapshot revision ${validated.expectedRevision} is stale; current revision is ${currentRevision}.`);
+    }
+    const cursor = validated.cursor === null ? null : decodeCursor(validated.cursor);
+    const rows = cursor === null
+      ? this.database.prepare(`
+          SELECT asset_id AS assetId, relative_path AS relativePath
+          FROM assets WHERE catalog_id = ?
+          ORDER BY relative_path, asset_id LIMIT ?
+        `).all(validated.catalogId, validated.limit + 1)
+      : this.database.prepare(`
+          SELECT asset_id AS assetId, relative_path AS relativePath
+          FROM assets
+          WHERE catalog_id = ? AND (relative_path > ? OR (relative_path = ? AND asset_id > ?))
+          ORDER BY relative_path, asset_id LIMIT ?
+        `).all(validated.catalogId, cursor.relativePath, cursor.relativePath, cursor.assetId, validated.limit + 1);
+    const parsedRows = rows.map((row) => {
+      if (!isRow(row)) throw new Error("Catalog v3 asset page row is invalid.");
+      return {
+        assetId: parseAssetId(stringValue(row, "assetId")),
+        relativePath: stringValue(row, "relativePath"),
+      };
+    });
+    const hasNext = parsedRows.length > validated.limit;
+    const visible = hasNext ? parsedRows.slice(0, validated.limit) : parsedRows;
+    const assets = visible.map((item) => this.assetSnapshot(validated.catalogId, item.assetId));
+    const last = visible.at(-1);
+    return {
+      catalogId: validated.catalogId,
+      revision: currentRevision,
+      assets,
+      nextCursor: hasNext && last !== undefined
+        ? encodeCursor({ relativePath: last.relativePath, assetId: last.assetId })
+        : null,
+    };
+  }
+
+  albumSnapshots(input: CatalogV3AlbumPageInput): CatalogV3AlbumSnapshotResult {
+    const validated = parseCatalogV3AlbumPageInput(input);
+    this.schema();
+    const currentRevision = this.revision(validated.catalogId);
+    if (validated.expectedRevision !== null && validated.expectedRevision !== currentRevision) {
+      throw new Error(`Catalog v3 album snapshot revision ${validated.expectedRevision} is stale; current revision is ${currentRevision}.`);
+    }
+    const rows = validated.cursor === null
+      ? this.database.prepare(`
+          SELECT album_id AS albumId, name, created_at AS createdAt, updated_at AS updatedAt, position
+          FROM albums WHERE catalog_id = ? ORDER BY position LIMIT ?
+        `).all(validated.catalogId, validated.limit + 1)
+      : this.database.prepare(`
+          SELECT album_id AS albumId, name, created_at AS createdAt, updated_at AS updatedAt, position
+          FROM albums WHERE catalog_id = ? AND position > ? ORDER BY position LIMIT ?
+        `).all(validated.catalogId, validated.cursor, validated.limit + 1);
+    const parsedRows: CatalogV3AlbumSnapshot[] = rows.map((row) => {
+      if (!isRow(row)) throw new Error("Catalog v3 album snapshot row is invalid.");
+      return {
+        catalogId: validated.catalogId,
+        id: stringValue(row, "albumId"),
+        name: stringValue(row, "name"),
+        createdAt: numberValue(row, "createdAt"),
+        updatedAt: numberValue(row, "updatedAt"),
+        position: integerValue(row, "position"),
+      };
+    });
+    const hasNext = parsedRows.length > validated.limit;
+    const albums = hasNext ? parsedRows.slice(0, validated.limit) : parsedRows;
+    return {
+      catalogId: validated.catalogId,
+      revision: currentRevision,
+      albums,
+      nextCursor: hasNext ? (albums.at(-1)?.position ?? null) : null,
+    };
+  }
+
+  albumAssetPage(input: CatalogV3AlbumAssetPageInput): CatalogV3AlbumAssetPage {
+    const validated = parseCatalogV3AlbumAssetPageInput(input);
+    this.schema();
+    const currentRevision = this.revision(validated.catalogId);
+    if (validated.expectedRevision !== null && validated.expectedRevision !== currentRevision) {
+      throw new Error(`Catalog v3 album asset snapshot revision ${validated.expectedRevision} is stale; current revision is ${currentRevision}.`);
+    }
+    const album = this.database.prepare(`
+      SELECT 1 FROM albums WHERE catalog_id = ? AND album_id = ?
+    `).get(validated.catalogId, validated.albumId);
+    if (album === undefined) throw new Error("Catalog v3 album is missing.");
+    const rows = validated.cursor === null
+      ? this.database.prepare(`
+          SELECT aa.position, a.asset_id AS assetId, a.root_id AS rootId,
+                 a.relative_path AS relativePath, a.health, a.revision
+          FROM album_assets AS aa
+          JOIN assets AS a ON a.catalog_id = aa.catalog_id AND a.asset_id = aa.asset_id
+          WHERE aa.catalog_id = ? AND aa.album_id = ?
+          ORDER BY aa.position LIMIT ?
+        `).all(validated.catalogId, validated.albumId, validated.limit + 1)
+      : this.database.prepare(`
+          SELECT aa.position, a.asset_id AS assetId, a.root_id AS rootId,
+                 a.relative_path AS relativePath, a.health, a.revision
+          FROM album_assets AS aa
+          JOIN assets AS a ON a.catalog_id = aa.catalog_id AND a.asset_id = aa.asset_id
+          WHERE aa.catalog_id = ? AND aa.album_id = ? AND aa.position > ?
+          ORDER BY aa.position LIMIT ?
+        `).all(validated.catalogId, validated.albumId, validated.cursor, validated.limit + 1);
+    const parsedRows: CatalogV3AlbumAssetSnapshot[] = rows.map((row) => {
+      if (!isRow(row)) throw new Error("Catalog v3 album membership row is invalid.");
+      const health = stringValue(row, "health");
+      if (!["present", "missing", "ambiguous", "unreadable"].includes(health)) {
+        throw new Error("Catalog v3 album membership health is invalid.");
+      }
+      return {
+        position: integerValue(row, "position"),
+        assetId: parseAssetId(stringValue(row, "assetId")),
+        rootId: parseRootId(stringValue(row, "rootId")),
+        relativePath: stringValue(row, "relativePath"),
+        health: health as CatalogV3AlbumAssetSnapshot["health"],
+        revision: integerValue(row, "revision"),
+      };
+    });
+    const hasNext = parsedRows.length > validated.limit;
+    const assets = hasNext ? parsedRows.slice(0, validated.limit) : parsedRows;
+    return {
+      catalogId: validated.catalogId,
+      albumId: validated.albumId,
+      revision: currentRevision,
+      assets,
+      nextCursor: hasNext ? (assets.at(-1)?.position ?? null) : null,
+    };
+  }
+}
+
+export function catalogV3Repository(database: DatabaseSync): CatalogV3Repository {
+  return new CatalogV3Repository(database);
+}

--- a/electron/catalog-v3-schema.ts
+++ b/electron/catalog-v3-schema.ts
@@ -1,0 +1,388 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  CATALOG_V3_APPLICATION_ID,
+  CATALOG_V3_SCHEMA_VERSION,
+} from "../lib/catalog/v3.ts";
+
+const HEX = "[0-9a-f]";
+
+function uuidPattern(): string {
+  return `${HEX.repeat(8)}-${HEX.repeat(4)}-[1-8]${HEX.repeat(3)}-[89ab]${HEX.repeat(3)}-${HEX.repeat(12)}`;
+}
+
+function uuidCheck(column: string): string {
+  return `${column} GLOB '${uuidPattern()}' AND lower(${column}) = ${column}`;
+}
+
+function hashCheck(column: string): string {
+  return `(${column} IS NULL OR (${column} GLOB '${HEX.repeat(64)}' AND lower(${column}) = ${column}))`;
+}
+
+export const CATALOG_V3_TABLES = [
+  "catalog_meta",
+  "migration_runs",
+  "roots",
+  "assets",
+  "asset_metadata",
+  "albums",
+  "album_assets",
+  "fingerprints",
+  "import_presets",
+  "auto_import_rules",
+  "operations",
+  "operation_items",
+  "migration_aliases",
+  "audit_log",
+] as const;
+
+export type CatalogV3TableName = (typeof CATALOG_V3_TABLES)[number];
+
+export interface CatalogV3SchemaManifest {
+  readonly applicationId: number;
+  readonly schemaVersion: number;
+  readonly userVersion: number;
+  readonly tables: readonly CatalogV3TableName[];
+}
+
+export function catalogV3SchemaSql(): string {
+  const migrationIdCheck = uuidCheck("migration_id");
+  const catalogIdCheck = uuidCheck("catalog_id");
+  const rootIdCheck = uuidCheck("root_id");
+  const assetIdCheck = uuidCheck("asset_id");
+  const fingerprintIdCheck = uuidCheck("fingerprint_id");
+  const operationIdCheck = uuidCheck("operation_id");
+  const presetIdCheck = uuidCheck("preset_id");
+
+  return `
+    BEGIN IMMEDIATE;
+
+    PRAGMA application_id = ${CATALOG_V3_APPLICATION_ID};
+    PRAGMA user_version = ${CATALOG_V3_SCHEMA_VERSION};
+
+    CREATE TABLE IF NOT EXISTS catalog_meta (
+      catalog_id TEXT PRIMARY KEY CHECK (${catalogIdCheck}),
+      singleton INTEGER NOT NULL DEFAULT 1 UNIQUE CHECK (singleton = 1),
+      display_name TEXT NOT NULL CHECK (length(display_name) > 0),
+      schema_version INTEGER NOT NULL CHECK (schema_version = 3),
+      app_version TEXT NOT NULL CHECK (length(app_version) > 0),
+      install_state TEXT NOT NULL CHECK (install_state IN ('staging', 'ready')),
+      revision INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+      created_at REAL NOT NULL,
+      updated_at REAL NOT NULL
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS migration_runs (
+      catalog_id TEXT NOT NULL,
+      migration_id TEXT NOT NULL CHECK (${migrationIdCheck}),
+      source_version INTEGER NOT NULL CHECK (source_version IN (1, 2)),
+      catalog_path TEXT NOT NULL CHECK (length(catalog_path) > 0 AND instr(catalog_path, char(0)) = 0),
+      settings_path TEXT,
+      catalog_sha256 TEXT NOT NULL CHECK (${hashCheck("catalog_sha256")}),
+      settings_sha256 TEXT CHECK (${hashCheck("settings_sha256")}),
+      root_available INTEGER NOT NULL CHECK (root_available IN (0, 1)),
+      expected_counts_json TEXT NOT NULL CHECK (json_valid(expected_counts_json)),
+      expected_state_sha256 TEXT NOT NULL CHECK (${hashCheck("expected_state_sha256")}),
+      phase TEXT NOT NULL CHECK (phase IN ('created', 'copying-assets', 'copying-relations', 'copied', 'validating', 'validated', 'failed')),
+      validation_report_json TEXT CHECK (validation_report_json IS NULL OR json_valid(validation_report_json)),
+      error_message TEXT,
+      created_at REAL NOT NULL,
+      updated_at REAL NOT NULL,
+      PRIMARY KEY (catalog_id, migration_id),
+      CHECK ((settings_path IS NULL) = (settings_sha256 IS NULL)),
+      FOREIGN KEY (catalog_id) REFERENCES catalog_meta (catalog_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS roots (
+      catalog_id TEXT NOT NULL,
+      root_id TEXT NOT NULL CHECK (${rootIdCheck}),
+      label TEXT NOT NULL CHECK (length(label) > 0 AND instr(label, char(0)) = 0),
+      configured_path TEXT NOT NULL CHECK (length(configured_path) > 0 AND instr(configured_path, char(0)) = 0),
+      canonical_path TEXT CHECK (canonical_path IS NULL OR (length(canonical_path) > 0 AND instr(canonical_path, char(0)) = 0)),
+      health TEXT NOT NULL CHECK (health IN ('online', 'missing', 'ambiguous', 'unreadable')),
+      scan_state TEXT NOT NULL CHECK (scan_state IN ('unknown', 'complete', 'partial', 'failed')),
+      watch_state TEXT NOT NULL CHECK (watch_state IN ('disabled', 'active', 'error')),
+      revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+      CHECK (health <> 'online' OR canonical_path IS NOT NULL),
+      PRIMARY KEY (catalog_id, root_id),
+      FOREIGN KEY (catalog_id) REFERENCES catalog_meta (catalog_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS assets (
+      catalog_id TEXT NOT NULL,
+      asset_id TEXT NOT NULL CHECK (${assetIdCheck}),
+      root_id TEXT NOT NULL CHECK (${rootIdCheck}),
+      relative_path TEXT NOT NULL CHECK (
+        length(relative_path) > 0
+        AND instr(relative_path, char(0)) = 0
+        AND substr(relative_path, 1, 1) <> '/'
+        AND instr(relative_path, char(92)) = 0
+        AND relative_path NOT LIKE '../%'
+        AND relative_path NOT LIKE '%/../%'
+        AND relative_path NOT LIKE '%/..'
+        AND relative_path <> '..'
+        AND relative_path NOT LIKE './%'
+        AND relative_path NOT LIKE '%/./%'
+        AND relative_path NOT LIKE '%/.'
+        AND relative_path <> '.'
+        AND relative_path NOT LIKE '%//%'
+        AND substr(relative_path, 2, 1) <> ':'
+      ),
+      observed_byte_length INTEGER CHECK (observed_byte_length IS NULL OR observed_byte_length >= 0),
+      observed_modified_at REAL,
+      observed_at REAL,
+      local_file_id TEXT,
+      revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+      health TEXT NOT NULL CHECK (health IN ('present', 'missing', 'ambiguous', 'unreadable')),
+      format_id TEXT NOT NULL CHECK (length(format_id) > 0),
+      camera_make TEXT,
+      camera_model TEXT,
+      lens_model TEXT,
+      PRIMARY KEY (catalog_id, asset_id),
+      UNIQUE (catalog_id, root_id, relative_path),
+      FOREIGN KEY (catalog_id, root_id) REFERENCES roots (catalog_id, root_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS asset_metadata (
+      catalog_id TEXT NOT NULL,
+      asset_id TEXT NOT NULL CHECK (${assetIdCheck}),
+      archive INTEGER NOT NULL DEFAULT 0 CHECK (archive IN (0, 1)),
+      pick TEXT NOT NULL CHECK (pick IN ('none', 'pick', 'reject')),
+      rating INTEGER NOT NULL CHECK (rating BETWEEN 0 AND 5),
+      color_label TEXT CHECK (color_label IS NULL OR color_label IN ('red', 'yellow', 'green', 'blue', 'purple')),
+      develop_json TEXT CHECK (develop_json IS NULL OR json_valid(develop_json)),
+      develop_updated_at REAL NOT NULL,
+      updated_at REAL NOT NULL,
+      title TEXT,
+      caption TEXT,
+      copyright TEXT,
+      keywords_json TEXT NOT NULL CHECK (json_valid(keywords_json) AND json_type(keywords_json) = 'array'),
+      raw_xmp TEXT,
+      xmp_state TEXT NOT NULL CHECK (xmp_state IN ('unknown', 'absent', 'preserved', 'malformed')),
+      xmp_mtime REAL,
+      xmp_sha256 TEXT CHECK (${hashCheck("xmp_sha256")}),
+      PRIMARY KEY (catalog_id, asset_id),
+      CHECK ((xmp_state = 'preserved') = (raw_xmp IS NOT NULL)),
+      CHECK (xmp_state <> 'absent' OR raw_xmp IS NULL),
+      FOREIGN KEY (catalog_id, asset_id) REFERENCES assets (catalog_id, asset_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS albums (
+      catalog_id TEXT NOT NULL,
+      album_id TEXT NOT NULL CHECK (length(album_id) > 0),
+      name TEXT NOT NULL,
+      created_at REAL NOT NULL,
+      updated_at REAL NOT NULL,
+      position INTEGER NOT NULL CHECK (position >= 0),
+      PRIMARY KEY (catalog_id, album_id),
+      UNIQUE (catalog_id, position),
+      FOREIGN KEY (catalog_id) REFERENCES catalog_meta (catalog_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS album_assets (
+      catalog_id TEXT NOT NULL,
+      album_id TEXT NOT NULL,
+      asset_id TEXT NOT NULL CHECK (${assetIdCheck}),
+      position INTEGER NOT NULL CHECK (position >= 0),
+      PRIMARY KEY (catalog_id, album_id, position),
+      UNIQUE (catalog_id, album_id, asset_id),
+      FOREIGN KEY (catalog_id, album_id) REFERENCES albums (catalog_id, album_id),
+      FOREIGN KEY (catalog_id, asset_id) REFERENCES assets (catalog_id, asset_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS fingerprints (
+      catalog_id TEXT NOT NULL,
+      fingerprint_id TEXT NOT NULL CHECK (${fingerprintIdCheck}),
+      asset_id TEXT NOT NULL CHECK (${assetIdCheck}),
+      status TEXT NOT NULL CHECK (status IN ('missing', 'hashing', 'valid', 'stale', 'failed')),
+      sha256 TEXT CHECK (${hashCheck("sha256")}),
+      observed_at REAL,
+      observed_byte_length INTEGER CHECK (observed_byte_length IS NULL OR observed_byte_length >= 0),
+      observed_modified_at REAL,
+      local_file_id TEXT,
+      updated_at REAL NOT NULL,
+      PRIMARY KEY (catalog_id, fingerprint_id),
+      UNIQUE (catalog_id, asset_id),
+      CHECK ((status = 'valid') = (sha256 IS NOT NULL)),
+      CHECK (status <> 'valid' OR (observed_at IS NOT NULL AND (observed_byte_length IS NOT NULL OR observed_modified_at IS NOT NULL OR local_file_id IS NOT NULL))),
+      FOREIGN KEY (catalog_id, asset_id) REFERENCES assets (catalog_id, asset_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS import_presets (
+      catalog_id TEXT NOT NULL,
+      preset_id TEXT NOT NULL CHECK (${presetIdCheck}),
+      name TEXT NOT NULL,
+      payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+      revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+      created_at REAL NOT NULL,
+      updated_at REAL NOT NULL,
+      PRIMARY KEY (catalog_id, preset_id),
+      FOREIGN KEY (catalog_id) REFERENCES catalog_meta (catalog_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS auto_import_rules (
+      catalog_id TEXT NOT NULL,
+      rule_id TEXT NOT NULL CHECK (${uuidCheck("rule_id")}),
+      name TEXT NOT NULL,
+      enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+      destination_root_id TEXT NOT NULL CHECK (${uuidCheck("destination_root_id")}),
+      preset_id TEXT NOT NULL CHECK (${presetIdCheck}),
+      config_json TEXT NOT NULL CHECK (json_valid(config_json)),
+      revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+      created_at REAL NOT NULL,
+      updated_at REAL NOT NULL,
+      PRIMARY KEY (catalog_id, rule_id),
+      FOREIGN KEY (catalog_id) REFERENCES catalog_meta (catalog_id),
+      FOREIGN KEY (catalog_id, destination_root_id) REFERENCES roots (catalog_id, root_id),
+      FOREIGN KEY (catalog_id, preset_id) REFERENCES import_presets (catalog_id, preset_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS operations (
+      catalog_id TEXT NOT NULL,
+      operation_id TEXT NOT NULL CHECK (${operationIdCheck}),
+      kind TEXT NOT NULL CHECK (length(kind) > 0),
+      state TEXT NOT NULL CHECK (state IN ('planned', 'running', 'completed', 'failed', 'cancelled')),
+      payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+      revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+      created_at REAL NOT NULL,
+      updated_at REAL NOT NULL,
+      PRIMARY KEY (catalog_id, operation_id),
+      FOREIGN KEY (catalog_id) REFERENCES catalog_meta (catalog_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS operation_items (
+      catalog_id TEXT NOT NULL,
+      operation_id TEXT NOT NULL CHECK (${operationIdCheck}),
+      item_id TEXT NOT NULL CHECK (length(item_id) > 0),
+      asset_id TEXT CHECK (${uuidCheck("asset_id")}),
+      state TEXT NOT NULL CHECK (state IN ('planned', 'running', 'completed', 'failed', 'cancelled')),
+      payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+      PRIMARY KEY (catalog_id, operation_id, item_id),
+      FOREIGN KEY (catalog_id, operation_id) REFERENCES operations (catalog_id, operation_id),
+      FOREIGN KEY (catalog_id, asset_id) REFERENCES assets (catalog_id, asset_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS migration_aliases (
+      catalog_id TEXT NOT NULL,
+      migration_id TEXT NOT NULL CHECK (${migrationIdCheck}),
+      legacy_id TEXT NOT NULL CHECK (length(legacy_id) > 0),
+      root_id TEXT NOT NULL CHECK (${rootIdCheck}),
+      relative_path TEXT NOT NULL CHECK (length(relative_path) > 0),
+      asset_id TEXT NOT NULL CHECK (${assetIdCheck}),
+      created_at REAL NOT NULL,
+      PRIMARY KEY (catalog_id, migration_id, legacy_id),
+      UNIQUE (catalog_id, migration_id, root_id, relative_path, legacy_id),
+      FOREIGN KEY (catalog_id, migration_id) REFERENCES migration_runs (catalog_id, migration_id),
+      FOREIGN KEY (catalog_id, root_id) REFERENCES roots (catalog_id, root_id),
+      FOREIGN KEY (catalog_id, asset_id) REFERENCES assets (catalog_id, asset_id)
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS audit_log (
+      audit_id INTEGER PRIMARY KEY,
+      catalog_id TEXT NOT NULL,
+      migration_id TEXT,
+      event TEXT NOT NULL CHECK (length(event) > 0),
+      payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+      created_at REAL NOT NULL,
+      FOREIGN KEY (catalog_id) REFERENCES catalog_meta (catalog_id),
+      FOREIGN KEY (catalog_id, migration_id) REFERENCES migration_runs (catalog_id, migration_id)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS assets_by_catalog_path
+      ON assets (catalog_id, root_id, relative_path);
+    CREATE INDEX IF NOT EXISTS album_assets_by_asset
+      ON album_assets (catalog_id, asset_id);
+    CREATE INDEX IF NOT EXISTS migration_aliases_by_asset
+      ON migration_aliases (catalog_id, migration_id, asset_id, legacy_id);
+    CREATE INDEX IF NOT EXISTS fingerprints_by_catalog_digest
+      ON fingerprints (catalog_id, sha256)
+      WHERE sha256 IS NOT NULL;
+    CREATE UNIQUE INDEX IF NOT EXISTS auto_import_one_enabled_per_catalog
+      ON auto_import_rules (catalog_id)
+      WHERE enabled = 1;
+    CREATE INDEX IF NOT EXISTS audit_log_by_catalog_time
+      ON audit_log (catalog_id, created_at, audit_id);
+
+    COMMIT;
+  `;
+}
+
+function pragmaInteger(opened: DatabaseSync, pragma: string): number {
+  const row = opened.prepare(`PRAGMA ${pragma}`).get();
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    throw new Error(`Catalog v3 ${pragma} pragma is invalid.`);
+  }
+  const value = Reflect.get(row, pragma);
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`Catalog v3 ${pragma} pragma is invalid.`);
+  }
+  return value;
+}
+
+function tableNames(opened: DatabaseSync): readonly CatalogV3TableName[] {
+  const rows = opened.prepare(
+    "SELECT name, strict FROM pragma_table_list WHERE schema = 'main' AND type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+  ).all();
+  const names = new Set<string>();
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) {
+      throw new Error("Catalog v3 table manifest is invalid.");
+    }
+    const name = Reflect.get(row, "name");
+    if (typeof name !== "string") throw new Error("Catalog v3 table name is invalid.");
+    if (Reflect.get(row, "strict") !== 1) throw new Error(`Catalog v3 table ${name} is not STRICT.`);
+    names.add(name);
+  }
+  const missing = CATALOG_V3_TABLES.filter((table) => !names.has(table));
+  if (missing.length > 0) {
+    throw new Error(`Catalog v3 schema is missing tables: ${missing.join(", ")}.`);
+  }
+  return CATALOG_V3_TABLES;
+}
+
+export function installCatalogV3Schema(opened: DatabaseSync): CatalogV3SchemaManifest {
+  if (!isCatalogV3DatabaseEmpty(opened)) {
+    throw new Error("Catalog v3 can only initialize an empty SQLite database.");
+  }
+  try {
+    opened.exec(catalogV3SchemaSql());
+  } catch (error) {
+    try {
+      opened.exec("ROLLBACK;");
+    } catch {
+      // SQLite may already have ended the failed schema transaction.
+    }
+    throw error;
+  }
+  return verifyCatalogV3Schema(opened);
+}
+
+export function isCatalogV3DatabaseEmpty(opened: DatabaseSync): boolean {
+  const row = opened.prepare(
+    "SELECT COUNT(*) AS count FROM sqlite_master WHERE type IN ('table', 'index', 'trigger', 'view') AND name NOT LIKE 'sqlite_%'",
+  ).get();
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    throw new Error("Catalog v3 database manifest is invalid.");
+  }
+  const count = Reflect.get(row, "count");
+  if (typeof count !== "number" || !Number.isInteger(count)) {
+    throw new Error("Catalog v3 database manifest count is invalid.");
+  }
+  return count === 0;
+}
+
+export function verifyCatalogV3Schema(opened: DatabaseSync): CatalogV3SchemaManifest {
+  const applicationId = pragmaInteger(opened, "application_id");
+  const userVersion = pragmaInteger(opened, "user_version");
+  if (applicationId !== CATALOG_V3_APPLICATION_ID) {
+    throw new Error(`Catalog v3 application id ${applicationId} is invalid.`);
+  }
+  if (userVersion !== CATALOG_V3_SCHEMA_VERSION) {
+    throw new Error(`Catalog v3 user version ${userVersion} is invalid.`);
+  }
+  return {
+    applicationId,
+    schemaVersion: CATALOG_V3_SCHEMA_VERSION,
+    userVersion,
+    tables: tableNames(opened),
+  };
+}

--- a/electron/catalog-v3-state.ts
+++ b/electron/catalog-v3-state.ts
@@ -1,0 +1,318 @@
+import { createHash, type Hash } from "node:crypto";
+import type {
+  CatalogV3AlbumInput,
+  CatalogV3AssetCandidate,
+  CatalogV3AssetMetadata,
+  CatalogV3FingerprintInput,
+  CatalogV3Observation,
+} from "../lib/catalog/v3.ts";
+import type { RootId } from "../lib/catalog/ids.ts";
+
+export const CATALOG_V3_DEFAULT_METADATA: CatalogV3AssetMetadata = {
+  archive: false,
+  pick: "none",
+  rating: 0,
+  colorLabel: null,
+  developJson: null,
+  developUpdatedAt: 0,
+  updatedAt: 0,
+  title: null,
+  caption: null,
+  copyright: null,
+  keywordsJson: "[]",
+  rawXmp: null,
+  xmpState: "unknown",
+  xmpMtime: null,
+  xmpSha256: null,
+};
+
+export interface CatalogV3StateLocation {
+  readonly rootId: RootId;
+  readonly relativePath: string;
+}
+
+export interface CatalogV3StateFingerprint {
+  readonly status: CatalogV3FingerprintInput["status"];
+  readonly sha256: string | null;
+  readonly observedAt: number | null;
+  readonly observedByteLength: number | null;
+  readonly observedModifiedAt: number | null;
+  readonly localFileId: string | null;
+}
+
+export interface CatalogV3StateAsset extends CatalogV3StateLocation {
+  readonly observation: CatalogV3Observation | null;
+  readonly health: CatalogV3AssetCandidate["health"];
+  readonly formatId: string;
+  readonly cameraMake: string | null;
+  readonly cameraModel: string | null;
+  readonly lensModel: string | null;
+  readonly legacyIds: readonly string[];
+  readonly metadata: CatalogV3AssetMetadata;
+  readonly fingerprint: CatalogV3StateFingerprint;
+}
+
+export interface CatalogV3StateAlbum {
+  readonly id: string;
+  readonly name: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly position: number;
+  readonly members: readonly CatalogV3StateLocation[];
+}
+
+export interface CatalogV3State {
+  readonly assets: readonly CatalogV3StateAsset[];
+  readonly albums: readonly CatalogV3StateAlbum[];
+}
+
+export interface CatalogV3ExpectedStateInput {
+  readonly assets: readonly CatalogV3AssetCandidate[];
+  readonly albums: readonly Pick<CatalogV3AlbumInput, "id" | "name" | "createdAt" | "updatedAt" | "position" | "entryIds">[];
+  readonly archiveLegacyIds: readonly string[];
+}
+
+function fingerprintFor(candidate: CatalogV3AssetCandidate): CatalogV3StateFingerprint {
+  const raw = candidate.fingerprint;
+  return {
+    status: raw?.status ?? "missing",
+    sha256: raw?.sha256 ?? null,
+    observedAt: raw?.observedAt ?? candidate.observation?.observedAt ?? null,
+    observedByteLength: raw?.observedByteLength ?? candidate.observation?.byteLength ?? null,
+    observedModifiedAt: raw?.observedModifiedAt ?? candidate.observation?.modifiedAt ?? null,
+    localFileId: raw?.localFileId ?? candidate.observation?.localFileId ?? null,
+  };
+}
+
+function compareText(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+type CatalogV3StateAlbumHeader = Omit<CatalogV3StateAlbum, "members">;
+
+const STATE_DIGEST_VERSION = "darkroom.catalog-v3-state.v1";
+
+export class CatalogV3StateDigest {
+  private readonly hash: Hash = createHash("sha256");
+  private phase: "assets" | "albums" | "finished" = "assets";
+
+  constructor() {
+    this.marker(1);
+    this.value(STATE_DIGEST_VERSION);
+  }
+
+  private marker(value: number): void {
+    this.hash.update(Buffer.from([0xff, value]));
+  }
+
+  private bytes(value: Uint8Array): void {
+    const length = Buffer.allocUnsafe(8);
+    length.writeBigUInt64BE(BigInt(value.byteLength));
+    this.hash.update(length);
+    this.hash.update(value);
+  }
+
+  private value(value: string | number | boolean | null): void {
+    if (value === null) {
+      this.hash.update(Buffer.from([0]));
+      return;
+    }
+    if (typeof value === "boolean") {
+      this.hash.update(Buffer.from([1, value ? 1 : 0]));
+      return;
+    }
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) throw new Error("Catalog v3 state number must be finite.");
+      this.hash.update(Buffer.from([2]));
+      this.bytes(Buffer.from(JSON.stringify(value), "utf8"));
+      return;
+    }
+    this.hash.update(Buffer.from([3]));
+    this.bytes(Buffer.from(value, "utf8"));
+  }
+
+  addAsset(asset: CatalogV3StateAsset): void {
+    if (this.phase !== "assets") throw new Error("Catalog v3 state assets are out of order.");
+    this.marker(2);
+    this.value(asset.rootId);
+    this.value(asset.relativePath);
+    this.value(asset.observation !== null);
+    if (asset.observation !== null) {
+      this.value(asset.observation.byteLength);
+      this.value(asset.observation.modifiedAt);
+      this.value(asset.observation.observedAt);
+      this.value(asset.observation.localFileId);
+    }
+    this.value(asset.health);
+    this.value(asset.formatId);
+    this.value(asset.cameraMake);
+    this.value(asset.cameraModel);
+    this.value(asset.lensModel);
+    const legacyIds = [...asset.legacyIds].sort(compareText);
+    this.value(legacyIds.length);
+    for (const legacyId of legacyIds) this.value(legacyId);
+
+    const metadata = asset.metadata;
+    this.value(metadata.archive);
+    this.value(metadata.pick);
+    this.value(metadata.rating);
+    this.value(metadata.colorLabel);
+    this.value(metadata.developJson);
+    this.value(metadata.developUpdatedAt);
+    this.value(metadata.updatedAt);
+    this.value(metadata.title);
+    this.value(metadata.caption);
+    this.value(metadata.copyright);
+    this.value(metadata.keywordsJson);
+    this.value(metadata.rawXmp);
+    this.value(metadata.xmpState);
+    this.value(metadata.xmpMtime);
+    this.value(metadata.xmpSha256);
+
+    const fingerprint = asset.fingerprint;
+    this.value(fingerprint.status);
+    this.value(fingerprint.sha256);
+    this.value(fingerprint.observedAt);
+    this.value(fingerprint.observedByteLength);
+    this.value(fingerprint.observedModifiedAt);
+    this.value(fingerprint.localFileId);
+  }
+
+  addAlbum(album: CatalogV3StateAlbumHeader, members: Iterable<CatalogV3StateLocation>): void {
+    if (this.phase === "assets") {
+      this.marker(3);
+      this.phase = "albums";
+    }
+    if (this.phase !== "albums") throw new Error("Catalog v3 state albums are out of order.");
+    this.marker(4);
+    this.value(album.id);
+    this.value(album.name);
+    this.value(album.createdAt);
+    this.value(album.updatedAt);
+    this.value(album.position);
+    for (const member of members) {
+      this.marker(5);
+      this.value(member.rootId);
+      this.value(member.relativePath);
+    }
+    this.marker(6);
+  }
+
+  digest(): string {
+    if (this.phase === "finished") throw new Error("Catalog v3 state digest is already finished.");
+    if (this.phase === "assets") this.marker(3);
+    this.marker(7);
+    this.phase = "finished";
+    return this.hash.digest("hex");
+  }
+}
+
+export function catalogV3StateSha256(state: CatalogV3State): string {
+  const digest = new CatalogV3StateDigest();
+  for (const asset of [...state.assets].sort((left, right) =>
+    compareText(left.rootId, right.rootId) || compareText(left.relativePath, right.relativePath)
+  )) {
+    digest.addAsset(asset);
+  }
+  for (const album of state.albums) {
+    const { members, ...header } = album;
+    digest.addAlbum(header, members);
+  }
+  return digest.digest();
+}
+
+function expectedStateFacts(input: CatalogV3ExpectedStateInput): {
+  readonly locations: ReadonlyMap<string, CatalogV3StateLocation>;
+  readonly archived: ReadonlySet<string>;
+} {
+  if (input.albums.some((album, index) => album.position !== index)) {
+    throw new Error("Catalog v3 expected album positions must be contiguous.");
+  }
+  const locations = new Map<string, CatalogV3StateLocation>();
+  for (const asset of input.assets) {
+    for (const legacyId of asset.legacyIds) {
+      if (locations.has(legacyId)) {
+        throw new Error(`Catalog v3 expected state has duplicate legacy ID ${legacyId}.`);
+      }
+      locations.set(legacyId, { rootId: asset.rootId, relativePath: asset.relativePath });
+    }
+  }
+  const archived = new Set(input.archiveLegacyIds);
+  for (const legacyId of archived) {
+    if (!locations.has(legacyId)) {
+      throw new Error(`Catalog v3 expected archive references unknown legacy ID ${legacyId}.`);
+    }
+  }
+  return { locations, archived };
+}
+
+function expectedAsset(
+  asset: CatalogV3AssetCandidate,
+  archived: ReadonlySet<string>,
+): CatalogV3StateAsset {
+  const metadata = asset.metadata ?? CATALOG_V3_DEFAULT_METADATA;
+  return {
+    rootId: asset.rootId,
+    relativePath: asset.relativePath,
+    observation: asset.observation,
+    health: asset.health,
+    formatId: asset.formatId,
+    cameraMake: asset.cameraMake,
+    cameraModel: asset.cameraModel,
+    lensModel: asset.lensModel,
+    legacyIds: asset.legacyIds,
+    metadata: archived.size > 0 && asset.legacyIds.some((legacyId) => archived.has(legacyId))
+      ? { ...metadata, archive: true }
+      : metadata,
+    fingerprint: fingerprintFor(asset),
+  };
+}
+
+function* albumMembers(
+  album: CatalogV3ExpectedStateInput["albums"][number],
+  locations: ReadonlyMap<string, CatalogV3StateLocation>,
+): Generator<CatalogV3StateLocation> {
+  for (const legacyId of album.entryIds) {
+    const location = locations.get(legacyId);
+    if (location === undefined) {
+      throw new Error(`Catalog v3 expected album references unknown legacy ID ${legacyId}.`);
+    }
+    yield location;
+  }
+}
+
+export function catalogV3ExpectedState(input: CatalogV3ExpectedStateInput): CatalogV3State {
+  const { locations, archived } = expectedStateFacts(input);
+
+  return {
+    assets: input.assets.map((asset) => expectedAsset(asset, archived)),
+    albums: input.albums.map((album) => ({
+      id: album.id,
+      name: album.name,
+      createdAt: album.createdAt,
+      updatedAt: album.updatedAt,
+      position: album.position,
+      members: [...albumMembers(album, locations)],
+    })),
+  };
+}
+
+export function catalogV3ExpectedStateSha256(input: CatalogV3ExpectedStateInput): string {
+  const { locations, archived } = expectedStateFacts(input);
+  const digest = new CatalogV3StateDigest();
+  for (const asset of [...input.assets].sort((left, right) =>
+    compareText(left.rootId, right.rootId) || compareText(left.relativePath, right.relativePath)
+  )) {
+    digest.addAsset(expectedAsset(asset, archived));
+  }
+  for (const album of input.albums) {
+    digest.addAlbum({
+      id: album.id,
+      name: album.name,
+      createdAt: album.createdAt,
+      updatedAt: album.updatedAt,
+      position: album.position,
+    }, albumMembers(album, locations));
+  }
+  return digest.digest();
+}

--- a/electron/catalog-worker-client.ts
+++ b/electron/catalog-worker-client.ts
@@ -2,7 +2,26 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { Worker, type WorkerOptions } from "node:worker_threads";
 import type { CatalogFaultPoint } from "./catalog-fault-injection.ts";
-import type { AssetId, OperationId } from "../lib/catalog/ids.ts";
+import type { AssetId, CatalogId, OperationId } from "../lib/catalog/ids.ts";
+import type {
+  CatalogV3ActivationResult,
+  CatalogV3AlbumAssetPage,
+  CatalogV3AlbumAssetPageInput,
+  CatalogV3AlbumPageInput,
+  CatalogV3AlbumSnapshotResult,
+  CatalogV3AssetBatchInput,
+  CatalogV3AssetBatchResult,
+  CatalogV3AssetPage,
+  CatalogV3AssetPageInput,
+  CatalogV3FinishCopyResult,
+  CatalogV3InstallInput,
+  CatalogV3InstallResult,
+  CatalogV3RelationsBatchInput,
+  CatalogV3RelationsBatchResult,
+  CatalogV3SealForInstallResult,
+  CatalogV3Summary,
+  CatalogV3ValidationResult,
+} from "../lib/catalog/v3.ts";
 import {
   parseCatalogWorkerResponse,
   type CatalogWorkerBackupResponse,
@@ -103,6 +122,60 @@ function requireKind<K extends CatalogWorkerResponse["kind"]>(
     throw new Error(`Catalog worker returned ${response.kind} for ${kind}.`);
   }
   return response as Extract<CatalogWorkerResponse, { kind: K }>;
+}
+
+function requireCatalogIdentity<T extends { readonly catalogId: CatalogId }>(
+  result: T,
+  catalogId: CatalogId,
+  operation: string,
+): T {
+  if (result.catalogId !== catalogId) {
+    throw new Error(`Catalog worker ${operation} returned a mismatched catalogId.`);
+  }
+  return result;
+}
+
+function requireMigrationIdentity<T extends { readonly catalogId: CatalogId; readonly migrationId: string }>(
+  result: T,
+  catalogId: CatalogId,
+  migrationId: string,
+  operation: string,
+): T {
+  requireCatalogIdentity(result, catalogId, operation);
+  if (result.migrationId !== migrationId) {
+    throw new Error(`Catalog worker ${operation} returned a mismatched migrationId.`);
+  }
+  return result;
+}
+
+function requireSnapshotRevision<T extends { readonly revision: number }>(
+  result: T,
+  expectedRevision: number | null,
+  operation: string,
+): T {
+  if (expectedRevision !== null && result.revision !== expectedRevision) {
+    throw new Error(`Catalog worker ${operation} returned a mismatched revision.`);
+  }
+  return result;
+}
+
+function requirePositionPage(
+  items: readonly { readonly position: number }[],
+  cursor: number | null,
+  limit: number,
+  nextCursor: number | null,
+  operation: string,
+): void {
+  if (items.length > limit) {
+    throw new Error(`Catalog worker ${operation} returned too many items.`);
+  }
+  const first = items[0];
+  if (first !== undefined && first.position !== (cursor ?? -1) + 1) {
+    throw new Error(`Catalog worker ${operation} returned a mismatched cursor.`);
+  }
+  if (nextCursor !== null && items.length !== limit) {
+    throw new Error(`Catalog worker ${operation} returned an inconsistent nextCursor.`);
+  }
 }
 
 export class CatalogWorkerClient {
@@ -305,6 +378,140 @@ export class CatalogWorkerClient {
       itemId: input.itemId,
     });
     return requireKind(response, "test-tracer-inspect");
+  }
+
+  async installV3(input: CatalogV3InstallInput): Promise<CatalogV3InstallResult> {
+    const response = await this.send({ kind: "v3-install", requestId: requestId(), input });
+    return requireMigrationIdentity(
+      requireKind(response, "v3-install").result,
+      input.catalogId,
+      input.migration.migrationId,
+      "v3-install",
+    );
+  }
+
+  async writeV3AssetBatch(input: CatalogV3AssetBatchInput): Promise<CatalogV3AssetBatchResult> {
+    const response = await this.send({ kind: "v3-assets", requestId: requestId(), input });
+    return requireMigrationIdentity(
+      requireKind(response, "v3-assets").result,
+      input.catalogId,
+      input.migrationId,
+      "v3-assets",
+    );
+  }
+
+  async writeV3RelationsBatch(input: CatalogV3RelationsBatchInput): Promise<CatalogV3RelationsBatchResult> {
+    const response = await this.send({ kind: "v3-relations", requestId: requestId(), input });
+    return requireMigrationIdentity(
+      requireKind(response, "v3-relations").result,
+      input.catalogId,
+      input.migrationId,
+      "v3-relations",
+    );
+  }
+
+  async finishV3Copy(catalogId: CatalogV3InstallInput["catalogId"], migrationId: string): Promise<CatalogV3FinishCopyResult> {
+    const response = await this.send({
+      kind: "v3-finish-copy",
+      requestId: requestId(),
+      catalogId,
+      migrationId,
+    });
+    return requireMigrationIdentity(
+      requireKind(response, "v3-finish-copy").result,
+      catalogId,
+      migrationId,
+      "v3-finish-copy",
+    );
+  }
+
+  async validateV3(catalogId: CatalogV3InstallInput["catalogId"], migrationId: string): Promise<CatalogV3ValidationResult> {
+    const response = await this.send({
+      kind: "v3-validate",
+      requestId: requestId(),
+      catalogId,
+      migrationId,
+    });
+    return requireMigrationIdentity(
+      requireKind(response, "v3-validate").result,
+      catalogId,
+      migrationId,
+      "v3-validate",
+    );
+  }
+
+  async prepareV3Activation(catalogId: CatalogV3InstallInput["catalogId"], migrationId: string): Promise<CatalogV3ActivationResult> {
+    const response = await this.send({
+      kind: "v3-prepare-activation",
+      requestId: requestId(),
+      catalogId,
+      migrationId,
+    });
+    return requireMigrationIdentity(
+      requireKind(response, "v3-prepare-activation").result,
+      catalogId,
+      migrationId,
+      "v3-prepare-activation",
+    );
+  }
+
+  async sealV3ForInstall(catalogId: CatalogV3InstallInput["catalogId"], migrationId: string): Promise<CatalogV3SealForInstallResult> {
+    const response = await this.send({
+      kind: "v3-seal-for-install",
+      requestId: requestId(),
+      catalogId,
+      migrationId,
+    });
+    return requireMigrationIdentity(
+      requireKind(response, "v3-seal-for-install").result,
+      catalogId,
+      migrationId,
+      "v3-seal-for-install",
+    );
+  }
+
+  async v3Summary(catalogId: CatalogV3InstallInput["catalogId"]): Promise<CatalogV3Summary> {
+    const response = await this.send({ kind: "v3-summary", requestId: requestId(), catalogId });
+    return requireCatalogIdentity(requireKind(response, "v3-summary").result, catalogId, "v3-summary");
+  }
+
+  async v3AssetsPage(input: CatalogV3AssetPageInput): Promise<CatalogV3AssetPage> {
+    const response = await this.send({ kind: "v3-assets-page", requestId: requestId(), input });
+    const result = requireSnapshotRevision(
+      requireCatalogIdentity(requireKind(response, "v3-assets-page").result, input.catalogId, "v3-assets-page"),
+      input.expectedRevision,
+      "v3-assets-page",
+    );
+    if (result.assets.length > input.limit || (result.nextCursor !== null && result.assets.length !== input.limit)) {
+      throw new Error("Catalog worker v3-assets-page returned inconsistent page bounds.");
+    }
+    return result;
+  }
+
+  async v3Albums(input: CatalogV3AlbumPageInput): Promise<CatalogV3AlbumSnapshotResult> {
+    const response = await this.send({ kind: "v3-albums", requestId: requestId(), input });
+    const result = requireSnapshotRevision(
+      requireCatalogIdentity(requireKind(response, "v3-albums").result, input.catalogId, "v3-albums"),
+      input.expectedRevision,
+      "v3-albums",
+    );
+    requirePositionPage(result.albums, input.cursor, input.limit, result.nextCursor, "v3-albums");
+    return result;
+  }
+
+  async v3AlbumAssetsPage(input: CatalogV3AlbumAssetPageInput): Promise<CatalogV3AlbumAssetPage> {
+    const response = await this.send({ kind: "v3-album-assets-page", requestId: requestId(), input });
+    const result = requireCatalogIdentity(
+      requireKind(response, "v3-album-assets-page").result,
+      input.catalogId,
+      "v3-album-assets-page",
+    );
+    if (result.albumId !== input.albumId) {
+      throw new Error("Catalog worker v3-album-assets-page returned a mismatched albumId.");
+    }
+    requireSnapshotRevision(result, input.expectedRevision, "v3-album-assets-page");
+    requirePositionPage(result.assets, input.cursor, input.limit, result.nextCursor, "v3-album-assets-page");
+    return result;
   }
 
   async shutdown(timeoutMs = this.defaultTimeoutMs): Promise<void> {

--- a/electron/catalog-worker-protocol.ts
+++ b/electron/catalog-worker-protocol.ts
@@ -1,10 +1,52 @@
 import path from "node:path";
 import {
   parseAssetId,
+  parseCatalogId,
   parseOperationId,
+  parseRootId,
   type AssetId,
+  type CatalogId,
   type OperationId,
 } from "../lib/catalog/ids.ts";
+import {
+  CATALOG_V3_APPLICATION_ID,
+  CATALOG_V3_MAX_XMP_BYTES,
+  CATALOG_V3_SCHEMA_VERSION,
+  parseCatalogV3AlbumAssetPageInput,
+  parseCatalogV3AlbumPageInput,
+  parseCatalogV3AssetBatchInput,
+  parseCatalogV3AssetCursor,
+  parseCatalogV3AssetPageInput,
+  parseCatalogV3InstallInput,
+  parseCatalogV3RelationsBatchInput,
+  type CatalogV3ActivationResult,
+  type CatalogV3AlbumAssetPage,
+  type CatalogV3AlbumAssetPageInput,
+  type CatalogV3AlbumAssetSnapshot,
+  type CatalogV3AlbumPageInput,
+  type CatalogV3AlbumSnapshot,
+  type CatalogV3AlbumSnapshotResult,
+  type CatalogV3AssetBatchInput,
+  type CatalogV3AssetBatchResult,
+  type CatalogV3AssetMetadata,
+  type CatalogV3AssetPage,
+  type CatalogV3AssetPageInput,
+  type CatalogV3AssetSnapshot,
+  type CatalogV3Counts,
+  type CatalogV3ExpectedCounts,
+  type CatalogV3FinishCopyResult,
+  type CatalogV3FingerprintCoverage,
+  type CatalogV3InstallInput,
+  type CatalogV3InstallResult,
+  type CatalogV3IntegrityResult,
+  type CatalogV3MigrationInput,
+  type CatalogV3RelationsBatchInput,
+  type CatalogV3RelationsBatchResult,
+  type CatalogV3RootInput,
+  type CatalogV3SealForInstallResult,
+  type CatalogV3Summary,
+  type CatalogV3ValidationResult,
+} from "../lib/catalog/v3.ts";
 import {
   parseCatalogFaultPoint,
   parseCatalogFaultStage,
@@ -109,6 +151,142 @@ export interface CatalogWorkerShutdownResponse {
   readonly wasOpen: boolean;
 }
 
+export interface CatalogWorkerCatalogV3InstallRequest {
+  readonly kind: "v3-install";
+  readonly requestId: string;
+  readonly input: CatalogV3InstallInput;
+}
+
+export interface CatalogWorkerCatalogV3InstallResponse {
+  readonly kind: "v3-install";
+  readonly requestId: string;
+  readonly result: CatalogV3InstallResult;
+}
+
+export interface CatalogWorkerCatalogV3AssetBatchRequest {
+  readonly kind: "v3-assets";
+  readonly requestId: string;
+  readonly input: CatalogV3AssetBatchInput;
+}
+
+export interface CatalogWorkerCatalogV3AssetBatchResponse {
+  readonly kind: "v3-assets";
+  readonly requestId: string;
+  readonly result: CatalogV3AssetBatchResult;
+}
+
+export interface CatalogWorkerCatalogV3RelationsBatchRequest {
+  readonly kind: "v3-relations";
+  readonly requestId: string;
+  readonly input: CatalogV3RelationsBatchInput;
+}
+
+export interface CatalogWorkerCatalogV3RelationsBatchResponse {
+  readonly kind: "v3-relations";
+  readonly requestId: string;
+  readonly result: CatalogV3RelationsBatchResult;
+}
+
+export interface CatalogWorkerCatalogV3FinishCopyRequest {
+  readonly kind: "v3-finish-copy";
+  readonly requestId: string;
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+}
+
+export interface CatalogWorkerCatalogV3FinishCopyResponse {
+  readonly kind: "v3-finish-copy";
+  readonly requestId: string;
+  readonly result: CatalogV3FinishCopyResult;
+}
+
+export interface CatalogWorkerCatalogV3ValidateRequest {
+  readonly kind: "v3-validate";
+  readonly requestId: string;
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+}
+
+export interface CatalogWorkerCatalogV3ValidateResponse {
+  readonly kind: "v3-validate";
+  readonly requestId: string;
+  readonly result: CatalogV3ValidationResult;
+}
+
+export interface CatalogWorkerCatalogV3PrepareActivationRequest {
+  readonly kind: "v3-prepare-activation";
+  readonly requestId: string;
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+}
+
+export interface CatalogWorkerCatalogV3PrepareActivationResponse {
+  readonly kind: "v3-prepare-activation";
+  readonly requestId: string;
+  readonly result: CatalogV3ActivationResult;
+}
+
+export interface CatalogWorkerCatalogV3SealForInstallRequest {
+  readonly kind: "v3-seal-for-install";
+  readonly requestId: string;
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+}
+
+export interface CatalogWorkerCatalogV3SealForInstallResponse {
+  readonly kind: "v3-seal-for-install";
+  readonly requestId: string;
+  readonly result: CatalogV3SealForInstallResult;
+}
+
+export interface CatalogWorkerCatalogV3SummaryRequest {
+  readonly kind: "v3-summary";
+  readonly requestId: string;
+  readonly catalogId: CatalogId;
+}
+
+export interface CatalogWorkerCatalogV3SummaryResponse {
+  readonly kind: "v3-summary";
+  readonly requestId: string;
+  readonly result: CatalogV3Summary;
+}
+
+export interface CatalogWorkerCatalogV3AssetPageRequest {
+  readonly kind: "v3-assets-page";
+  readonly requestId: string;
+  readonly input: CatalogV3AssetPageInput;
+}
+
+export interface CatalogWorkerCatalogV3AssetPageResponse {
+  readonly kind: "v3-assets-page";
+  readonly requestId: string;
+  readonly result: CatalogV3AssetPage;
+}
+
+export interface CatalogWorkerCatalogV3AlbumSnapshotsRequest {
+  readonly kind: "v3-albums";
+  readonly requestId: string;
+  readonly input: CatalogV3AlbumPageInput;
+}
+
+export interface CatalogWorkerCatalogV3AlbumSnapshotsResponse {
+  readonly kind: "v3-albums";
+  readonly requestId: string;
+  readonly result: CatalogV3AlbumSnapshotResult;
+}
+
+export interface CatalogWorkerCatalogV3AlbumAssetPageRequest {
+  readonly kind: "v3-album-assets-page";
+  readonly requestId: string;
+  readonly input: CatalogV3AlbumAssetPageInput;
+}
+
+export interface CatalogWorkerCatalogV3AlbumAssetPageResponse {
+  readonly kind: "v3-album-assets-page";
+  readonly requestId: string;
+  readonly result: CatalogV3AlbumAssetPage;
+}
+
 export interface CatalogWorkerTestTracerRunRequest {
   readonly kind: "test-tracer-run";
   readonly requestId: string;
@@ -161,6 +339,17 @@ export type CatalogWorkerRequest =
   | CatalogWorkerIntegrityCheckRequest
   | CatalogWorkerCloseRequest
   | CatalogWorkerShutdownRequest
+  | CatalogWorkerCatalogV3InstallRequest
+  | CatalogWorkerCatalogV3AssetBatchRequest
+  | CatalogWorkerCatalogV3RelationsBatchRequest
+  | CatalogWorkerCatalogV3FinishCopyRequest
+  | CatalogWorkerCatalogV3ValidateRequest
+  | CatalogWorkerCatalogV3PrepareActivationRequest
+  | CatalogWorkerCatalogV3SealForInstallRequest
+  | CatalogWorkerCatalogV3SummaryRequest
+  | CatalogWorkerCatalogV3AssetPageRequest
+  | CatalogWorkerCatalogV3AlbumSnapshotsRequest
+  | CatalogWorkerCatalogV3AlbumAssetPageRequest
   | CatalogWorkerTestTracerRunRequest
   | CatalogWorkerTestTracerRecoverRequest
   | CatalogWorkerTestTracerInspectRequest;
@@ -202,6 +391,17 @@ export type CatalogWorkerResponse =
   | CatalogWorkerIntegrityCheckResponse
   | CatalogWorkerCloseResponse
   | CatalogWorkerShutdownResponse
+  | CatalogWorkerCatalogV3InstallResponse
+  | CatalogWorkerCatalogV3AssetBatchResponse
+  | CatalogWorkerCatalogV3RelationsBatchResponse
+  | CatalogWorkerCatalogV3FinishCopyResponse
+  | CatalogWorkerCatalogV3ValidateResponse
+  | CatalogWorkerCatalogV3PrepareActivationResponse
+  | CatalogWorkerCatalogV3SealForInstallResponse
+  | CatalogWorkerCatalogV3SummaryResponse
+  | CatalogWorkerCatalogV3AssetPageResponse
+  | CatalogWorkerCatalogV3AlbumSnapshotsResponse
+  | CatalogWorkerCatalogV3AlbumAssetPageResponse
   | CatalogWorkerTestTracerRunResponse
   | CatalogWorkerTestTracerRecoverResponse
   | CatalogWorkerTestTracerInspectResponse
@@ -213,9 +413,25 @@ function isRecord(value: unknown): value is RecordValue {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function requiredString(record: RecordValue, key: string): string {
+function requiredRecord(value: unknown, label: string): RecordValue {
+  if (!isRecord(value)) {
+    throw new Error(`Catalog worker ${label} is invalid.`);
+  }
+  return value;
+}
+
+function requiredString(record: RecordValue, key: string, allowEmpty = false): string {
   const value = record[key];
-  if (typeof value !== "string" || value.length === 0) {
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+    throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+  return value;
+}
+
+function requiredNullableString(record: RecordValue, key: string): string | null {
+  const value = record[key];
+  if (value === null) return null;
+  if (typeof value !== "string") {
     throw new Error(`Catalog worker ${key} is invalid.`);
   }
   return value;
@@ -249,8 +465,24 @@ function requiredInteger(record: RecordValue, key: string): number {
   return value;
 }
 
+function requiredNonnegativeInteger(record: RecordValue, key: string): number {
+  const value = requiredInteger(record, key);
+  if (value < 0) {
+    throw new Error(`Catalog worker ${key} must be a nonnegative integer.`);
+  }
+  return value;
+}
+
 function requiredNullableInteger(record: RecordValue, key: string): number | null {
   return record[key] === null ? null : requiredInteger(record, key);
+}
+
+function requiredNullableNonnegativeInteger(record: RecordValue, key: string): number | null {
+  return record[key] === null ? null : requiredNonnegativeInteger(record, key);
+}
+
+function requiredNullableNumber(record: RecordValue, key: string): number | null {
+  return record[key] === null ? null : requiredNumber(record, key);
 }
 
 function requiredBoolean(record: RecordValue, key: string): boolean {
@@ -267,6 +499,591 @@ function requiredStringArray(record: RecordValue, key: string): readonly string[
     throw new Error(`Catalog worker ${key} is invalid.`);
   }
   return value;
+}
+
+function requiredCatalogId(record: RecordValue, key = "catalogId"): CatalogId {
+  return parseCatalogId(record[key]);
+}
+
+function requiredUuid(value: unknown, key: string): string {
+  if (
+    typeof value !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value) ||
+    value !== value.toLowerCase()
+  ) {
+    throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+  return value;
+}
+
+function requiredMigrationId(record: RecordValue, key = "migrationId"): string {
+  return requiredUuid(record[key], key);
+}
+
+function requiredHash(value: unknown, key: string): string {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+  return value;
+}
+
+function requiredNullableHash(record: RecordValue, key: string): string | null {
+  const value = record[key];
+  return value === null ? null : requiredHash(value, key);
+}
+
+function requiredEnum<T extends string>(value: unknown, key: string, values: readonly T[]): T {
+  const match = values.find((candidate) => candidate === value);
+  if (match === undefined) {
+    throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+  return match;
+}
+
+function requiredNullableEnum<T extends string>(
+  value: unknown,
+  key: string,
+  values: readonly T[],
+): T | null {
+  return value === null ? null : requiredEnum(value, key, values);
+}
+
+function requiredRelativePath(value: unknown, key: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.includes("\u0000") ||
+    value.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith("\\\\") ||
+    value.includes("\\")
+  ) {
+    throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+  const segments = value.split("/");
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+  return value;
+}
+
+function requiredJsonText(value: unknown, key: string, nullable: boolean): string | null {
+  if (value === null && nullable) return null;
+  if (typeof value !== "string") {
+    throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+  try {
+    JSON.parse(value);
+  } catch {
+    throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+  return value;
+}
+
+function requiredRating(value: unknown, key: string): 0 | 1 | 2 | 3 | 4 | 5 {
+  const rating = typeof value === "number" && Number.isInteger(value) ? value : null;
+  switch (rating) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+      return rating;
+    default:
+      throw new Error(`Catalog worker ${key} is invalid.`);
+  }
+}
+
+function requiredV3Result(record: RecordValue): RecordValue {
+  const result = record.result;
+  const parsed = requiredRecord(result, "v3 result");
+  requiredCatalogId(parsed);
+  const revision = parsed.revision;
+  if (revision !== undefined && (typeof revision !== "number" || !Number.isInteger(revision) || revision < 0)) {
+    throw new Error("Catalog worker v3 result revision is invalid.");
+  }
+  return parsed;
+}
+
+function parseExpectedCounts(value: unknown, key: string): CatalogV3ExpectedCounts {
+  const record = requiredRecord(value, key);
+  return {
+    assets: requiredNonnegativeInteger(record, "assets"),
+    metadata: requiredNonnegativeInteger(record, "metadata"),
+    albums: requiredNonnegativeInteger(record, "albums"),
+    albumAssets: requiredNonnegativeInteger(record, "albumAssets"),
+    archived: requiredNonnegativeInteger(record, "archived"),
+    aliases: requiredNonnegativeInteger(record, "aliases"),
+    fingerprints: requiredNonnegativeInteger(record, "fingerprints"),
+    present: requiredNonnegativeInteger(record, "present"),
+    missing: requiredNonnegativeInteger(record, "missing"),
+  };
+}
+
+function parseCounts(value: unknown): CatalogV3Counts {
+  const record = requiredRecord(value, "counts");
+  return {
+    ...parseExpectedCounts(record, "counts"),
+    ambiguous: requiredNonnegativeInteger(record, "ambiguous"),
+    unreadable: requiredNonnegativeInteger(record, "unreadable"),
+  };
+}
+
+function parseFingerprintCoverage(value: unknown): CatalogV3FingerprintCoverage {
+  const record = requiredRecord(value, "fingerprintCoverage");
+  const coverage = {
+    total: requiredNonnegativeInteger(record, "total"),
+    missing: requiredNonnegativeInteger(record, "missing"),
+    hashing: requiredNonnegativeInteger(record, "hashing"),
+    valid: requiredNonnegativeInteger(record, "valid"),
+    stale: requiredNonnegativeInteger(record, "stale"),
+    failed: requiredNonnegativeInteger(record, "failed"),
+  };
+  if (coverage.total !== coverage.missing + coverage.hashing + coverage.valid + coverage.stale + coverage.failed) {
+    throw new Error("Catalog worker fingerprint coverage is inconsistent.");
+  }
+  return coverage;
+}
+
+function parseIntegrity(value: unknown): CatalogV3IntegrityResult {
+  const record = requiredRecord(value, "integrity");
+  const foreignKeyCheckValue = record.foreignKeyCheck;
+  if (!Array.isArray(foreignKeyCheckValue)) {
+    throw new Error("Catalog worker foreignKeyCheck is invalid.");
+  }
+  return {
+    integrityCheck: requiredStringArray(record, "integrityCheck"),
+    foreignKeyCheck: foreignKeyCheckValue.map((item) => {
+      const violation = requiredRecord(item, "foreign-key result");
+      return {
+        table: requiredString(violation, "table"),
+        rowId: requiredNullableNonnegativeInteger(violation, "rowId"),
+        parent: requiredString(violation, "parent"),
+        foreignKeyIndex: requiredNonnegativeInteger(violation, "foreignKeyIndex"),
+      };
+    }),
+  };
+}
+
+function parseMetadata(value: unknown): CatalogV3AssetMetadata {
+  const record = requiredRecord(value, "metadata");
+  const rawXmp = requiredNullableString(record, "rawXmp");
+  if (rawXmp !== null && new TextEncoder().encode(rawXmp).byteLength > CATALOG_V3_MAX_XMP_BYTES) {
+    throw new Error("Catalog worker rawXmp is too large.");
+  }
+  const xmpState = requiredEnum(record.xmpState, "xmpState", ["unknown", "absent", "preserved", "malformed"] as const);
+  if ((xmpState === "preserved") !== (rawXmp !== null)) {
+    throw new Error("Catalog worker XMP state is inconsistent.");
+  }
+  const keywordsJson = requiredJsonText(record.keywordsJson, "keywordsJson", false);
+  if (keywordsJson === null || !Array.isArray(JSON.parse(keywordsJson))) {
+    throw new Error("Catalog worker keywordsJson is invalid.");
+  }
+  return {
+    archive: requiredBoolean(record, "archive"),
+    pick: requiredEnum(record.pick, "pick", ["none", "pick", "reject"] as const),
+    rating: requiredRating(record.rating, "rating"),
+    colorLabel: requiredNullableEnum(record.colorLabel, "colorLabel", ["red", "yellow", "green", "blue", "purple"] as const),
+    developJson: requiredJsonText(record.developJson, "developJson", true),
+    developUpdatedAt: requiredNumber(record, "developUpdatedAt"),
+    updatedAt: requiredNumber(record, "updatedAt"),
+    title: requiredNullableString(record, "title"),
+    caption: requiredNullableString(record, "caption"),
+    copyright: requiredNullableString(record, "copyright"),
+    keywordsJson,
+    rawXmp,
+    xmpState,
+    xmpMtime: requiredNullableNumber(record, "xmpMtime"),
+    xmpSha256: requiredNullableHash(record, "xmpSha256"),
+  };
+}
+
+function parseObservation(value: unknown): CatalogV3AssetSnapshot["observation"] {
+  if (value === null) return null;
+  const record = requiredRecord(value, "observation");
+  return {
+    byteLength: requiredNullableNonnegativeInteger(record, "byteLength"),
+    modifiedAt: requiredNullableNumber(record, "modifiedAt"),
+    observedAt: requiredNumber(record, "observedAt"),
+    localFileId: requiredNullableString(record, "localFileId"),
+  };
+}
+
+function parseAssetSnapshot(value: unknown): CatalogV3AssetSnapshot {
+  const record = requiredRecord(value, "asset snapshot");
+  const observation = parseObservation(record.observation);
+  const health = requiredEnum(record.health, "health", ["present", "missing", "ambiguous", "unreadable"] as const);
+  if ((health === "present") !== (observation !== null)) {
+    throw new Error("Catalog worker asset health and observation are inconsistent.");
+  }
+  const fingerprintStatus = requiredEnum(record.fingerprintStatus, "fingerprintStatus", ["missing", "hashing", "valid", "stale", "failed"] as const);
+  const fingerprintSha256 = requiredNullableHash(record, "fingerprintSha256");
+  if (fingerprintStatus === "valid" && fingerprintSha256 === null) {
+    throw new Error("Catalog worker valid fingerprint needs sha256.");
+  }
+  if (fingerprintStatus !== "valid" && fingerprintSha256 !== null) {
+    throw new Error("Catalog worker non-valid fingerprint cannot have sha256.");
+  }
+  return {
+    catalogId: requiredCatalogId(record),
+    assetId: parseAssetId(record.assetId),
+    rootId: parseRootId(record.rootId),
+    relativePath: requiredRelativePath(record.relativePath, "relativePath"),
+    observation,
+    revision: requiredNonnegativeInteger(record, "revision"),
+    health,
+    formatId: requiredNullableString(record, "formatId"),
+    cameraMake: requiredNullableString(record, "cameraMake"),
+    cameraModel: requiredNullableString(record, "cameraModel"),
+    lensModel: requiredNullableString(record, "lensModel"),
+    fingerprintId: parseAssetId(record.fingerprintId),
+    fingerprintStatus,
+    fingerprintSha256,
+    fingerprintObservedAt: requiredNullableNumber(record, "fingerprintObservedAt"),
+    fingerprintObservedByteLength: requiredNullableNonnegativeInteger(record, "fingerprintObservedByteLength"),
+    fingerprintObservedModifiedAt: requiredNullableNumber(record, "fingerprintObservedModifiedAt"),
+    fingerprintLocalFileId: requiredNullableString(record, "fingerprintLocalFileId"),
+    metadata: parseMetadata(record.metadata),
+  };
+}
+
+function parseMigration(value: unknown): CatalogV3MigrationInput {
+  const record = requiredRecord(value, "migration");
+  const settingsPath = requiredNullableString(record, "settingsPath");
+  const settingsSha256 = requiredNullableHash(record, "settingsSha256");
+  if ((settingsPath === null) !== (settingsSha256 === null)) {
+    throw new Error("Catalog worker settings path and hash must be paired.");
+  }
+  const sourceVersion = record.sourceVersion;
+  if (sourceVersion !== 1 && sourceVersion !== 2) {
+    throw new Error("Catalog worker sourceVersion is invalid.");
+  }
+  return {
+    migrationId: requiredMigrationId(record),
+    sourceVersion,
+    catalogPath: requiredAbsolutePath(record, "catalogPath"),
+    settingsPath: settingsPath === null ? null : requiredAbsolutePath({ settingsPath }, "settingsPath"),
+    catalogSha256: requiredHash(record.catalogSha256, "catalogSha256"),
+    settingsSha256,
+    rootAvailable: requiredBoolean(record, "rootAvailable"),
+    expectedCounts: parseExpectedCounts(record.expectedCounts, "expectedCounts"),
+    expectedStateSha256: requiredHash(record.expectedStateSha256, "expectedStateSha256"),
+  };
+}
+
+function parseRoot(value: unknown): CatalogV3RootInput {
+  const record = requiredRecord(value, "root");
+  const canonicalPath = requiredNullableString(record, "canonicalPath");
+  const health = requiredEnum(record.health, "health", ["online", "missing", "ambiguous", "unreadable"] as const);
+  if (health === "online" && canonicalPath === null) {
+    throw new Error("Catalog worker online root needs canonicalPath.");
+  }
+  return {
+    rootId: parseRootId(record.rootId),
+    label: requiredString(record, "label"),
+    configuredPath: requiredAbsolutePath(record, "configuredPath"),
+    canonicalPath: canonicalPath === null ? null : requiredAbsolutePath({ canonicalPath }, "canonicalPath"),
+    health,
+    scanState: requiredEnum(record.scanState, "scanState", ["unknown", "complete", "partial", "failed"] as const),
+    watchState: requiredEnum(record.watchState, "watchState", ["disabled", "active", "error"] as const),
+  };
+}
+
+function parseValidationReport(value: unknown): CatalogV3ValidationResult["report"] {
+  const record = requiredRecord(value, "validation report");
+  const relationFailuresValue = requiredRecord(record.relationFailures, "relationFailures");
+  const report = {
+    catalogId: requiredCatalogId(record),
+    migrationId: requiredMigrationId(record),
+    clean: requiredBoolean(record, "clean"),
+    before: parseExpectedCounts(record.before, "before"),
+    after: parseCounts(record.after),
+    fingerprintCoverage: parseFingerprintCoverage(record.fingerprintCoverage),
+    expectedStateSha256: requiredHash(record.expectedStateSha256, "expectedStateSha256"),
+    actualStateSha256: requiredHash(record.actualStateSha256, "actualStateSha256"),
+    relationFailures: {
+      aliases: requiredNonnegativeInteger(relationFailuresValue, "aliases"),
+      albums: requiredNonnegativeInteger(relationFailuresValue, "albums"),
+      albumAssets: requiredNonnegativeInteger(relationFailuresValue, "albumAssets"),
+      archived: requiredNonnegativeInteger(relationFailuresValue, "archived"),
+    },
+    integrity: parseIntegrity(record.integrity),
+    applicationId: requiredNonnegativeInteger(record, "applicationId"),
+    schemaVersion: requiredNonnegativeInteger(record, "schemaVersion"),
+    userVersion: requiredNonnegativeInteger(record, "userVersion"),
+    limitations: requiredStringArray(record, "limitations"),
+    blockingErrors: requiredStringArray(record, "blockingErrors"),
+  };
+  if (report.schemaVersion !== CATALOG_V3_SCHEMA_VERSION) {
+    throw new Error("Catalog worker validation schemaVersion is invalid.");
+  }
+  if (report.applicationId !== CATALOG_V3_APPLICATION_ID || report.userVersion !== CATALOG_V3_SCHEMA_VERSION) {
+    throw new Error("Catalog worker validation database identity is invalid.");
+  }
+  if (
+    report.after.assets !== report.after.present + report.after.missing + report.after.ambiguous + report.after.unreadable ||
+    report.fingerprintCoverage.total !== report.after.fingerprints
+  ) {
+    throw new Error("Catalog worker validation totals are inconsistent.");
+  }
+  if (report.clean) {
+    const countKeys: readonly (keyof CatalogV3ExpectedCounts)[] = [
+      "assets",
+      "metadata",
+      "albums",
+      "albumAssets",
+      "archived",
+      "aliases",
+      "fingerprints",
+      "present",
+      "missing",
+    ];
+    if (
+      countKeys.some((key) => report.before[key] !== report.after[key]) ||
+      report.expectedStateSha256 !== report.actualStateSha256 ||
+      report.fingerprintCoverage.missing !== report.after.assets ||
+      report.fingerprintCoverage.hashing !== 0 ||
+      report.fingerprintCoverage.valid !== 0 ||
+      report.fingerprintCoverage.stale !== 0 ||
+      report.fingerprintCoverage.failed !== 0 ||
+      Object.values(report.relationFailures).some((count) => count !== 0) ||
+      report.integrity.integrityCheck.length !== 1 ||
+      report.integrity.integrityCheck[0] !== "ok" ||
+      report.integrity.foreignKeyCheck.length !== 0 ||
+      report.blockingErrors.length !== 0
+    ) {
+      throw new Error("Catalog worker clean validation report is inconsistent.");
+    }
+  } else if (report.blockingErrors.length === 0) {
+    throw new Error("Catalog worker failed validation report needs a blocking error.");
+  }
+  return report;
+}
+
+function parseAssetMapping(value: unknown): CatalogV3AssetBatchResult["assets"][number] {
+  const record = requiredRecord(value, "asset mapping");
+  return {
+    legacyIds: requiredStringArray(record, "legacyIds"),
+    relativePath: requiredRelativePath(record.relativePath, "relativePath"),
+    assetId: parseAssetId(record.assetId),
+    fingerprintId: parseAssetId(record.fingerprintId),
+  };
+}
+
+function parseCatalogV3InstallResult(value: RecordValue): CatalogV3InstallResult {
+  const schemaVersion = requiredInteger(value, "schemaVersion");
+  if (schemaVersion !== CATALOG_V3_SCHEMA_VERSION) {
+    throw new Error("Catalog worker install schemaVersion is invalid.");
+  }
+  return {
+    catalogId: requiredCatalogId(value),
+    migrationId: requiredMigrationId(value),
+    created: requiredBoolean(value, "created"),
+    installState: requiredEnum(value.installState, "installState", ["staging", "ready"] as const),
+    revision: requiredNonnegativeInteger(value, "revision"),
+    schemaVersion,
+  };
+}
+
+function parseCatalogV3AssetBatchResult(value: RecordValue): CatalogV3AssetBatchResult {
+  const assetsValue = value.assets;
+  if (!Array.isArray(assetsValue)) throw new Error("Catalog worker asset result assets is invalid.");
+  return {
+    catalogId: requiredCatalogId(value),
+    migrationId: requiredMigrationId(value),
+    revision: requiredNonnegativeInteger(value, "revision"),
+    assets: assetsValue.map(parseAssetMapping),
+  };
+}
+
+function parseCatalogV3RelationsBatchResult(value: RecordValue): CatalogV3RelationsBatchResult {
+  return {
+    catalogId: requiredCatalogId(value),
+    migrationId: requiredMigrationId(value),
+    revision: requiredNonnegativeInteger(value, "revision"),
+    albums: requiredNonnegativeInteger(value, "albums"),
+    albumAssets: requiredNonnegativeInteger(value, "albumAssets"),
+    archived: requiredNonnegativeInteger(value, "archived"),
+  };
+}
+
+function parseCatalogV3FinishCopyResult(value: RecordValue): CatalogV3FinishCopyResult {
+  if (value.phase !== "copied") {
+    throw new Error("Catalog worker finish phase is invalid.");
+  }
+  return {
+    catalogId: requiredCatalogId(value),
+    migrationId: requiredMigrationId(value),
+    phase: "copied",
+    revision: requiredNonnegativeInteger(value, "revision"),
+  };
+}
+
+function parseCatalogV3ValidationResult(value: RecordValue): CatalogV3ValidationResult {
+  const catalogId = requiredCatalogId(value);
+  const migrationId = requiredMigrationId(value);
+  const report = parseValidationReport(value.report);
+  if (report.catalogId !== catalogId || report.migrationId !== migrationId) {
+    throw new Error("Catalog worker validation report identity does not match its result.");
+  }
+  const phase = requiredEnum(value.phase, "phase", ["created", "copying-assets", "copying-relations", "copied", "validating", "validated", "failed"] as const);
+  if ((phase === "validated") !== report.clean || (!report.clean && phase !== "failed")) {
+    throw new Error("Catalog worker validation phase does not match its report.");
+  }
+  return {
+    catalogId,
+    migrationId,
+    phase,
+    report,
+    revision: requiredNonnegativeInteger(value, "revision"),
+  };
+}
+
+function parseCatalogV3ActivationResult(value: RecordValue): CatalogV3ActivationResult {
+  if (value.installState !== "ready") {
+    throw new Error("Catalog worker activation installState is invalid.");
+  }
+  return {
+    catalogId: requiredCatalogId(value),
+    migrationId: requiredMigrationId(value),
+    installState: "ready",
+    revision: requiredNonnegativeInteger(value, "revision"),
+  };
+}
+
+function parseCatalogV3SealForInstallResult(value: RecordValue): CatalogV3SealForInstallResult {
+  const busy = requiredNonnegativeInteger(value, "busy");
+  if (busy !== 0) throw new Error("Catalog worker seal busy is invalid.");
+  return {
+    catalogId: requiredCatalogId(value),
+    migrationId: requiredMigrationId(value),
+    busy,
+    logFrames: requiredNonnegativeInteger(value, "logFrames"),
+    checkpointedFrames: requiredNonnegativeInteger(value, "checkpointedFrames"),
+    journalMode: value.journalMode === "delete" ? "delete" : (() => {
+      throw new Error("Catalog worker journalMode is invalid.");
+    })(),
+  };
+}
+
+function parseCatalogV3Summary(value: RecordValue): CatalogV3Summary {
+  const catalogId = requiredCatalogId(value);
+  const migrationId = requiredMigrationId(value);
+  const migration = parseMigration(value.migration);
+  if (migration.migrationId !== migrationId || migration.sourceVersion !== value.sourceVersion) {
+    throw new Error("Catalog worker summary migration identity does not match its result.");
+  }
+  const root = parseRoot(value.root);
+  const counts = parseCounts(value.counts);
+  const fingerprintCoverage = parseFingerprintCoverage(value.fingerprintCoverage);
+  if (
+    migration.rootAvailable !== (root.health === "online") ||
+    counts.assets !== counts.present + counts.missing + counts.ambiguous + counts.unreadable ||
+    fingerprintCoverage.total !== counts.fingerprints
+  ) {
+    throw new Error("Catalog worker summary totals are inconsistent.");
+  }
+  return {
+    catalogId,
+    displayName: requiredString(value, "displayName"),
+    appVersion: requiredString(value, "appVersion"),
+    installState: requiredEnum(value.installState, "installState", ["staging", "ready"] as const),
+    revision: requiredNonnegativeInteger(value, "revision"),
+    migrationId,
+    migrationPhase: requiredEnum(value.migrationPhase, "migrationPhase", ["created", "copying-assets", "copying-relations", "copied", "validating", "validated", "failed"] as const),
+    sourceVersion: value.sourceVersion === 1 || value.sourceVersion === 2 ? value.sourceVersion : (() => {
+      throw new Error("Catalog worker sourceVersion is invalid.");
+    })(),
+    migration,
+    root,
+    counts,
+    fingerprintCoverage,
+  };
+}
+
+function parseCatalogV3AssetPage(value: RecordValue): CatalogV3AssetPage {
+  const catalogId = requiredCatalogId(value);
+  const assetsValue = value.assets;
+  if (!Array.isArray(assetsValue)) throw new Error("Catalog worker asset page assets is invalid.");
+  const assets = assetsValue.map(parseAssetSnapshot);
+  if (assets.some((asset) => asset.catalogId !== catalogId)) {
+    throw new Error("Catalog worker asset page asset identity does not match its result.");
+  }
+  const nextCursor = value.nextCursor === null ? null : parseCatalogV3AssetCursor(value.nextCursor);
+  return {
+    catalogId,
+    revision: requiredNonnegativeInteger(value, "revision"),
+    assets,
+    nextCursor,
+  };
+}
+
+function parseCatalogV3AlbumSnapshot(value: unknown): CatalogV3AlbumSnapshot {
+  const record = requiredRecord(value, "album snapshot");
+  return {
+    catalogId: requiredCatalogId(record),
+    id: requiredString(record, "id"),
+    name: requiredString(record, "name", true),
+    createdAt: requiredNumber(record, "createdAt"),
+    updatedAt: requiredNumber(record, "updatedAt"),
+    position: requiredNonnegativeInteger(record, "position"),
+  };
+}
+
+function parseCatalogV3Albums(value: RecordValue): CatalogV3AlbumSnapshotResult {
+  const catalogId = requiredCatalogId(value);
+  const albumsValue = value.albums;
+  if (!Array.isArray(albumsValue)) throw new Error("Catalog worker album result albums is invalid.");
+  const albums = albumsValue.map(parseCatalogV3AlbumSnapshot);
+  if (albums.some((album) => album.catalogId !== catalogId)) {
+    throw new Error("Catalog worker album identity does not match its result.");
+  }
+  if (albums.some((album, index) => index > 0 && album.position !== albums[index - 1]!.position + 1)) {
+    throw new Error("Catalog worker album positions are inconsistent.");
+  }
+  const nextCursor = requiredNullableNonnegativeInteger(value, "nextCursor");
+  if (nextCursor !== null && nextCursor !== albums.at(-1)?.position) {
+    throw new Error("Catalog worker album cursor is inconsistent.");
+  }
+  return {
+    catalogId,
+    revision: requiredNonnegativeInteger(value, "revision"),
+    albums,
+    nextCursor,
+  };
+}
+
+function parseCatalogV3AlbumAssetPage(value: RecordValue): CatalogV3AlbumAssetPage {
+  const catalogId = requiredCatalogId(value);
+  const albumId = requiredString(value, "albumId");
+  const assetsValue = value.assets;
+  if (!Array.isArray(assetsValue)) throw new Error("Catalog worker album asset page assets is invalid.");
+  const assets: CatalogV3AlbumAssetSnapshot[] = assetsValue.map((item) => {
+    const member = requiredRecord(item, "album member");
+    return {
+      position: requiredNonnegativeInteger(member, "position"),
+      assetId: parseAssetId(member.assetId),
+      rootId: parseRootId(member.rootId),
+      relativePath: requiredRelativePath(member.relativePath, "relativePath"),
+      health: requiredEnum(member.health, "health", ["present", "missing", "ambiguous", "unreadable"] as const),
+      revision: requiredNonnegativeInteger(member, "revision"),
+    };
+  });
+  if (assets.some((asset, index) => index > 0 && asset.position !== assets[index - 1]!.position + 1)) {
+    throw new Error("Catalog worker album asset positions are inconsistent.");
+  }
+  const nextCursor = requiredNullableNonnegativeInteger(value, "nextCursor");
+  if (nextCursor !== null && nextCursor !== assets.at(-1)?.position) {
+    throw new Error("Catalog worker album asset cursor is inconsistent.");
+  }
+  return {
+    catalogId,
+    albumId,
+    revision: requiredNonnegativeInteger(value, "revision"),
+    assets,
+    nextCursor,
+  };
 }
 
 function parseForeignKeyViolation(value: unknown): CatalogForeignKeyViolation {
@@ -302,6 +1119,48 @@ function parseRequestRecord(record: RecordValue): CatalogWorkerRequest {
       return { kind, requestId };
     case "shutdown":
       return { kind, requestId };
+    case "v3-install":
+      return { kind, requestId, input: parseCatalogV3InstallInput(record.input) };
+    case "v3-assets":
+      return { kind, requestId, input: parseCatalogV3AssetBatchInput(record.input) };
+    case "v3-relations":
+      return { kind, requestId, input: parseCatalogV3RelationsBatchInput(record.input) };
+    case "v3-finish-copy":
+      return {
+        kind,
+        requestId,
+        catalogId: requiredCatalogId(record),
+        migrationId: requiredMigrationId(record),
+      };
+    case "v3-validate":
+      return {
+        kind,
+        requestId,
+        catalogId: requiredCatalogId(record),
+        migrationId: requiredMigrationId(record),
+      };
+    case "v3-prepare-activation":
+      return {
+        kind,
+        requestId,
+        catalogId: requiredCatalogId(record),
+        migrationId: requiredMigrationId(record),
+      };
+    case "v3-seal-for-install":
+      return {
+        kind,
+        requestId,
+        catalogId: requiredCatalogId(record),
+        migrationId: requiredMigrationId(record),
+      };
+    case "v3-summary":
+      return { kind, requestId, catalogId: requiredCatalogId(record) };
+    case "v3-assets-page":
+      return { kind, requestId, input: parseCatalogV3AssetPageInput(record.input) };
+    case "v3-albums":
+      return { kind, requestId, input: parseCatalogV3AlbumPageInput(record.input) };
+    case "v3-album-assets-page":
+      return { kind, requestId, input: parseCatalogV3AlbumAssetPageInput(record.input) };
     case "test-tracer-run":
       return {
         kind,
@@ -410,6 +1269,39 @@ function parseResponseRecord(record: RecordValue): CatalogWorkerResponse {
     case "shutdown":
       if (requestId === null) throw new Error("Shutdown response needs a requestId.");
       return { kind, requestId, wasOpen: requiredBoolean(record, "wasOpen") };
+    case "v3-install":
+      if (requestId === null) throw new Error("Catalog v3 install response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3InstallResult(requiredV3Result(record)) };
+    case "v3-assets":
+      if (requestId === null) throw new Error("Catalog v3 asset response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3AssetBatchResult(requiredV3Result(record)) };
+    case "v3-relations":
+      if (requestId === null) throw new Error("Catalog v3 relation response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3RelationsBatchResult(requiredV3Result(record)) };
+    case "v3-finish-copy":
+      if (requestId === null) throw new Error("Catalog v3 finish response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3FinishCopyResult(requiredV3Result(record)) };
+    case "v3-validate":
+      if (requestId === null) throw new Error("Catalog v3 validate response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3ValidationResult(requiredV3Result(record)) };
+    case "v3-prepare-activation":
+      if (requestId === null) throw new Error("Catalog v3 activation response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3ActivationResult(requiredV3Result(record)) };
+    case "v3-seal-for-install":
+      if (requestId === null) throw new Error("Catalog v3 seal response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3SealForInstallResult(requiredV3Result(record)) };
+    case "v3-summary":
+      if (requestId === null) throw new Error("Catalog v3 summary response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3Summary(requiredV3Result(record)) };
+    case "v3-assets-page":
+      if (requestId === null) throw new Error("Catalog v3 asset page response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3AssetPage(requiredV3Result(record)) };
+    case "v3-albums":
+      if (requestId === null) throw new Error("Catalog v3 album response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3Albums(requiredV3Result(record)) };
+    case "v3-album-assets-page":
+      if (requestId === null) throw new Error("Catalog v3 album asset response needs a requestId.");
+      return { kind, requestId, result: parseCatalogV3AlbumAssetPage(requiredV3Result(record)) };
     case "test-tracer-run":
     case "test-tracer-recover":
     case "test-tracer-inspect":

--- a/electron/catalog-worker.ts
+++ b/electron/catalog-worker.ts
@@ -29,6 +29,7 @@ import {
   type CatalogWorkerTestTracerRecoverRequest,
   type CatalogWorkerTestTracerRunRequest,
 } from "./catalog-worker-protocol.ts";
+import { CatalogV3Repository } from "./catalog-v3-repository.ts";
 
 function requiredWorkerPort(): NonNullable<typeof parentPort> {
   if (!parentPort) {
@@ -89,6 +90,10 @@ function requireDatabase(): DatabaseSync {
     throw new Error("Catalog database is not open.");
   }
   return database;
+}
+
+function catalogV3Repository(): CatalogV3Repository {
+  return new CatalogV3Repository(requireDatabase());
 }
 
 function rowValue(row: Record<string, unknown>, key: string): unknown {
@@ -585,6 +590,83 @@ async function handleRequest(request: CatalogWorkerRequest): Promise<void> {
       workerPort.close();
       return;
     }
+    case "v3-install":
+      post({
+        kind: "v3-install",
+        requestId: request.requestId,
+        result: catalogV3Repository().install(request.input),
+      });
+      return;
+    case "v3-assets":
+      post({
+        kind: "v3-assets",
+        requestId: request.requestId,
+        result: catalogV3Repository().writeAssetBatch(request.input),
+      });
+      return;
+    case "v3-relations":
+      post({
+        kind: "v3-relations",
+        requestId: request.requestId,
+        result: catalogV3Repository().writeRelationsBatch(request.input),
+      });
+      return;
+    case "v3-finish-copy":
+      post({
+        kind: "v3-finish-copy",
+        requestId: request.requestId,
+        result: catalogV3Repository().finishCopy(request.catalogId, request.migrationId),
+      });
+      return;
+    case "v3-validate":
+      post({
+        kind: "v3-validate",
+        requestId: request.requestId,
+        result: catalogV3Repository().validate(request.catalogId, request.migrationId),
+      });
+      return;
+    case "v3-prepare-activation":
+      post({
+        kind: "v3-prepare-activation",
+        requestId: request.requestId,
+        result: catalogV3Repository().prepareActivation(request.catalogId, request.migrationId),
+      });
+      return;
+    case "v3-seal-for-install":
+      post({
+        kind: "v3-seal-for-install",
+        requestId: request.requestId,
+        result: catalogV3Repository().sealForInstall(request.catalogId, request.migrationId),
+      });
+      return;
+    case "v3-summary":
+      post({
+        kind: "v3-summary",
+        requestId: request.requestId,
+        result: catalogV3Repository().summary(request.catalogId),
+      });
+      return;
+    case "v3-assets-page":
+      post({
+        kind: "v3-assets-page",
+        requestId: request.requestId,
+        result: catalogV3Repository().assetPage(request.input),
+      });
+      return;
+    case "v3-albums":
+      post({
+        kind: "v3-albums",
+        requestId: request.requestId,
+        result: catalogV3Repository().albumSnapshots(request.input),
+      });
+      return;
+    case "v3-album-assets-page":
+      post({
+        kind: "v3-album-assets-page",
+        requestId: request.requestId,
+        result: catalogV3Repository().albumAssetPage(request.input),
+      });
+      return;
     case "test-tracer-run": {
       const result = await runTestTracer(request);
       post({ kind: "test-tracer-run", requestId: request.requestId, ...result });

--- a/lib/cache/asset-cache-key.ts
+++ b/lib/cache/asset-cache-key.ts
@@ -1,0 +1,32 @@
+import type { AssetId, CatalogId } from "../catalog/ids.ts";
+
+export interface AssetCacheIdentity {
+  catalogId: CatalogId;
+  assetId: AssetId;
+  revision: number;
+}
+
+function requireKeyPart(value: string, name: string): void {
+  if (value.length === 0) {
+    throw new Error(`${name} must not be empty.`);
+  }
+  if (value.includes(":")) {
+    throw new Error(`${name} must not contain ':'.`);
+  }
+  if (value.includes("\0")) {
+    throw new Error(`${name} must not contain NUL.`);
+  }
+}
+
+export function assetCacheKey(
+  identity: AssetCacheIdentity,
+  variant: string,
+): string {
+  requireKeyPart(identity.catalogId, "catalogId");
+  requireKeyPart(identity.assetId, "assetId");
+  if (!Number.isInteger(identity.revision) || identity.revision < 0) {
+    throw new Error("revision must be a nonnegative integer.");
+  }
+  requireKeyPart(variant, "variant");
+  return `${identity.catalogId}:${identity.assetId}:${identity.revision}:${variant}`;
+}

--- a/lib/catalog/legacy-migration.ts
+++ b/lib/catalog/legacy-migration.ts
@@ -1,0 +1,661 @@
+import type {
+  ExportConflictBehavior,
+  ExportFormatId,
+  ExportSizeOptions,
+} from "../export/types.ts";
+import type {
+  Album,
+  EntryMetadata,
+  PhotoCatalog,
+} from "./types.ts";
+
+export interface MigrationRawSource {
+  path: string;
+  bytes: Uint8Array;
+  text: string;
+  sha256: string;
+}
+
+export interface MigrationSourceDescriptor {
+  catalog: MigrationRawSource;
+  settings?: MigrationRawSource;
+}
+
+export interface StrictMigrationSettings {
+  lastFolderPath?: string | null;
+  exportOptions?: {
+    format: ExportFormatId;
+    quality: number;
+    lossless: boolean;
+    size: ExportSizeOptions;
+    suffix: string;
+    conflict: ExportConflictBehavior;
+  };
+}
+
+export interface OnlineScanObservation {
+  relativePath: string;
+  byteLength: number;
+  modifiedAt: number;
+  observedAt: number;
+  localFileId: string | null;
+  formatId: string;
+}
+
+export interface CompleteOnlineScan {
+  complete: boolean;
+  xmpComplete: boolean;
+  observations: readonly OnlineScanObservation[];
+  error?: string | null;
+}
+
+export type XmpEvidenceState = "unknown" | "absent" | "preserved" | "malformed";
+
+export interface XmpEvidence {
+  state: XmpEvidenceState;
+  contents?: string;
+  modifiedAt?: number;
+  sha256?: string;
+}
+
+export interface LegacyCandidateSourceFlags {
+  entries: boolean;
+  albums: boolean;
+  archive: boolean;
+  scan: boolean;
+}
+
+export interface LegacyAssetObservation {
+  byteLength: number;
+  modifiedAt: number;
+  observedAt: number;
+  localFileId: string | null;
+  formatId: string;
+}
+
+export interface LegacyAssetCandidate {
+  relativePath: string;
+  legacyIdAlias: string;
+  sourceFlags: LegacyCandidateSourceFlags;
+  metadata?: EntryMetadata;
+  observation: LegacyAssetObservation | null;
+  health: "present" | "missing";
+  xmp: XmpEvidence;
+}
+
+export interface LegacyAlbumRelation {
+  id: string;
+  name: string;
+  entryIds: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface MigrationCounts {
+  metadataEntries: number;
+  albums: number;
+  albumMemberships: number;
+  archiveReferences: number;
+  distinctReferencedIds: number;
+  scannedAssetCount: number | null;
+  expectedTotalAssets: number;
+  expectedPresentAssets: number;
+  expectedMissingAssets: number;
+  expectedAliases: number;
+  offlineInventoryLimited: boolean;
+}
+
+export interface LegacyMigrationPlan {
+  rawCatalogVersion: 1 | 2;
+  source: MigrationSourceDescriptor;
+  catalog: PhotoCatalog;
+  settings: StrictMigrationSettings | null;
+  scan: "offline" | "online";
+  candidates: LegacyAssetCandidate[];
+  albums: LegacyAlbumRelation[];
+  archivedEntryIds: string[];
+  counts: MigrationCounts;
+}
+
+export type LegacyCatalogParser = (value: unknown) => PhotoCatalog;
+
+export interface LegacyMigrationInput {
+  catalog: unknown;
+  source: MigrationSourceDescriptor;
+  parseCatalog: LegacyCatalogParser;
+  settings?: unknown;
+  onlineScan?: CompleteOnlineScan;
+  xmpByRelativePath?: Readonly<Record<string, XmpEvidence>>;
+}
+
+const MAX_EXPORT_EDGE = 100_000;
+const MAX_SUFFIX_LENGTH = 200;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function requireSha256(value: string, path: string): string {
+  if (!SHA256_PATTERN.test(value)) {
+    fail(`${path} must be a lowercase SHA-256 digest.`);
+  }
+  return value;
+}
+
+function validateSourceDescriptor(source: MigrationSourceDescriptor): void {
+  if (!source || !source.catalog) {
+    fail("source.catalog is required.");
+  }
+  const sources: Array<[string, MigrationRawSource | undefined]> = [
+    ["source.catalog", source.catalog],
+    ["source.settings", source.settings],
+  ];
+  for (const [sourcePath, item] of sources) {
+    if (item === undefined) continue;
+    if (typeof item !== "object" || item === null) {
+      fail(`${sourcePath} must be an object.`);
+    }
+    if (typeof item.path !== "string") {
+      fail(`${sourcePath}.path must be a string.`);
+    }
+    validateAbsoluteRootPath(item.path);
+    if (!(item.bytes instanceof Uint8Array)) {
+      fail(`${sourcePath}.bytes must be a byte array.`);
+    }
+    if (typeof item.text !== "string") {
+      fail(`${sourcePath}.text must be a string.`);
+    }
+    if (typeof item.sha256 !== "string") {
+      fail(`${sourcePath}.sha256 must be a string.`);
+    }
+    requireSha256(item.sha256, `${sourcePath}.sha256`);
+  }
+}
+
+function validateAbsoluteRootPath(rootPath: string): string {
+  if (typeof rootPath !== "string" || rootPath.length === 0 || rootPath.includes("\0")) {
+    fail("Catalog rootPath must be an absolute, normalized path without NUL.");
+  }
+
+  if (rootPath.startsWith("/")) {
+    if (rootPath !== "/" && rootPath.endsWith("/")) {
+      fail("Catalog rootPath must be normalized.");
+    }
+    if (rootPath.startsWith("//")) {
+      fail("Catalog rootPath must not use an ambiguous UNC-style prefix.");
+    }
+    const segments = rootPath.slice(1).split("/");
+    if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+      fail("Catalog rootPath contains a noncanonical segment.");
+    }
+    return rootPath;
+  }
+
+  const driveMatch = /^([A-Za-z]):([\\/])/.exec(rootPath);
+  if (!driveMatch) {
+    fail("Catalog rootPath must be absolute.");
+  }
+  const separator = driveMatch[2];
+  if (rootPath.length === 3) {
+    return rootPath;
+  }
+  if (rootPath.includes(separator === "/" ? "\\" : "/")) {
+    fail("Catalog rootPath must use one normalized separator style.");
+  }
+  if (rootPath.length > 3 && rootPath.endsWith(separator)) {
+    fail("Catalog rootPath must be normalized.");
+  }
+  const segments = rootPath.slice(3).split(separator);
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    fail("Catalog rootPath contains a noncanonical segment.");
+  }
+  return rootPath;
+}
+
+export function canonicalRelativePath(value: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\0")) {
+    fail("Relative path must be nonempty and NUL-free.");
+  }
+  if (value.includes("\\") || value.startsWith("/") || value.startsWith("//")) {
+    fail(`Relative path "${value}" is not a safe POSIX path.`);
+  }
+  if (/^[A-Za-z]:/.test(value)) {
+    fail(`Relative path "${value}" must not use a Windows drive prefix.`);
+  }
+  const segments = value.split("/");
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    fail(`Relative path "${value}" contains a noncanonical segment.`);
+  }
+  return segments.join("/");
+}
+
+export function decodeLegacyId(legacyId: string): { legacyId: string; relativePath: string } {
+  if (typeof legacyId !== "string" || legacyId.length === 0 || legacyId.includes("\0")) {
+    fail("Legacy ID must be nonempty and NUL-free.");
+  }
+  let relativePath: string;
+  try {
+    relativePath = decodeURIComponent(legacyId);
+  } catch {
+    fail(`Legacy ID "${legacyId}" contains malformed percent escapes.`);
+  }
+  if (encodeURIComponent(relativePath) !== legacyId) {
+    fail(`Legacy ID "${legacyId}" is not canonically encoded.`);
+  }
+  return { legacyId, relativePath: canonicalRelativePath(relativePath) };
+}
+
+function requireKnownKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  path: string,
+): void {
+  const allowedSet = new Set(allowed);
+  for (const key of Object.keys(value)) {
+    if (!allowedSet.has(key)) {
+      fail(`${path}.${key} is not supported.`);
+    }
+  }
+}
+
+function positiveInteger(value: unknown, maximum: number): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= maximum;
+}
+
+function parseStrictSize(value: unknown): ExportSizeOptions {
+  if (!isRecord(value) || typeof value.mode !== "string") {
+    fail("settings.exportOptions.size must be an object with a mode.");
+  }
+  if (value.mode === "original") {
+    requireKnownKeys(value, ["mode"], "settings.exportOptions.size");
+    return { mode: "original" };
+  }
+  if (value.mode === "long-edge" || value.mode === "longEdge") {
+    requireKnownKeys(value, ["mode", "pixels", "longEdge", "neverUpscale"], "settings.exportOptions.size");
+    const hasPixels = hasOwn(value, "pixels");
+    const hasLongEdge = hasOwn(value, "longEdge");
+    if (hasPixels === hasLongEdge) {
+      fail("settings.exportOptions.size must contain exactly one edge field.");
+    }
+    const edge = hasPixels ? value.pixels : value.longEdge;
+    if (!positiveInteger(edge, MAX_EXPORT_EDGE)) {
+      fail("settings.exportOptions.size edge must be a positive integer.");
+    }
+    if (hasOwn(value, "neverUpscale") && typeof value.neverUpscale !== "boolean") {
+      fail("settings.exportOptions.size.neverUpscale must be a boolean.");
+    }
+    const neverUpscale = typeof value.neverUpscale === "boolean"
+      ? value.neverUpscale
+      : undefined;
+    return value.mode === "long-edge"
+      ? { mode: "long-edge", pixels: edge, ...(neverUpscale === undefined ? {} : { neverUpscale }) }
+      : { mode: "longEdge", longEdge: edge, ...(neverUpscale === undefined ? {} : { neverUpscale }) };
+  }
+  if (value.mode === "fit") {
+    requireKnownKeys(value, ["mode", "width", "height", "neverUpscale"], "settings.exportOptions.size");
+    if (!positiveInteger(value.width, MAX_EXPORT_EDGE) || !positiveInteger(value.height, MAX_EXPORT_EDGE)) {
+      fail("settings.exportOptions.size width and height must be positive integers.");
+    }
+    if (hasOwn(value, "neverUpscale") && typeof value.neverUpscale !== "boolean") {
+      fail("settings.exportOptions.size.neverUpscale must be a boolean.");
+    }
+    const neverUpscale = typeof value.neverUpscale === "boolean"
+      ? value.neverUpscale
+      : undefined;
+    return {
+      mode: "fit",
+      width: value.width,
+      height: value.height,
+      ...(neverUpscale === undefined ? {} : { neverUpscale }),
+    };
+  }
+  fail(`settings.exportOptions.size.mode "${value.mode}" is unsupported.`);
+}
+
+function parseStrictExportOptions(value: unknown): NonNullable<StrictMigrationSettings["exportOptions"]> {
+  if (!isRecord(value)) {
+    fail("settings.exportOptions must be an object.");
+  }
+  requireKnownKeys(value, ["format", "quality", "lossless", "size", "suffix", "conflict"], "settings.exportOptions");
+  const format = value.format;
+  const isFormat = format === "jpeg" || format === "png" || format === "webp" || format === "avif" || format === "tiff";
+  if (!isFormat) {
+    fail("settings.exportOptions.format is unsupported.");
+  }
+  if (!positiveInteger(value.quality, 100)) {
+    fail("settings.exportOptions.quality must be an integer from 1 to 100.");
+  }
+  if (typeof value.lossless !== "boolean") {
+    fail("settings.exportOptions.lossless must be a boolean.");
+  }
+  if (typeof value.suffix !== "string" || value.suffix.length > MAX_SUFFIX_LENGTH || value.suffix.includes("\0") || value.suffix.includes("/") || value.suffix.includes("\\") || value.suffix.includes("..")) {
+    fail("settings.exportOptions.suffix is invalid.");
+  }
+  const conflict = value.conflict;
+  const isConflict = conflict === "rename" || conflict === "skip" || conflict === "replace";
+  if (!isConflict) {
+    fail("settings.exportOptions.conflict is unsupported.");
+  }
+  return {
+    format,
+    quality: value.quality,
+    lossless: value.lossless,
+    size: parseStrictSize(value.size),
+    suffix: value.suffix,
+    conflict,
+  };
+}
+
+export function parseStrictMigrationSettings(value: unknown): StrictMigrationSettings {
+  if (!isRecord(value)) {
+    fail("Settings must be a plain object.");
+  }
+  requireKnownKeys(value, ["lastFolderPath", "exportOptions"], "settings");
+  const result: StrictMigrationSettings = {};
+  if (hasOwn(value, "lastFolderPath")) {
+    if (value.lastFolderPath !== null && typeof value.lastFolderPath !== "string") {
+      fail("settings.lastFolderPath must be a string or null.");
+    }
+    result.lastFolderPath = value.lastFolderPath;
+  }
+  if (hasOwn(value, "exportOptions")) {
+    result.exportOptions = parseStrictExportOptions(value.exportOptions);
+  }
+  return result;
+}
+
+function rawCatalogVersion(value: unknown): 1 | 2 {
+  if (!isRecord(value) || (value.version !== 1 && value.version !== 2)) {
+    fail("Legacy catalog must declare version 1 or 2.");
+  }
+  return value.version;
+}
+
+function copyFlags(flags: LegacyCandidateSourceFlags): LegacyCandidateSourceFlags {
+  return { ...flags };
+}
+
+interface CandidateBuilder {
+  relativePath: string;
+  legacyIdAlias: string;
+  sourceFlags: LegacyCandidateSourceFlags;
+  metadata?: EntryMetadata;
+  observation: LegacyAssetObservation | null;
+  health: "present" | "missing";
+}
+
+function createCandidate(relativePath: string): CandidateBuilder {
+  return {
+    relativePath,
+    legacyIdAlias: encodeURIComponent(relativePath),
+    sourceFlags: { entries: false, albums: false, archive: false, scan: false },
+    observation: null,
+    health: "missing",
+  };
+}
+
+function setLegacyAlias(candidate: CandidateBuilder, legacyId: string): void {
+  if (candidate.legacyIdAlias !== encodeURIComponent(candidate.relativePath) && candidate.legacyIdAlias !== legacyId) {
+    fail(`Relative path "${candidate.relativePath}" has conflicting legacy IDs.`);
+  }
+  candidate.legacyIdAlias = legacyId;
+}
+
+function addReferencedCandidate(
+  candidates: Map<string, CandidateBuilder>,
+  legacyId: string,
+  flag: keyof LegacyCandidateSourceFlags,
+  metadata?: EntryMetadata,
+): void {
+  const decoded = decodeLegacyId(legacyId);
+  const candidate = candidates.get(decoded.relativePath) ?? createCandidate(decoded.relativePath);
+  setLegacyAlias(candidate, decoded.legacyId);
+  candidate.sourceFlags[flag] = true;
+  if (metadata !== undefined) {
+    candidate.metadata = metadata;
+  }
+  candidates.set(decoded.relativePath, candidate);
+}
+
+function parseXmpEvidence(value: unknown, path: string): XmpEvidence {
+  if (!isRecord(value)) {
+    fail(`${path} must be an object.`);
+  }
+  const state = value.state;
+  if (state !== "unknown" && state !== "absent" && state !== "preserved" && state !== "malformed") {
+    fail(`${path}.state is invalid.`);
+  }
+  if (hasOwn(value, "modifiedAt") && (typeof value.modifiedAt !== "number" || !Number.isFinite(value.modifiedAt))) {
+    fail(`${path}.modifiedAt must be finite.`);
+  }
+  if (hasOwn(value, "sha256")) {
+    if (typeof value.sha256 !== "string") fail(`${path}.sha256 must be a string.`);
+    requireSha256(value.sha256, `${path}.sha256`);
+  }
+  if (hasOwn(value, "contents") && typeof value.contents !== "string") {
+    fail(`${path}.contents must be a string.`);
+  }
+  if (state === "preserved" && (!hasOwn(value, "contents") || !hasOwn(value, "modifiedAt") || !hasOwn(value, "sha256"))) {
+    fail(`${path} preserved evidence must include contents, modifiedAt, and sha256.`);
+  }
+  return {
+    state,
+    ...(typeof value.contents === "string" ? { contents: value.contents } : {}),
+    ...(typeof value.modifiedAt === "number" ? { modifiedAt: value.modifiedAt } : {}),
+    ...(typeof value.sha256 === "string" ? { sha256: value.sha256 } : {}),
+  };
+}
+
+function validateObservation(observation: OnlineScanObservation, path: string): LegacyAssetObservation {
+  if (typeof observation.relativePath !== "string") {
+    fail(`${path}.relativePath must be a string.`);
+  }
+  canonicalRelativePath(observation.relativePath);
+  if (!Number.isInteger(observation.byteLength) || observation.byteLength < 0) {
+    fail(`${path}.byteLength must be a nonnegative integer.`);
+  }
+  if (!Number.isFinite(observation.modifiedAt) || !Number.isFinite(observation.observedAt)) {
+    fail(`${path} timestamps must be finite.`);
+  }
+  if (observation.localFileId !== null && (typeof observation.localFileId !== "string" || observation.localFileId.includes("\0"))) {
+    fail(`${path}.localFileId must be a NUL-free string or null.`);
+  }
+  if (typeof observation.formatId !== "string" || observation.formatId.length === 0 || observation.formatId.includes("\0")) {
+    fail(`${path}.formatId must be a nonempty NUL-free string.`);
+  }
+  return {
+    byteLength: observation.byteLength,
+    modifiedAt: observation.modifiedAt,
+    observedAt: observation.observedAt,
+    localFileId: observation.localFileId,
+    formatId: observation.formatId,
+  };
+}
+
+function relationFromAlbum(album: Album): LegacyAlbumRelation {
+  return {
+    id: album.id,
+    name: album.name,
+    entryIds: [...album.entryIds],
+    createdAt: album.createdAt,
+    updatedAt: album.updatedAt,
+  };
+}
+
+function defaultXmp(online: boolean): XmpEvidence {
+  return online ? { state: "absent" } : { state: "unknown" };
+}
+
+export function prepareLegacyMigration(input: LegacyMigrationInput): LegacyMigrationPlan {
+  if (typeof input.parseCatalog !== "function") {
+    fail("parseCatalog must be a function.");
+  }
+  if (input.onlineScan === null) {
+    fail("onlineScan must be omitted or a complete scan descriptor.");
+  }
+  validateSourceDescriptor(input.source);
+  const version = rawCatalogVersion(input.catalog);
+  const catalog = input.parseCatalog(input.catalog);
+  if (catalog.version !== 2) {
+    fail("Strict catalog parser must return normalized version 2 data.");
+  }
+  validateAbsoluteRootPath(catalog.rootPath);
+
+  let settings: StrictMigrationSettings | null = null;
+  if (input.settings !== undefined) {
+    settings = parseStrictMigrationSettings(input.settings);
+  } else if (input.source.settings) {
+    let parsedSettings: unknown;
+    try {
+      parsedSettings = JSON.parse(input.source.settings.text);
+    } catch {
+    fail("Raw settings source is not valid JSON.");
+    }
+    settings = parseStrictMigrationSettings(parsedSettings);
+  }
+
+  const candidates = new Map<string, CandidateBuilder>();
+  for (const [legacyId, metadata] of Object.entries(catalog.entries)) {
+    addReferencedCandidate(candidates, legacyId, "entries", metadata);
+  }
+
+  const albums: LegacyAlbumRelation[] = [];
+  const albumIds = new Set<string>();
+  let albumMemberships = 0;
+  for (const [index, album] of catalog.albums.entries()) {
+    if (albumIds.has(album.id)) {
+      fail(`albums[${index}].id is duplicated.`);
+    }
+    albumIds.add(album.id);
+    const membershipIds = new Set<string>();
+    for (const [membershipIndex, legacyId] of album.entryIds.entries()) {
+      const decoded = decodeLegacyId(legacyId);
+      if (membershipIds.has(decoded.relativePath)) {
+        fail(`albums[${index}].entryIds[${membershipIndex}] duplicates a membership.`);
+      }
+      membershipIds.add(decoded.relativePath);
+      addReferencedCandidate(candidates, legacyId, "albums");
+      albumMemberships += 1;
+    }
+    albums.push(relationFromAlbum(album));
+  }
+
+  const archivedEntryIds = [...catalog.archivedEntryIds];
+  const archiveIds = new Set<string>();
+  for (const [index, legacyId] of archivedEntryIds.entries()) {
+    const decoded = decodeLegacyId(legacyId);
+    if (archiveIds.has(decoded.relativePath)) {
+      fail(`archivedEntryIds[${index}] duplicates an archive reference.`);
+    }
+    archiveIds.add(decoded.relativePath);
+    addReferencedCandidate(candidates, legacyId, "archive");
+  }
+
+  const online = input.onlineScan !== undefined;
+  if (input.onlineScan) {
+    if (input.onlineScan.complete !== true ||
+      (input.onlineScan.error !== undefined && input.onlineScan.error !== null)) {
+      fail("Online scan must be explicitly complete and error-free.");
+    }
+    if (typeof input.onlineScan.xmpComplete !== "boolean") {
+      fail("Online scan must declare whether XMP coverage is complete.");
+    }
+    if (!Array.isArray(input.onlineScan.observations)) {
+      fail("Online scan observations must be an array.");
+    }
+  }
+  const scanPaths = new Set<string>();
+  if (input.onlineScan) {
+    for (const [index, observation] of input.onlineScan.observations.entries()) {
+      const validated = validateObservation(observation, `onlineScan.observations[${index}]`);
+      const relativePath = canonicalRelativePath(observation.relativePath);
+      if (scanPaths.has(relativePath)) {
+        fail(`onlineScan.observations[${index}] duplicates a scan path.`);
+      }
+      scanPaths.add(relativePath);
+      const candidate = candidates.get(relativePath) ?? createCandidate(relativePath);
+      candidate.sourceFlags.scan = true;
+      candidate.observation = validated;
+      candidate.health = "present";
+      candidates.set(relativePath, candidate);
+    }
+  }
+
+  const xmpEvidence = new Map<string, XmpEvidence>();
+  for (const [relativePath, evidence] of Object.entries(input.xmpByRelativePath ?? {})) {
+    const canonicalPath = canonicalRelativePath(relativePath);
+    if (xmpEvidence.has(canonicalPath)) {
+      fail(`XMP evidence duplicates "${canonicalPath}".`);
+    }
+    xmpEvidence.set(canonicalPath, parseXmpEvidence(evidence, `xmpByRelativePath.${relativePath}`));
+  }
+
+  const orderedCandidates = [...candidates.values()]
+    .sort((left, right) => left.relativePath < right.relativePath ? -1 : left.relativePath > right.relativePath ? 1 : 0)
+    .map((candidate) => {
+      const evidence = xmpEvidence.get(candidate.relativePath) ?? defaultXmp(input.onlineScan?.xmpComplete === true);
+      if (online && !candidate.observation) {
+        candidate.health = "missing";
+      }
+      return {
+        relativePath: candidate.relativePath,
+        legacyIdAlias: candidate.legacyIdAlias,
+        sourceFlags: copyFlags(candidate.sourceFlags),
+        ...(candidate.metadata === undefined ? {} : { metadata: candidate.metadata }),
+        observation: candidate.observation,
+        health: candidate.health,
+        xmp: evidence,
+      } satisfies LegacyAssetCandidate;
+    });
+
+  for (const relativePath of xmpEvidence.keys()) {
+    if (!candidates.has(relativePath)) {
+      fail(`XMP evidence references unknown path "${relativePath}".`);
+    }
+  }
+
+  const presentCount = online
+    ? orderedCandidates.filter((candidate) => candidate.observation !== null).length
+    : 0;
+  const missingCount = online
+    ? orderedCandidates.filter((candidate) => candidate.observation === null).length
+    : orderedCandidates.length;
+  const counts: MigrationCounts = {
+    metadataEntries: Object.keys(catalog.entries).length,
+    albums: catalog.albums.length,
+    albumMemberships,
+    archiveReferences: archivedEntryIds.length,
+    distinctReferencedIds: orderedCandidates.filter((candidate) => candidate.sourceFlags.entries || candidate.sourceFlags.albums || candidate.sourceFlags.archive).length,
+    scannedAssetCount: input.onlineScan?.observations.length ?? null,
+    expectedTotalAssets: orderedCandidates.length,
+    expectedPresentAssets: presentCount,
+    expectedMissingAssets: missingCount,
+    expectedAliases: orderedCandidates.length,
+    offlineInventoryLimited: !online,
+  };
+
+  return {
+    rawCatalogVersion: version,
+    source: input.source,
+    catalog,
+    settings,
+    scan: online ? "online" : "offline",
+    candidates: orderedCandidates,
+    albums,
+    archivedEntryIds,
+    counts,
+  };
+}

--- a/lib/catalog/v3.ts
+++ b/lib/catalog/v3.ts
@@ -1,0 +1,835 @@
+import {
+  parseAssetId,
+  parseCatalogId,
+  parseRootId,
+  type AssetId,
+  type CatalogId,
+  type RootId,
+} from "./ids.ts";
+import type { ColorLabel, PickStatus, StarRating } from "./types.ts";
+
+export const CATALOG_V3_SCHEMA_VERSION = 3;
+export const CATALOG_V3_APPLICATION_ID = 1_146_243_891;
+export const CATALOG_V3_MAX_ASSET_BATCH = 250;
+export const CATALOG_V3_MAX_RELATION_BATCH = 250;
+export const CATALOG_V3_MAX_PAGE_SIZE = 250;
+export const CATALOG_V3_MAX_XMP_BYTES = 16 * 1024 * 1024;
+
+export type CatalogV3InstallState = "staging" | "ready";
+export type CatalogV3MigrationPhase =
+  | "created"
+  | "copying-assets"
+  | "copying-relations"
+  | "copied"
+  | "validating"
+  | "validated"
+  | "failed";
+export type CatalogV3AssetHealth = "present" | "missing" | "ambiguous" | "unreadable";
+export type CatalogV3RootHealth = "online" | "missing" | "ambiguous" | "unreadable";
+export type CatalogV3ScanState = "unknown" | "complete" | "partial" | "failed";
+export type CatalogV3WatchState = "disabled" | "active" | "error";
+export type CatalogV3FingerprintStatus =
+  | "missing"
+  | "hashing"
+  | "valid"
+  | "stale"
+  | "failed";
+export type CatalogV3XmpState = "unknown" | "absent" | "preserved" | "malformed";
+
+export interface CatalogV3ExpectedCounts {
+  readonly assets: number;
+  readonly metadata: number;
+  readonly albums: number;
+  readonly albumAssets: number;
+  readonly archived: number;
+  readonly aliases: number;
+  readonly fingerprints: number;
+  readonly present: number;
+  readonly missing: number;
+}
+
+export interface CatalogV3RootInput {
+  readonly rootId: RootId;
+  readonly label: string;
+  readonly configuredPath: string;
+  readonly canonicalPath: string | null;
+  readonly health: CatalogV3RootHealth;
+  readonly scanState: CatalogV3ScanState;
+  readonly watchState: CatalogV3WatchState;
+}
+
+export interface CatalogV3MigrationInput {
+  readonly migrationId: string;
+  readonly sourceVersion: 1 | 2;
+  readonly catalogPath: string;
+  readonly settingsPath: string | null;
+  readonly catalogSha256: string;
+  readonly settingsSha256: string | null;
+  readonly rootAvailable: boolean;
+  readonly expectedCounts: CatalogV3ExpectedCounts;
+  readonly expectedStateSha256: string;
+}
+
+export interface CatalogV3InstallInput {
+  readonly catalogId: CatalogId;
+  readonly displayName: string;
+  readonly appVersion: string;
+  readonly root: CatalogV3RootInput;
+  readonly migration: CatalogV3MigrationInput;
+  readonly now?: number;
+}
+
+export interface CatalogV3Observation {
+  readonly byteLength: number | null;
+  readonly modifiedAt: number | null;
+  readonly observedAt: number;
+  readonly localFileId: string | null;
+}
+
+export interface CatalogV3FingerprintInput {
+  readonly status: CatalogV3FingerprintStatus;
+  readonly sha256: string | null;
+  readonly observedAt?: number | null;
+  readonly observedByteLength?: number | null;
+  readonly observedModifiedAt?: number | null;
+  readonly localFileId?: string | null;
+}
+
+export interface CatalogV3MetadataInput {
+  readonly archive: boolean;
+  readonly pick: PickStatus;
+  readonly rating: StarRating;
+  readonly colorLabel: ColorLabel;
+  readonly developJson: string | null;
+  readonly developUpdatedAt: number;
+  readonly updatedAt: number;
+  readonly title: string | null;
+  readonly caption: string | null;
+  readonly copyright: string | null;
+  readonly keywordsJson: string;
+  readonly rawXmp: string | null;
+  readonly xmpState: CatalogV3XmpState;
+  readonly xmpMtime: number | null;
+  readonly xmpSha256: string | null;
+}
+
+export interface CatalogV3AssetCandidate {
+  readonly rootId: RootId;
+  readonly relativePath: string;
+  readonly observation: CatalogV3Observation | null;
+  readonly health: CatalogV3AssetHealth;
+  readonly formatId: string;
+  readonly cameraMake: string | null;
+  readonly cameraModel: string | null;
+  readonly lensModel: string | null;
+  readonly legacyIds: readonly string[];
+  readonly metadata: CatalogV3MetadataInput | null;
+  readonly fingerprint?: CatalogV3FingerprintInput;
+}
+
+export interface CatalogV3AssetBatchInput {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly assets: readonly CatalogV3AssetCandidate[];
+}
+
+export interface CatalogV3AlbumInput {
+  readonly id: string;
+  readonly name: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly position: number;
+  readonly positionOffset: number;
+  readonly entryIds: readonly string[];
+}
+
+export interface CatalogV3RelationsBatchInput {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly albums: readonly CatalogV3AlbumInput[];
+  readonly archiveLegacyIds: readonly string[];
+}
+
+export interface CatalogV3AssetMapping {
+  readonly legacyIds: readonly string[];
+  readonly relativePath: string;
+  readonly assetId: AssetId;
+  readonly fingerprintId: string;
+}
+
+export interface CatalogV3AssetBatchResult {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly revision: number;
+  readonly assets: readonly CatalogV3AssetMapping[];
+}
+
+export interface CatalogV3InstallResult {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly created: boolean;
+  readonly installState: CatalogV3InstallState;
+  readonly revision: number;
+  readonly schemaVersion: number;
+}
+
+export interface CatalogV3RelationsBatchResult {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly revision: number;
+  readonly albums: number;
+  readonly albumAssets: number;
+  readonly archived: number;
+}
+
+export interface CatalogV3FinishCopyResult {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly phase: CatalogV3MigrationPhase;
+  readonly revision: number;
+}
+
+export interface CatalogV3FingerprintCoverage {
+  readonly total: number;
+  readonly missing: number;
+  readonly hashing: number;
+  readonly valid: number;
+  readonly stale: number;
+  readonly failed: number;
+}
+
+export interface CatalogV3Counts extends CatalogV3ExpectedCounts {
+  readonly ambiguous: number;
+  readonly unreadable: number;
+}
+
+export interface CatalogV3IntegrityResult {
+  readonly integrityCheck: readonly string[];
+  readonly foreignKeyCheck: readonly {
+    readonly table: string;
+    readonly rowId: number | null;
+    readonly parent: string;
+    readonly foreignKeyIndex: number;
+  }[];
+}
+
+export interface CatalogV3ValidationReport {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly clean: boolean;
+  readonly before: CatalogV3ExpectedCounts;
+  readonly after: CatalogV3Counts;
+  readonly fingerprintCoverage: CatalogV3FingerprintCoverage;
+  readonly expectedStateSha256: string;
+  readonly actualStateSha256: string;
+  readonly relationFailures: {
+    readonly aliases: number;
+    readonly albums: number;
+    readonly albumAssets: number;
+    readonly archived: number;
+  };
+  readonly integrity: CatalogV3IntegrityResult;
+  readonly applicationId: number;
+  readonly schemaVersion: number;
+  readonly userVersion: number;
+  readonly limitations: readonly string[];
+  readonly blockingErrors: readonly string[];
+}
+
+export interface CatalogV3ValidationResult {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly phase: CatalogV3MigrationPhase;
+  readonly report: CatalogV3ValidationReport;
+  readonly revision: number;
+}
+
+export interface CatalogV3ActivationResult {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly installState: CatalogV3InstallState;
+  readonly revision: number;
+}
+
+export interface CatalogV3SealForInstallResult {
+  readonly catalogId: CatalogId;
+  readonly migrationId: string;
+  readonly busy: number;
+  readonly logFrames: number;
+  readonly checkpointedFrames: number;
+  readonly journalMode: "delete";
+}
+
+export interface CatalogV3Summary {
+  readonly catalogId: CatalogId;
+  readonly displayName: string;
+  readonly appVersion: string;
+  readonly installState: CatalogV3InstallState;
+  readonly revision: number;
+  readonly migrationId: string;
+  readonly migrationPhase: CatalogV3MigrationPhase;
+  readonly sourceVersion: 1 | 2;
+  readonly migration: CatalogV3MigrationInput;
+  readonly root: CatalogV3RootInput;
+  readonly counts: CatalogV3Counts;
+  readonly fingerprintCoverage: CatalogV3FingerprintCoverage;
+}
+
+export interface CatalogV3AssetMetadata {
+  readonly archive: boolean;
+  readonly pick: PickStatus;
+  readonly rating: StarRating;
+  readonly colorLabel: ColorLabel;
+  readonly developJson: string | null;
+  readonly developUpdatedAt: number;
+  readonly updatedAt: number;
+  readonly title: string | null;
+  readonly caption: string | null;
+  readonly copyright: string | null;
+  readonly keywordsJson: string;
+  readonly rawXmp: string | null;
+  readonly xmpState: CatalogV3XmpState;
+  readonly xmpMtime: number | null;
+  readonly xmpSha256: string | null;
+}
+
+export interface CatalogV3AssetSnapshot {
+  readonly catalogId: CatalogId;
+  readonly assetId: AssetId;
+  readonly rootId: RootId;
+  readonly relativePath: string;
+  readonly observation: CatalogV3Observation | null;
+  readonly revision: number;
+  readonly health: CatalogV3AssetHealth;
+  readonly formatId: string | null;
+  readonly cameraMake: string | null;
+  readonly cameraModel: string | null;
+  readonly lensModel: string | null;
+  readonly fingerprintId: string;
+  readonly fingerprintStatus: CatalogV3FingerprintStatus;
+  readonly fingerprintSha256: string | null;
+  readonly fingerprintObservedAt: number | null;
+  readonly fingerprintObservedByteLength: number | null;
+  readonly fingerprintObservedModifiedAt: number | null;
+  readonly fingerprintLocalFileId: string | null;
+  readonly metadata: CatalogV3AssetMetadata;
+}
+
+export interface CatalogV3AssetPageInput {
+  readonly catalogId: CatalogId;
+  readonly expectedRevision: number | null;
+  readonly cursor: string | null;
+  readonly limit: number;
+}
+
+export interface CatalogV3AssetPage {
+  readonly catalogId: CatalogId;
+  readonly revision: number;
+  readonly assets: readonly CatalogV3AssetSnapshot[];
+  readonly nextCursor: string | null;
+}
+
+export interface CatalogV3AlbumPageInput {
+  readonly catalogId: CatalogId;
+  readonly expectedRevision: number | null;
+  readonly cursor: number | null;
+  readonly limit: number;
+}
+
+export interface CatalogV3AlbumSnapshot {
+  readonly catalogId: CatalogId;
+  readonly id: string;
+  readonly name: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly position: number;
+}
+
+export interface CatalogV3AlbumSnapshotResult {
+  readonly catalogId: CatalogId;
+  readonly revision: number;
+  readonly albums: readonly CatalogV3AlbumSnapshot[];
+  readonly nextCursor: number | null;
+}
+
+export interface CatalogV3AlbumAssetPageInput {
+  readonly catalogId: CatalogId;
+  readonly albumId: string;
+  readonly expectedRevision: number | null;
+  readonly cursor: number | null;
+  readonly limit: number;
+}
+
+export interface CatalogV3AlbumAssetSnapshot {
+  readonly position: number;
+  readonly assetId: AssetId;
+  readonly rootId: RootId;
+  readonly relativePath: string;
+  readonly health: CatalogV3AssetHealth;
+  readonly revision: number;
+}
+
+export interface CatalogV3AlbumAssetPage {
+  readonly catalogId: CatalogId;
+  readonly albumId: string;
+  readonly revision: number;
+  readonly assets: readonly CatalogV3AlbumAssetSnapshot[];
+  readonly nextCursor: number | null;
+}
+
+type RecordValue = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(message: string): never {
+  throw new Error(`Catalog v3 ${message}.`);
+}
+
+function stringValue(record: RecordValue, key: string, allowEmpty = false): string {
+  const value = record[key];
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+    return fail(`${key} is invalid`);
+  }
+  return value;
+}
+
+function nullableString(record: RecordValue, key: string): string | null {
+  const value = record[key];
+  if (value === null) return null;
+  return typeof value === "string" ? value : fail(`${key} is invalid`);
+}
+
+function finiteNumber(record: RecordValue, key: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fail(`${key} is invalid`);
+  }
+  return value;
+}
+
+function nonnegativeInteger(record: RecordValue, key: string): number {
+  const value = finiteNumber(record, key);
+  if (!Number.isInteger(value) || value < 0) return fail(`${key} is invalid`);
+  return value;
+}
+
+function nullableFiniteNumber(record: RecordValue, key: string): number | null {
+  const value = record[key];
+  if (value === null) return null;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : fail(`${key} is invalid`);
+}
+
+function booleanValue(record: RecordValue, key: string): boolean {
+  const value = record[key];
+  return typeof value === "boolean" ? value : fail(`${key} is invalid`);
+}
+
+function enumValue<T extends string>(record: RecordValue, key: string, values: readonly T[]): T {
+  const value = record[key];
+  return typeof value === "string" && values.includes(value as T)
+    ? value as T
+    : fail(`${key} is invalid`);
+}
+
+function nullableEnumValue<T extends string>(
+  record: RecordValue,
+  key: string,
+  values: readonly T[],
+): T | null {
+  const value = record[key];
+  if (value === null) return null;
+  return typeof value === "string" && values.includes(value as T)
+    ? value as T
+    : fail(`${key} is invalid`);
+}
+
+function stringArray(record: RecordValue, key: string): readonly string[] {
+  const value = record[key];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    return fail(`${key} is invalid`);
+  }
+  return value;
+}
+
+function uuidString(value: unknown, label: string): string {
+  if (typeof value !== "string") return fail(`${label} is invalid`);
+  const parsed = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.exec(value);
+  if (!parsed || value !== value.toLowerCase()) return fail(`${label} is invalid`);
+  return value;
+}
+
+function hashString(record: RecordValue, key: string): string | null {
+  const value = record[key];
+  if (value === null) return null;
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    return fail(`${key} is invalid`);
+  }
+  return value;
+}
+
+function requiredHash(record: RecordValue, key: string): string {
+  const value = hashString(record, key);
+  return value === null ? fail(`${key} is invalid`) : value;
+}
+
+function normalizedAbsolutePath(value: unknown, key: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\u0000")) {
+    return fail(`${key} is invalid`);
+  }
+  if (value.startsWith("/")) {
+    if (value === "/") return value;
+    if (value.startsWith("//") || (value.length > 1 && value.endsWith("/"))) {
+      return fail(`${key} is invalid`);
+    }
+    const segments = value.slice(1).split("/");
+    if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+      return fail(`${key} is invalid`);
+    }
+    return value;
+  }
+  const drive = /^([A-Za-z]):([\\/])/.exec(value);
+  if (!drive) return fail(`${key} is invalid`);
+  const separator = drive[2];
+  if (value.includes(separator === "/" ? "\\" : "/")) return fail(`${key} is invalid`);
+  if (value.length === 3) return value;
+  if (value.length > 3 && value.endsWith(separator)) return fail(`${key} is invalid`);
+  const segments = value.slice(3).split(separator);
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    return fail(`${key} is invalid`);
+  }
+  return value;
+}
+
+function normalizedRelativePath(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\u0000")) {
+    return fail("relativePath is invalid");
+  }
+  if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\")) {
+    return fail("relativePath is invalid");
+  }
+  const segments = value.split("/");
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    return fail("relativePath is invalid");
+  }
+  if (value.includes("\\")) return fail("relativePath is invalid");
+  return value;
+}
+
+function jsonText(record: RecordValue, key: string, nullable: boolean): string | null {
+  const value = record[key];
+  if (value === null && nullable) return null;
+  if (typeof value !== "string" || !jsonValid(value)) return fail(`${key} is invalid`);
+  return value;
+}
+
+function jsonValid(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const rootHealth = ["online", "missing", "ambiguous", "unreadable"] as const;
+const scanStates = ["unknown", "complete", "partial", "failed"] as const;
+const watchStates = ["disabled", "active", "error"] as const;
+const assetHealth = ["present", "missing", "ambiguous", "unreadable"] as const;
+const fingerprintStatuses = ["missing", "hashing", "valid", "stale", "failed"] as const;
+const xmpStates = ["unknown", "absent", "preserved", "malformed"] as const;
+
+export function parseCatalogV3ExpectedCounts(value: unknown): CatalogV3ExpectedCounts {
+  if (!isRecord(value)) return fail("expectedCounts must be an object");
+  return {
+    assets: nonnegativeInteger(value, "assets"),
+    metadata: nonnegativeInteger(value, "metadata"),
+    albums: nonnegativeInteger(value, "albums"),
+    albumAssets: nonnegativeInteger(value, "albumAssets"),
+    archived: nonnegativeInteger(value, "archived"),
+    aliases: nonnegativeInteger(value, "aliases"),
+    fingerprints: nonnegativeInteger(value, "fingerprints"),
+    present: nonnegativeInteger(value, "present"),
+    missing: nonnegativeInteger(value, "missing"),
+  };
+}
+
+function parseRoot(value: unknown): CatalogV3RootInput {
+  if (!isRecord(value)) return fail("root must be an object");
+  const health = enumValue(value, "health", rootHealth);
+  const canonicalPath = nullableString(value, "canonicalPath");
+  if (health === "online" && canonicalPath === null) return fail("online roots need canonicalPath");
+  return {
+    rootId: parseRootId(value.rootId),
+    label: stringValue(value, "label"),
+    configuredPath: normalizedAbsolutePath(value.configuredPath, "configuredPath"),
+    canonicalPath: canonicalPath === null
+      ? null
+      : normalizedAbsolutePath(canonicalPath, "canonicalPath"),
+    health,
+    scanState: enumValue(value, "scanState", scanStates),
+    watchState: enumValue(value, "watchState", watchStates),
+  };
+}
+
+function parseMigration(value: unknown): CatalogV3MigrationInput {
+  if (!isRecord(value)) return fail("migration must be an object");
+  const sourceVersion = value.sourceVersion;
+  if (sourceVersion !== 1 && sourceVersion !== 2) return fail("sourceVersion is invalid");
+  const settingsPath = nullableString(value, "settingsPath");
+  const settingsSha256 = hashString(value, "settingsSha256");
+  if ((settingsPath === null) !== (settingsSha256 === null)) return fail("settings path and hash must be paired");
+  return {
+    migrationId: uuidString(value.migrationId, "migrationId"),
+    sourceVersion,
+    catalogPath: normalizedAbsolutePath(value.catalogPath, "catalogPath"),
+    settingsPath: settingsPath === null
+      ? null
+      : normalizedAbsolutePath(settingsPath, "settingsPath"),
+    catalogSha256: requiredHash(value, "catalogSha256"),
+    settingsSha256,
+    rootAvailable: booleanValue(value, "rootAvailable"),
+    expectedCounts: parseCatalogV3ExpectedCounts(value.expectedCounts),
+    expectedStateSha256: requiredHash(value, "expectedStateSha256"),
+  };
+}
+
+export function parseCatalogV3InstallInput(value: unknown): CatalogV3InstallInput {
+  if (!isRecord(value)) return fail("install input must be an object");
+  const now = value.now === undefined ? undefined : finiteNumber(value, "now");
+  const root = parseRoot(value.root);
+  const migration = parseMigration(value.migration);
+  if (migration.rootAvailable !== (root.health === "online")) {
+    return fail("root availability does not match root health");
+  }
+  return {
+    catalogId: parseCatalogId(value.catalogId),
+    displayName: stringValue(value, "displayName"),
+    appVersion: stringValue(value, "appVersion"),
+    root,
+    migration,
+    ...(now === undefined ? {} : { now }),
+  };
+}
+
+function parseObservation(value: unknown): CatalogV3Observation | null {
+  if (value === null) return null;
+  if (!isRecord(value)) return fail("observation is invalid");
+  return {
+    byteLength: nonnegativeInteger(value, "byteLength"),
+    modifiedAt: finiteNumber(value, "modifiedAt"),
+    observedAt: finiteNumber(value, "observedAt"),
+    localFileId: nullableString(value, "localFileId"),
+  };
+}
+
+function parseFingerprint(value: unknown): CatalogV3FingerprintInput | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) return fail("fingerprint is invalid");
+  const status = enumValue(value, "status", fingerprintStatuses);
+  const sha256 = hashString(value, "sha256");
+  const observedAt = value.observedAt === undefined ? null : nullableFiniteNumber(value, "observedAt");
+  const observedByteLength = value.observedByteLength === undefined ? null : nullableFiniteNumber(value, "observedByteLength");
+  const observedModifiedAt = value.observedModifiedAt === undefined ? null : nullableFiniteNumber(value, "observedModifiedAt");
+  const localFileId = value.localFileId === undefined ? null : nullableString(value, "localFileId");
+  if (observedByteLength !== null && (!Number.isInteger(observedByteLength) || observedByteLength < 0)) {
+    return fail("observedByteLength is invalid");
+  }
+  if (status === "valid" && sha256 === null) return fail("valid fingerprint needs sha256");
+  if (status !== "valid" && sha256 !== null) return fail("only valid fingerprints may have sha256");
+  return { status, sha256, observedAt, observedByteLength, observedModifiedAt, localFileId };
+}
+
+function parseMetadata(value: unknown): CatalogV3MetadataInput | null {
+  if (value === null) return null;
+  if (!isRecord(value)) return fail("metadata is invalid");
+  const pick = enumValue(value, "pick", ["none", "pick", "reject"] as const);
+  const rating = nonnegativeInteger(value, "rating");
+  if (rating > 5) return fail("rating is invalid");
+  const colorLabel = nullableEnumValue(value, "colorLabel", ["red", "yellow", "green", "blue", "purple"] as const);
+  const developJson = jsonText(value, "developJson", true);
+  const keywordsJson = jsonText(value, "keywordsJson", false);
+  if (keywordsJson === null) return fail("keywordsJson is invalid");
+  const rawXmp = nullableString(value, "rawXmp");
+  if (rawXmp !== null && new TextEncoder().encode(rawXmp).byteLength > CATALOG_V3_MAX_XMP_BYTES) {
+    return fail("rawXmp is too large");
+  }
+  const xmpState = enumValue(value, "xmpState", xmpStates);
+  const xmpSha256 = hashString(value, "xmpSha256");
+  if (xmpState === "preserved" && rawXmp === null) return fail("preserved XMP needs rawXmp");
+  if (xmpState === "absent" && rawXmp !== null) return fail("absent XMP cannot have rawXmp");
+  return {
+    archive: booleanValue(value, "archive"),
+    pick,
+    rating: rating as StarRating,
+    colorLabel,
+    developJson,
+    developUpdatedAt: finiteNumber(value, "developUpdatedAt"),
+    updatedAt: finiteNumber(value, "updatedAt"),
+    title: nullableString(value, "title"),
+    caption: nullableString(value, "caption"),
+    copyright: nullableString(value, "copyright"),
+    keywordsJson,
+    rawXmp,
+    xmpState,
+    xmpMtime: nullableFiniteNumber(value, "xmpMtime"),
+    xmpSha256,
+  };
+}
+
+function parseAssetCandidate(value: unknown): CatalogV3AssetCandidate {
+  if (!isRecord(value)) return fail("asset candidate is invalid");
+  const legacyIds = stringArray(value, "legacyIds");
+  const fingerprint = parseFingerprint(value.fingerprint);
+  const observation = parseObservation(value.observation);
+  const health = enumValue(value, "health", assetHealth);
+  if ((health === "present") !== (observation !== null)) {
+    return fail("asset health and observation do not match");
+  }
+  return {
+    rootId: parseRootId(value.rootId),
+    relativePath: normalizedRelativePath(value.relativePath),
+    observation,
+    health,
+    formatId: stringValue(value, "formatId"),
+    cameraMake: nullableString(value, "cameraMake"),
+    cameraModel: nullableString(value, "cameraModel"),
+    lensModel: nullableString(value, "lensModel"),
+    legacyIds,
+    metadata: parseMetadata(value.metadata),
+    ...(fingerprint === undefined ? {} : { fingerprint }),
+  };
+}
+
+export function parseCatalogV3AssetBatchInput(value: unknown): CatalogV3AssetBatchInput {
+  if (!isRecord(value) || !Array.isArray(value.assets)) return fail("asset batch is invalid");
+  if (value.assets.length > CATALOG_V3_MAX_ASSET_BATCH) {
+    return fail("asset batch size is invalid");
+  }
+  return {
+    catalogId: parseCatalogId(value.catalogId),
+    migrationId: uuidString(value.migrationId, "migrationId"),
+    assets: value.assets.map(parseAssetCandidate),
+  };
+}
+
+function parseAlbum(value: unknown): CatalogV3AlbumInput {
+  if (!isRecord(value)) return fail("album is invalid");
+  const entryIds = stringArray(value, "entryIds");
+  const positionOffset = value.positionOffset === undefined
+    ? 0
+    : nonnegativeInteger(value, "positionOffset");
+  if (positionOffset > Number.MAX_SAFE_INTEGER - entryIds.length) {
+    return fail("positionOffset is invalid");
+  }
+  return {
+    id: stringValue(value, "id"),
+    name: stringValue(value, "name", true),
+    createdAt: finiteNumber(value, "createdAt"),
+    updatedAt: finiteNumber(value, "updatedAt"),
+    position: nonnegativeInteger(value, "position"),
+    positionOffset,
+    entryIds,
+  };
+}
+
+export function parseCatalogV3RelationsBatchInput(value: unknown): CatalogV3RelationsBatchInput {
+  if (!isRecord(value) || !Array.isArray(value.albums)) return fail("relations batch is invalid");
+  const albums = value.albums.map(parseAlbum);
+  const archiveLegacyIds = stringArray(value, "archiveLegacyIds");
+  const relationCount = albums.reduce((total, album) => total + album.entryIds.length, 0) + albums.length + archiveLegacyIds.length;
+  if (relationCount > CATALOG_V3_MAX_RELATION_BATCH) return fail("relations batch size is invalid");
+  return {
+    catalogId: parseCatalogId(value.catalogId),
+    migrationId: uuidString(value.migrationId, "migrationId"),
+    albums,
+    archiveLegacyIds,
+  };
+}
+
+export function parseCatalogV3AssetPageInput(value: unknown): CatalogV3AssetPageInput {
+  if (!isRecord(value)) return fail("asset page input is invalid");
+  const expectedRevision = value.expectedRevision === undefined || value.expectedRevision === null
+    ? null
+    : nonnegativeInteger(value, "expectedRevision");
+  const cursor = value.cursor === undefined ? null : parseCursor(value.cursor);
+  const limit = nonnegativeInteger(value, "limit");
+  if (limit < 1 || limit > CATALOG_V3_MAX_PAGE_SIZE) return fail("limit is invalid");
+  return {
+    catalogId: parseCatalogId(value.catalogId),
+    expectedRevision,
+    cursor,
+    limit,
+  };
+}
+
+function parseCursor(value: unknown): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string" || value.length === 0 || value.length > 1024 || !/^[A-Za-z0-9_-]+$/.test(value)) {
+    return fail("cursor is invalid");
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch {
+    return fail("cursor is invalid");
+  }
+  if (!isRecord(decoded) || typeof decoded.relativePath !== "string" || decoded.relativePath.length === 0) {
+    return fail("cursor is invalid");
+  }
+  parseAssetId(decoded.assetId);
+  return value;
+}
+
+export function parseCatalogV3AssetCursor(value: unknown): string {
+  const cursor = parseCursor(value);
+  return cursor === null ? fail("cursor is invalid") : cursor;
+}
+
+export function parseCatalogV3AlbumPageInput(value: unknown): CatalogV3AlbumPageInput {
+  if (!isRecord(value)) return fail("album page input is invalid");
+  const limit = nonnegativeInteger(value, "limit");
+  if (limit < 1 || limit > CATALOG_V3_MAX_PAGE_SIZE) return fail("limit is invalid");
+  return {
+    catalogId: parseCatalogId(value.catalogId),
+    expectedRevision: value.expectedRevision === undefined || value.expectedRevision === null
+      ? null
+      : nonnegativeInteger(value, "expectedRevision"),
+    cursor: value.cursor === undefined || value.cursor === null
+      ? null
+      : nonnegativeInteger(value, "cursor"),
+    limit,
+  };
+}
+
+export function parseCatalogV3AlbumAssetPageInput(value: unknown): CatalogV3AlbumAssetPageInput {
+  if (!isRecord(value)) return fail("album asset page input is invalid");
+  const limit = nonnegativeInteger(value, "limit");
+  if (limit < 1 || limit > CATALOG_V3_MAX_PAGE_SIZE) return fail("limit is invalid");
+  return {
+    catalogId: parseCatalogId(value.catalogId),
+    albumId: stringValue(value, "albumId"),
+    expectedRevision: value.expectedRevision === undefined || value.expectedRevision === null
+      ? null
+      : nonnegativeInteger(value, "expectedRevision"),
+    cursor: value.cursor === undefined || value.cursor === null
+      ? null
+      : nonnegativeInteger(value, "cursor"),
+    limit,
+  };
+}
+
+export function parseCatalogV3CatalogId(value: unknown): CatalogId {
+  return parseCatalogId(value);
+}
+
+export function parseCatalogV3AssetId(value: unknown): AssetId {
+  return parseAssetId(value);
+}
+
+export function parseCatalogV3RootId(value: unknown): RootId {
+  return parseRootId(value);
+}

--- a/tests/asset-cache-key.test.mts
+++ b/tests/asset-cache-key.test.mts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assetCacheKey } from "../lib/cache/asset-cache-key.ts";
+import { createAssetId, createCatalogId } from "../lib/catalog/ids.ts";
+
+test("asset cache keys use the exact stable identity contract", () => {
+  const identity = { catalogId: createCatalogId(), assetId: createAssetId(), revision: 3 };
+  assert.equal(
+    assetCacheKey(identity, "thumbnail"),
+    `${identity.catalogId}:${identity.assetId}:3:thumbnail`,
+  );
+  assert.notEqual(
+    assetCacheKey(identity, "thumbnail"),
+    assetCacheKey({ ...identity, catalogId: createCatalogId() }, "thumbnail"),
+  );
+  assert.notEqual(
+    assetCacheKey(identity, "thumbnail"),
+    assetCacheKey({ ...identity, revision: 4 }, "thumbnail"),
+  );
+  assert.notEqual(assetCacheKey(identity, "thumbnail"), assetCacheKey(identity, "develop-preview"));
+});
+
+test("asset cache keys reject ambiguous identity parts", () => {
+  const identity = { catalogId: createCatalogId(), assetId: createAssetId(), revision: 0 };
+  assert.throws(() => assetCacheKey({ ...identity, revision: -1 }, "thumbnail"));
+  assert.throws(() => assetCacheKey({ ...identity, revision: 1.5 }, "thumbnail"));
+  assert.throws(() => assetCacheKey(identity, ""));
+  assert.throws(() => assetCacheKey(identity, "thumb:narrow"));
+  assert.throws(() => assetCacheKey(identity, "thumb\0narrow"));
+});

--- a/tests/catalog-migration-snapshot.test.mts
+++ b/tests/catalog-migration-snapshot.test.mts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  copyMigrationRecoveryEvidence,
+  readMigrationSources,
+  recheckMigrationSources,
+} from "../electron/catalog-migration-snapshot.ts";
+
+function digest(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+test("raw migration snapshots preserve bytes, hash exact content, and recheck changes", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-migration-snapshot-test-"));
+  try {
+    const catalogPath = path.join(root, "catalog.json");
+    const settingsPath = path.join(root, "settings.json");
+    const catalogBytes = Buffer.from('{"version":2,"rootPath":"/photos"}\n', "utf8");
+    const settingsBytes = Buffer.from('{"lastFolderPath":"/photos"}\n', "utf8");
+    await writeFile(catalogPath, catalogBytes);
+    await writeFile(settingsPath, settingsBytes);
+
+    const snapshot = await readMigrationSources({ catalogPath, settingsPath });
+    assert.equal(snapshot.catalog.text, catalogBytes.toString("utf8"));
+    assert.equal(snapshot.catalog.sha256, digest(catalogBytes));
+    assert.equal(snapshot.settings?.sha256, digest(settingsBytes));
+    assert.deepEqual([...snapshot.catalog.bytes], [...catalogBytes]);
+
+    const userDataPath = path.join(root, "user-data");
+    const first = await copyMigrationRecoveryEvidence(userDataPath, "migration-1", snapshot);
+    const second = await copyMigrationRecoveryEvidence(userDataPath, "migration-1", snapshot);
+    assert.deepEqual(second, first);
+    assert.deepEqual([...await readFile(path.join(first.directory, "catalog.json"))], [...catalogBytes]);
+    assert.deepEqual([...await readFile(path.join(first.directory, "settings.json"))], [...settingsBytes]);
+
+    const malformedPath = path.join(root, "malformed-catalog.json");
+    const malformedBytes = Uint8Array.from([0xff, 0x00, 0x7b]);
+    await writeFile(malformedPath, malformedBytes);
+    const malformed = await readMigrationSources({ catalogPath: malformedPath });
+    const malformedEvidence = await copyMigrationRecoveryEvidence(userDataPath, "malformed", malformed);
+    assert.deepEqual([...malformed.catalog.bytes], [...malformedBytes]);
+    assert.equal(malformed.catalog.sha256, digest(malformedBytes));
+    assert.deepEqual([...await readFile(path.join(malformedEvidence.directory, "catalog.json"))], [...malformedBytes]);
+
+    const unchanged = await recheckMigrationSources(snapshot);
+    assert.equal(unchanged.unchanged, true);
+
+    await writeFile(catalogPath, Buffer.from('{"version":2,"rootPath":"/changed"}\n', "utf8"));
+    const changed = await recheckMigrationSources(snapshot);
+    assert.equal(changed.unchanged, false);
+    await assert.rejects(copyMigrationRecoveryEvidence(userDataPath, "migration-1", changed));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("raw migration snapshots reject unsafe source and recovery paths", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-migration-path-test-"));
+  try {
+    const catalogPath = path.join(root, "catalog.json");
+    await writeFile(catalogPath, "{}");
+    await assert.rejects(readMigrationSources({ catalogPath: "relative/catalog.json" }));
+    const snapshot = await readMigrationSources({ catalogPath });
+    await assert.rejects(copyMigrationRecoveryEvidence(root, "../escape", snapshot));
+    await assert.rejects(copyMigrationRecoveryEvidence(root, "migration/escape", snapshot));
+    await assert.rejects(copyMigrationRecoveryEvidence(`${root}/../${path.basename(root)}`, "migration", snapshot));
+    await assert.rejects(stat(path.join(root, "catalog-migration-recovery", "migration", "catalog.json")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("source recheck detects settings created after an initially missing snapshot", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-migration-settings-test-"));
+  try {
+    const catalogPath = path.join(root, "catalog.json");
+    const settingsPath = path.join(root, "settings.json");
+    await writeFile(catalogPath, "{}");
+    const snapshot = await readMigrationSources({ catalogPath, settingsPath });
+    assert.equal(snapshot.settings, undefined);
+    assert.equal((await recheckMigrationSources(snapshot, { settingsPath })).unchanged, true);
+
+    await writeFile(settingsPath, "{}\n");
+    assert.equal((await recheckMigrationSources(snapshot, { settingsPath })).unchanged, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tests/catalog-migration.test.mts
+++ b/tests/catalog-migration.test.mts
@@ -1,0 +1,351 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import type { DevelopDocument } from "../lib/develop/types.ts";
+import type {
+  Album,
+  EntryMetadata,
+  PhotoCatalog,
+} from "../lib/catalog/types.ts";
+import {
+  canonicalRelativePath,
+  decodeLegacyId,
+  parseStrictMigrationSettings,
+  prepareLegacyMigration,
+  type LegacyCatalogParser,
+  type MigrationSourceDescriptor,
+} from "../lib/catalog/legacy-migration.ts";
+
+function sourceDescriptor(): MigrationSourceDescriptor {
+  const bytes = new TextEncoder().encode("{}");
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  return {
+    catalog: { path: "/tmp/legacy-catalog.json", bytes, text: "{}", sha256 },
+  };
+}
+
+function rawSource(path: string, text: string) {
+  const bytes = new TextEncoder().encode(text);
+  return { path, bytes, text, sha256: createHash("sha256").update(bytes).digest("hex") };
+}
+
+function developDocument(): DevelopDocument {
+  const zeroBand = { hue: 0, saturation: 0, luminance: 0 };
+  const basic = {
+    exposure: 0,
+    contrast: 0,
+    highlights: 0,
+    shadows: 0,
+    whites: 0,
+    blacks: 0,
+    temperature: 0,
+    tint: 0,
+    vibrance: 0,
+    saturation: 0,
+  };
+  return {
+    version: 2,
+    settings: {
+      basic,
+      crop: {
+        enabled: false,
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1,
+        angle: 0,
+        perspectiveX: 0,
+        perspectiveY: 0,
+        distortion: 0,
+        aspectPreset: "original",
+        customAspectWidth: 1,
+        customAspectHeight: 1,
+      },
+      curve: {
+        rgb: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+        red: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+        green: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+        blue: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+      },
+      mixer: {
+        red: zeroBand,
+        orange: zeroBand,
+        yellow: zeroBand,
+        green: zeroBand,
+        aqua: zeroBand,
+        blue: zeroBand,
+        purple: zeroBand,
+        magenta: zeroBand,
+      },
+      effects: {
+        vignette: 0,
+        vignetteMidpoint: 50,
+        vignetteRoundness: 0,
+        vignetteFeather: 50,
+        vignetteHighlights: 0,
+        grain: 0,
+        grainSize: 25,
+        grainRoughness: 50,
+        sharpening: 0,
+        sharpenRadius: 1,
+        sharpenDetail: 25,
+        sharpenMasking: 0,
+        noiseReduction: 0,
+        noiseDetail: 50,
+        noiseContrast: 0,
+        colorNoiseReduction: 0,
+        colorNoiseDetail: 50,
+        colorNoiseSmoothness: 50,
+      },
+      masking: { masks: [] },
+    },
+    maskAssets: {},
+  };
+}
+
+function metadata(develop?: DevelopDocument): EntryMetadata {
+  return {
+    pick: "none",
+    rating: 0,
+    colorLabel: null,
+    ...(develop ? { develop } : {}),
+    developUpdatedAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function album(id: string, entryIds: string[]): Album {
+  return { id, name: id, entryIds, createdAt: 1, updatedAt: 2 };
+}
+
+function parserFor(catalog: PhotoCatalog): LegacyCatalogParser {
+  return () => catalog;
+}
+
+function catalogFor(
+  entries: Record<string, EntryMetadata>,
+  albums: Album[] = [],
+  archivedEntryIds: string[] = [],
+): PhotoCatalog {
+  return {
+    version: 2,
+    rootPath: "/photos",
+    entries,
+    albums,
+    archivedEntryIds,
+  };
+}
+
+function observation(relativePath: string, byteLength = 100) {
+  return {
+    relativePath,
+    byteLength,
+    modifiedAt: 10,
+    observedAt: 20,
+    localFileId: null,
+    formatId: "jpeg",
+  };
+}
+
+test("v1 online migration unions relations and scan, preserves develop, and orders candidates", () => {
+  const alpha = encodeURIComponent("album/a.jpg");
+  const beta = encodeURIComponent("album/b.jpg");
+  const gamma = encodeURIComponent("archive/c.jpg");
+  const develop = developDocument();
+  const catalog = catalogFor(
+    { [alpha]: metadata(develop) },
+    [album("album-1", [alpha, beta])],
+    [gamma],
+  );
+  const plan = prepareLegacyMigration({
+    catalog: { version: 1, rootPath: "/photos", entries: {} },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(catalog),
+    onlineScan: {
+      complete: true,
+      xmpComplete: true,
+      observations: [observation("album/a.jpg"), observation("album/b.jpg"), observation("scan-only.jpg")],
+    },
+    xmpByRelativePath: {
+      "album/a.jpg": {
+        state: "preserved",
+        contents: "<x:xmpmeta/>\n",
+        modifiedAt: 30,
+        sha256: "0".repeat(64),
+      },
+    },
+  });
+
+  assert.equal(plan.rawCatalogVersion, 1);
+  assert.deepEqual(plan.candidates.map((candidate) => candidate.relativePath), [
+    "album/a.jpg",
+    "album/b.jpg",
+    "archive/c.jpg",
+    "scan-only.jpg",
+  ]);
+  assert.equal(plan.catalog.entries[alpha]?.develop, develop);
+  assert.deepEqual(plan.albums[0]?.entryIds, [alpha, beta]);
+  assert.deepEqual(plan.archivedEntryIds, [gamma]);
+  assert.equal(plan.candidates[0]?.sourceFlags.entries, true);
+  assert.equal(plan.candidates[1]?.sourceFlags.albums, true);
+  assert.equal(plan.candidates[2]?.health, "missing");
+  assert.equal(plan.candidates[3]?.health, "present");
+  assert.equal(plan.candidates[3]?.legacyIdAlias, encodeURIComponent("scan-only.jpg"));
+  assert.equal(plan.candidates[0]?.xmp.state, "preserved");
+  assert.equal(plan.candidates[2]?.xmp.state, "absent");
+  assert.deepEqual(plan.counts, {
+    metadataEntries: 1,
+    albums: 1,
+    albumMemberships: 2,
+    archiveReferences: 1,
+    distinctReferencedIds: 3,
+    scannedAssetCount: 3,
+    expectedTotalAssets: 4,
+    expectedPresentAssets: 3,
+    expectedMissingAssets: 1,
+    expectedAliases: 4,
+    offlineInventoryLimited: false,
+  });
+});
+
+test("v2 offline migration reports only the recoverable referenced inventory", () => {
+  const metadataId = encodeURIComponent("metadata.jpg");
+  const albumId = encodeURIComponent("album-only.jpg");
+  const archiveId = encodeURIComponent("archive-only.jpg");
+  const catalog = catalogFor(
+    { [metadataId]: metadata() },
+    [album("album-1", [albumId])],
+    [archiveId],
+  );
+  const plan = prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos", entries: {} },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(catalog),
+  });
+
+  assert.equal(plan.scan, "offline");
+  assert.equal(plan.candidates.every((candidate) => candidate.observation === null), true);
+  assert.equal(plan.candidates.every((candidate) => candidate.health === "missing"), true);
+  assert.equal(plan.candidates.every((candidate) => candidate.xmp.state === "unknown"), true);
+  assert.equal(plan.counts.expectedTotalAssets, 3);
+  assert.equal(plan.counts.expectedPresentAssets, 0);
+  assert.equal(plan.counts.expectedMissingAssets, 3);
+  assert.equal(plan.counts.offlineInventoryLimited, true);
+});
+
+test("online migration does not invent absent XMP without complete sidecar coverage", () => {
+  const id = encodeURIComponent("photo.jpg");
+  const plan = prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos", entries: {} },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(catalogFor({ [id]: metadata() })),
+    onlineScan: {
+      complete: true,
+      xmpComplete: false,
+      observations: [observation("photo.jpg")],
+    },
+  });
+  assert.equal(plan.candidates[0]?.xmp.state, "unknown");
+});
+
+test("strict settings parser accepts existing settings shape and rejects malformed fields", () => {
+  const settings = parseStrictMigrationSettings({
+    lastFolderPath: "/photos",
+    exportOptions: {
+      format: "jpeg",
+      quality: 90,
+      lossless: false,
+      size: { mode: "long-edge", pixels: 2_000, neverUpscale: true },
+      suffix: "-darkroom",
+      conflict: "rename",
+    },
+  });
+  assert.equal(settings.exportOptions?.size.mode, "long-edge");
+  assert.throws(() => parseStrictMigrationSettings({ exportOptions: { format: "jpeg" } }));
+  assert.throws(() => parseStrictMigrationSettings({ lastFolderPath: 4 }));
+  assert.throws(() => parseStrictMigrationSettings({ unexpected: true }));
+});
+
+test("migration captures the raw version and refuses malformed catalog or settings input", () => {
+  const catalog = catalogFor({});
+  assert.throws(() => prepareLegacyMigration({
+    catalog: { version: 3, rootPath: "/photos" },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(catalog),
+  }));
+
+  const malformedSettings = {
+    catalog: sourceDescriptor().catalog,
+    settings: rawSource("/tmp/legacy-settings.json", "{\"exportOptions\": {\"quality\": \"bad\"}}"),
+  };
+  assert.throws(() => prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos" },
+    source: malformedSettings,
+    parseCatalog: parserFor(catalog),
+  }));
+
+  assert.throws(() => prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos" },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor({ ...catalog, rootPath: "/photos/../photos" }),
+  }));
+});
+
+test("unsafe IDs and paths are rejected before relation planning", () => {
+  const unsafeIds = [
+    "",
+    "%",
+    "%E0%A4%A",
+    encodeURIComponent("\0"),
+    "%2fabsolute",
+    encodeURIComponent("/absolute.jpg"),
+    encodeURIComponent("../escape.jpg"),
+    encodeURIComponent("folder/../escape.jpg"),
+    encodeURIComponent("folder\\file.jpg"),
+    encodeURIComponent("C:\\file.jpg"),
+    encodeURIComponent("//server/share.jpg"),
+    encodeURIComponent("folder//file.jpg"),
+  ];
+  for (const unsafeId of unsafeIds) {
+    assert.throws(() => decodeLegacyId(unsafeId), unsafeId);
+  }
+  assert.throws(() => canonicalRelativePath("folder/./file.jpg"));
+  assert.throws(() => canonicalRelativePath("folder/../file.jpg"));
+});
+
+test("duplicate relations and incomplete scans block migration", () => {
+  const id = encodeURIComponent("photo.jpg");
+  const catalog = catalogFor({ [id]: metadata() }, [album("album", [id, id])], [id]);
+  assert.throws(() => prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos", entries: {} },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(catalog),
+  }));
+
+  const duplicateAlbums = catalogFor({ [id]: metadata() }, [album("album", []), album("album", [])]);
+  assert.throws(() => prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos", entries: {} },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(duplicateAlbums),
+  }));
+
+  const archiveDuplicate = catalogFor({ [id]: metadata() }, [], [id, id]);
+  assert.throws(() => prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos", entries: {} },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(archiveDuplicate),
+  }));
+
+  assert.throws(() => prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos", entries: {} },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(catalogFor({ [id]: metadata() })),
+    onlineScan: { complete: false, xmpComplete: false, observations: [] },
+  }));
+  assert.throws(() => prepareLegacyMigration({
+    catalog: { version: 2, rootPath: "/photos", entries: {} },
+    source: sourceDescriptor(),
+    parseCatalog: parserFor(catalogFor({ [id]: metadata() })),
+    onlineScan: { complete: true, xmpComplete: false, observations: [observation("photo.jpg"), observation("photo.jpg")] },
+  }));
+});

--- a/tests/catalog-v3-migration.test.mts
+++ b/tests/catalog-v3-migration.test.mts
@@ -1,0 +1,709 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
+import { createCatalogRegistryStore } from "../electron/catalog-registry.ts";
+import {
+  installCatalogV3Migration,
+  type CatalogV3MigrationInstallerInput,
+} from "../electron/catalog-v3-migration.ts";
+import { createCatalogWorkerTestClient, type CatalogWorkerClient } from "../electron/catalog-worker-client.ts";
+import {
+  createCatalogId,
+  createOperationId,
+  createRootId,
+} from "../lib/catalog/ids.ts";
+import type { CatalogV3AlbumAssetSnapshot } from "../lib/catalog/v3.ts";
+import type {
+  Album,
+  ColorLabel,
+  EntryMetadata,
+  PhotoCatalog,
+  PickStatus,
+  StarRating,
+} from "../lib/catalog/types.ts";
+
+interface Fixture {
+  readonly root: string;
+  readonly userDataPath: string;
+  readonly catalogPath: string;
+  readonly settingsPath: string;
+  readonly workerPath: string;
+  readonly catalogId: ReturnType<typeof createCatalogId>;
+  readonly rootId: ReturnType<typeof createRootId>;
+  readonly migrationId: ReturnType<typeof createOperationId>;
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function legacyId(relativePath: string): string {
+  return encodeURIComponent(relativePath);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function testParser(value: unknown): PhotoCatalog {
+  if (!isRecord(value) || (value.version !== 1 && value.version !== 2) || typeof value.rootPath !== "string" || !isRecord(value.entries)) {
+    throw new Error("Test legacy catalog is malformed.");
+  }
+  const entries: Record<string, EntryMetadata> = {};
+  for (const [id, rawMetadata] of Object.entries(value.entries)) {
+    if (!isRecord(rawMetadata)) throw new Error("Test legacy metadata is malformed.");
+    const pick = rawMetadata.pick;
+    const rating = rawMetadata.rating;
+    const colorLabel = rawMetadata.colorLabel;
+    if (
+      (pick !== "none" && pick !== "pick" && pick !== "reject") ||
+      (rating !== 0 && rating !== 1 && rating !== 2 && rating !== 3 && rating !== 4 && rating !== 5) ||
+      (colorLabel !== null && colorLabel !== "red" && colorLabel !== "yellow" && colorLabel !== "green" && colorLabel !== "blue" && colorLabel !== "purple") ||
+      typeof rawMetadata.updatedAt !== "number" ||
+      !Number.isFinite(rawMetadata.updatedAt)
+    ) {
+      throw new Error("Test legacy metadata is malformed.");
+    }
+    const develop = rawMetadata.develop === undefined
+      ? undefined
+      : JSON.parse(JSON.stringify(rawMetadata.develop));
+    entries[id] = {
+      pick: pick as PickStatus,
+      rating: rating as StarRating,
+      colorLabel: colorLabel as ColorLabel,
+      ...(develop === undefined ? {} : { develop }),
+      developUpdatedAt: typeof rawMetadata.developUpdatedAt === "number" && Number.isFinite(rawMetadata.developUpdatedAt)
+        ? rawMetadata.developUpdatedAt
+        : develop === undefined ? 0 : rawMetadata.updatedAt,
+      updatedAt: rawMetadata.updatedAt,
+    };
+  }
+  const rawAlbums = value.albums === undefined ? [] : value.albums;
+  const rawArchived = value.archivedEntryIds === undefined ? [] : value.archivedEntryIds;
+  if (!Array.isArray(rawAlbums) || !Array.isArray(rawArchived)) throw new Error("Test legacy relations are malformed.");
+  const albums: Album[] = rawAlbums.map((rawAlbum) => {
+    if (!isRecord(rawAlbum) || typeof rawAlbum.id !== "string" || typeof rawAlbum.name !== "string" || !Array.isArray(rawAlbum.entryIds) || typeof rawAlbum.createdAt !== "number" || typeof rawAlbum.updatedAt !== "number") {
+      throw new Error("Test legacy album is malformed.");
+    }
+    if (!rawAlbum.entryIds.every((entryId) => typeof entryId === "string")) throw new Error("Test legacy album is malformed.");
+    return {
+      id: rawAlbum.id,
+      name: rawAlbum.name,
+      entryIds: rawAlbum.entryIds,
+      createdAt: rawAlbum.createdAt,
+      updatedAt: rawAlbum.updatedAt,
+    };
+  });
+  if (!rawArchived.every((entryId) => typeof entryId === "string")) throw new Error("Test legacy archive is malformed.");
+  return { version: 2, rootPath: value.rootPath, entries, albums, archivedEntryIds: rawArchived };
+}
+
+async function fixture(): Promise<Fixture> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-v3-installer-test-"));
+  return {
+    root,
+    userDataPath: path.join(root, "user-data"),
+    catalogPath: path.join(root, "legacy-catalog.json"),
+    settingsPath: path.join(root, "legacy-settings.json"),
+    workerPath: path.resolve("electron/catalog-worker.ts"),
+    catalogId: createCatalogId(),
+    rootId: createRootId(),
+    migrationId: createOperationId(),
+  };
+}
+
+function inputFor(
+  value: Fixture,
+  extra: Partial<CatalogV3MigrationInstallerInput> = {},
+): CatalogV3MigrationInstallerInput {
+  return {
+    userDataPath: value.userDataPath,
+    workerPath: value.workerPath,
+    catalogPath: value.catalogPath,
+    settingsPath: value.settingsPath,
+    catalogId: value.catalogId,
+    rootId: value.rootId,
+    migrationId: value.migrationId,
+    displayName: "Migration test catalog",
+    appVersion: "test",
+    parseCatalog: testParser,
+    ...extra,
+  };
+}
+
+async function writeLegacy(
+  value: Fixture,
+  catalog: unknown,
+  settings: unknown = { lastFolderPath: "/photos" },
+): Promise<{ readonly catalog: Buffer; readonly settings: Buffer }> {
+  const catalogBytes = Buffer.from(`${JSON.stringify(catalog)}\n`, "utf8");
+  const settingsBytes = Buffer.from(`${JSON.stringify(settings)}\n`, "utf8");
+  await writeFile(value.catalogPath, catalogBytes);
+  await writeFile(value.settingsPath, settingsBytes);
+  return { catalog: catalogBytes, settings: settingsBytes };
+}
+
+function workerClient(): CatalogWorkerClient {
+  return createCatalogWorkerTestClient({
+    workerPath: path.resolve("electron/catalog-worker.ts"),
+    execArgv: ["--no-warnings", "--experimental-strip-types"],
+  });
+}
+
+async function productionCatalogParser(outputDirectory: string): Promise<(value: unknown) => PhotoCatalog> {
+  const outfile = path.join(outputDirectory, "production-catalog-parser.mjs");
+  await build({
+    entryPoints: [path.resolve("lib/catalog/types.ts")],
+    outfile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    target: "node24",
+  });
+  const parserModule: unknown = await import(`${pathToFileURL(outfile).href}?migration-test`);
+  if (!isRecord(parserModule) || typeof parserModule.parsePhotoCatalog !== "function") {
+    throw new Error("Production catalog parser bundle is invalid.");
+  }
+  return parserModule.parsePhotoCatalog as (value: unknown) => PhotoCatalog;
+}
+
+async function readAssets(databasePath: string, catalogId: ReturnType<typeof createCatalogId>) {
+  let client: CatalogWorkerClient | undefined;
+  try {
+    client = workerClient();
+    await client.open(databasePath);
+    const first = await client.v3AssetsPage({ catalogId, expectedRevision: null, cursor: null, limit: 250 });
+    return first.assets;
+  } finally {
+    await client?.shutdown().catch(() => client?.forceTerminate());
+  }
+}
+
+test("v1 online installation preserves metadata, relations, XMP, and legacy bytes", async () => {
+  const value = await fixture();
+  try {
+    const photoRoot = path.join(value.root, "photos");
+    await mkdir(photoRoot);
+    const edited = legacyId("edited/photo.JPG");
+    const missing = legacyId("album/missing.jpeg");
+    const archived = legacyId("archive/old.png");
+    const catalog = {
+      version: 1,
+      rootPath: photoRoot,
+      entries: {
+        [edited]: {
+          pick: "pick",
+          rating: 4,
+          colorLabel: "red",
+          develop: { basic: { exposure: 1.25 } },
+          developUpdatedAt: 22,
+          updatedAt: 23,
+        },
+      },
+      albums: [{ id: "album-1", name: "Album", entryIds: [edited, missing], createdAt: 4, updatedAt: 5 }],
+      archivedEntryIds: [archived],
+    };
+    const parseCatalog = await productionCatalogParser(value.root);
+    const expectedDevelop = parseCatalog(catalog).entries[edited]?.develop;
+    assert.notEqual(expectedDevelop, undefined);
+    const source = await writeLegacy(value, catalog);
+    const xmp = "<x:xmpmeta>preserved</x:xmpmeta>\n";
+    const result = await installCatalogV3Migration(inputFor(value, {
+      parseCatalog,
+      onlineScan: {
+        complete: true,
+        xmpComplete: true,
+        observations: [
+          { relativePath: "edited/photo.JPG", byteLength: 100, modifiedAt: 10, observedAt: 11, localFileId: null, formatId: "jpeg" },
+          { relativePath: "scan-only.NEF", byteLength: 200, modifiedAt: 12, observedAt: 13, localFileId: "file-1", formatId: "nef" },
+          { relativePath: "archive/old.png", byteLength: 300, modifiedAt: 14, observedAt: 15, localFileId: null, formatId: "png" },
+        ],
+      },
+      xmpByRelativePath: {
+        "edited/photo.JPG": { state: "preserved", contents: xmp, modifiedAt: 30, sha256: digest(xmp) },
+      },
+    }));
+
+    assert.equal(result.phase, "registry-activated");
+    assert.deepEqual(result.before, {
+      metadataEntries: 1,
+      albums: 1,
+      albumMemberships: 2,
+      archiveReferences: 1,
+      distinctReferencedIds: 3,
+      scannedAssetCount: 3,
+      expectedTotalAssets: 4,
+      expectedPresentAssets: 3,
+      expectedMissingAssets: 1,
+      expectedAliases: 4,
+      offlineInventoryLimited: false,
+    });
+    assert.equal(result.after.assets, 4);
+    assert.equal(result.after.present, 3);
+    assert.equal(result.after.missing, 1);
+    assert.equal(result.after.archived, 1);
+    assert.equal(result.fingerprintCoverage.missing, 4);
+    assert.equal(result.fingerprintCoverage.valid, 0);
+    assert.deepEqual(await readFile(value.catalogPath), source.catalog);
+    assert.deepEqual(await readFile(value.settingsPath), source.settings);
+    assert.deepEqual(
+      await readFile(path.join(result.recoveryEvidence.directory, "catalog.json")),
+      source.catalog,
+    );
+    const assets = await readAssets(result.databasePath, value.catalogId);
+    const editedAsset = assets.find((asset) => asset.relativePath === "edited/photo.JPG");
+    assert.equal(editedAsset?.formatId, "jpeg");
+    assert.equal(editedAsset?.metadata.pick, "pick");
+    assert.equal(editedAsset?.metadata.rating, 4);
+    assert.equal(editedAsset?.metadata.developUpdatedAt, 22);
+    assert.equal(editedAsset?.metadata.updatedAt, 23);
+    assert.deepEqual(JSON.parse(editedAsset?.metadata.developJson ?? "null"), expectedDevelop);
+    assert.equal(editedAsset?.metadata.archive, false);
+    assert.equal(editedAsset?.metadata.rawXmp, xmp);
+    assert.equal(editedAsset?.metadata.xmpMtime, 30);
+    assert.equal(editedAsset?.metadata.xmpSha256, digest(xmp));
+    assert.equal(editedAsset?.fingerprintStatus, "missing");
+    const archivedAsset = assets.find((asset) => asset.relativePath === "archive/old.png");
+    assert.equal(archivedAsset?.metadata.archive, true);
+
+    let client: CatalogWorkerClient | undefined;
+    try {
+      client = workerClient();
+      await client.open(result.databasePath);
+      const albums = await client.v3Albums({
+        catalogId: value.catalogId,
+        expectedRevision: null,
+        cursor: null,
+        limit: 250,
+      });
+      const members = await client.v3AlbumAssetsPage({
+        catalogId: value.catalogId,
+        albumId: albums.albums[0]!.id,
+        expectedRevision: albums.revision,
+        cursor: null,
+        limit: 250,
+      });
+      assert.deepEqual(members.assets.map((item) => item.relativePath), [
+        "edited/photo.JPG",
+        "album/missing.jpeg",
+      ]);
+      assert.equal(albums.albums[0]?.createdAt, 4);
+      assert.equal(albums.albums[0]?.updatedAt, 5);
+    } finally {
+      await client?.shutdown().catch(() => client?.forceTerminate());
+    }
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("v2 offline installation creates recoverable placeholders and declares limits", async () => {
+  const value = await fixture();
+  try {
+    const metadata = legacyId("metadata.jpg");
+    const albumOnly = legacyId("album-only.jpg");
+    const archived = legacyId("archive-only.jpg");
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: "/photos",
+      entries: {
+        [metadata]: { pick: "none", rating: 0, colorLabel: null, developUpdatedAt: 0, updatedAt: 1 },
+      },
+      albums: [{ id: "album", name: "Offline", entryIds: [albumOnly], createdAt: 1, updatedAt: 2 }],
+      archivedEntryIds: [archived],
+    });
+    const result = await installCatalogV3Migration(inputFor(value));
+    assert.equal(result.after.assets, 3);
+    assert.equal(result.after.present, 0);
+    assert.equal(result.after.missing, 3);
+    assert.equal(result.after.archived, 1);
+    assert.deepEqual(result.limitations, [
+      "No asset has a proven digest; duplicate readiness is unavailable.",
+      "offline-v2-incomplete-inventory",
+      "offline-xmp-state-unknown",
+    ]);
+    const assets = await readAssets(result.databasePath, value.catalogId);
+    assert.equal(assets.every((asset) => asset.health === "missing"), true);
+    assert.equal(assets.every((asset) => asset.metadata.xmpState === "unknown"), true);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("one album preserves membership order across the 249-entry batch boundary", async () => {
+  const value = await fixture();
+  try {
+    const relativePaths = Array.from(
+      { length: 251 },
+      (_, index) => `batch/photo-${index.toString().padStart(3, "0")}.jpg`,
+    );
+    const entryIds = relativePaths.map(legacyId);
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: "/photos",
+      entries: {},
+      albums: [{
+        id: "large-album",
+        name: "Large album",
+        entryIds,
+        createdAt: 10,
+        updatedAt: 20,
+      }],
+      archivedEntryIds: [],
+    });
+    const result = await installCatalogV3Migration(inputFor(value));
+
+    let client: CatalogWorkerClient | undefined;
+    try {
+      client = workerClient();
+      await client.open(result.databasePath);
+      const albums = await client.v3Albums({
+        catalogId: value.catalogId,
+        expectedRevision: null,
+        cursor: null,
+        limit: 250,
+      });
+      const members: CatalogV3AlbumAssetSnapshot[] = [];
+      let cursor: number | null = null;
+      do {
+        const page = await client.v3AlbumAssetsPage({
+          catalogId: value.catalogId,
+          albumId: albums.albums[0]!.id,
+          expectedRevision: albums.revision,
+          cursor,
+          limit: 100,
+        });
+        members.push(...page.assets);
+        cursor = page.nextCursor;
+      } while (cursor !== null);
+      assert.equal(members.length, 251);
+      assert.deepEqual(members.map((member) => member.position), Array.from({ length: 251 }, (_, index) => index));
+      assert.deepEqual(members.map((member) => member.relativePath), relativePaths);
+    } finally {
+      await client?.shutdown().catch(() => client?.forceTerminate());
+    }
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("malformed catalog saves exact recovery evidence without a database or registry", async () => {
+  const value = await fixture();
+  try {
+    const malformed = Buffer.concat([
+      Buffer.from('{"version":2,"rootPath":"/photos","entries":{},"albums":[{"id":"a","name":"'),
+      Buffer.from([0xff]),
+      Buffer.from('","entryIds":[],"createdAt":0,"updatedAt":0}],"archivedEntryIds":[]}'),
+    ]);
+    await writeFile(value.catalogPath, malformed);
+    await writeFile(value.settingsPath, "{\"lastFolderPath\":\"/photos\"}\n");
+    await assert.rejects(installCatalogV3Migration(inputFor(value)), /not valid JSON/);
+    const recoveryPath = path.join(value.userDataPath, "catalog-migration-recovery", value.migrationId, "catalog.json");
+    assert.deepEqual(await readFile(recoveryPath), malformed);
+    await assert.rejects(access(path.join(value.userDataPath, "catalogs-v3", `${value.catalogId}.sqlite`)));
+    assert.deepEqual((await createCatalogRegistryStore(value.userDataPath).read()).catalogs, []);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("malformed settings save exact recovery evidence without activation", async () => {
+  const value = await fixture();
+  try {
+    const catalog = Buffer.from(
+      '{"version":2,"rootPath":"/photos","entries":{},"albums":[],"archivedEntryIds":[]}\n',
+      "utf8",
+    );
+    const malformedSettings = Buffer.concat([
+      Buffer.from('{"lastFolderPath":"/pho', "utf8"),
+      Buffer.from([0xff]),
+      Buffer.from('tos"}\n', "utf8"),
+    ]);
+    await writeFile(value.catalogPath, catalog);
+    await writeFile(value.settingsPath, malformedSettings);
+
+    await assert.rejects(installCatalogV3Migration(inputFor(value)), /settings source is not valid JSON/i);
+    const recoveryDirectory = path.join(
+      value.userDataPath,
+      "catalog-migration-recovery",
+      value.migrationId,
+    );
+    assert.deepEqual(await readFile(path.join(recoveryDirectory, "catalog.json")), catalog);
+    assert.deepEqual(await readFile(path.join(recoveryDirectory, "settings.json")), malformedSettings);
+    await assert.rejects(access(path.join(value.userDataPath, "catalogs-v3", `${value.catalogId}.sqlite`)));
+    assert.deepEqual((await createCatalogRegistryStore(value.userDataPath).read()).catalogs, []);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("a source mutation before recheck refuses activation", async () => {
+  const value = await fixture();
+  try {
+    const photoRoot = path.join(value.root, "photos");
+    await mkdir(photoRoot);
+    const entry = legacyId("photo.jpg");
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: photoRoot,
+      entries: { [entry]: { pick: "none", rating: 0, colorLabel: null, developUpdatedAt: 0, updatedAt: 1 } },
+      albums: [],
+      archivedEntryIds: [],
+    });
+    await assert.rejects(installCatalogV3Migration(inputFor(value, {
+      onlineScan: {
+        complete: true,
+        xmpComplete: false,
+        observations: [{ relativePath: "photo.jpg", byteLength: 1, modifiedAt: 1, observedAt: 1, localFileId: null, formatId: "jpg" }],
+      },
+      beforeSourceRecheck: async () => {
+        await writeFile(value.catalogPath, "{\"version\":2,\"rootPath\":\"/changed\",\"entries\":{},\"albums\":[],\"archivedEntryIds\":[]}\n");
+      },
+    })), /sources changed/);
+    await assert.rejects(access(path.join(value.userDataPath, "catalogs-v3", `${value.catalogId}.sqlite`)));
+    assert.deepEqual((await createCatalogRegistryStore(value.userDataPath).read()).catalogs, []);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("an interrupted asset copy retries with stable IDs and one registry entry", async () => {
+  const value = await fixture();
+  try {
+    const photoRoot = path.join(value.root, "photos");
+    await mkdir(photoRoot);
+    const entryIds = Array.from({ length: 251 }, (_, index) => legacyId(`photo-${index.toString().padStart(3, "0")}.jpg`));
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: photoRoot,
+      entries: Object.fromEntries(entryIds.map((entryId, index) => [
+        entryId,
+        { pick: "none", rating: 0, colorLabel: null, developUpdatedAt: 0, updatedAt: index + 1 },
+      ])),
+      albums: [{ id: "album", name: "Retry", entryIds: [entryIds[0], entryIds.at(-1)], createdAt: 1, updatedAt: 1 }],
+      archivedEntryIds: [],
+    });
+    const scan = {
+      complete: true as const,
+      xmpComplete: false,
+      observations: entryIds.map((_, index) => ({
+        relativePath: `photo-${index.toString().padStart(3, "0")}.jpg`,
+        byteLength: index + 1,
+        modifiedAt: index + 1,
+        observedAt: index + 1,
+        localFileId: null,
+        formatId: "jpeg",
+      })),
+    };
+    await assert.rejects(installCatalogV3Migration(inputFor(value, {
+      onlineScan: scan,
+      afterFirstAssetBatch: () => {
+        throw new Error("intentional interrupt");
+      },
+    })), /intentional interrupt/);
+    const stagePath = path.join(value.userDataPath, "catalogs-v3", `.${value.catalogId}.${value.migrationId}.sqlite.tmp`);
+    const stagedAssets = await readAssets(stagePath, value.catalogId);
+    assert.equal(stagedAssets.length, 250);
+    const stagedIds = new Map(stagedAssets.map((asset) => [asset.relativePath, asset.assetId]));
+    const changedScan = {
+      ...scan,
+      observations: scan.observations.map((observation, index) => index === 0
+        ? { ...observation, modifiedAt: observation.modifiedAt + 1 }
+        : observation),
+    };
+    await assert.rejects(
+      installCatalogV3Migration(inputFor(value, { onlineScan: changedScan })),
+      /envelope conflicts/,
+    );
+    const result = await installCatalogV3Migration(inputFor(value, { onlineScan: scan }));
+    const retry = await installCatalogV3Migration(inputFor(value, { onlineScan: scan }));
+    assert.equal(retry.databasePath, result.databasePath);
+    assert.equal(result.after.assets, 251);
+    const registry = await createCatalogRegistryStore(value.userDataPath).read();
+    assert.equal(registry.catalogs.length, 1);
+    const assets = await readAssets(result.databasePath, value.catalogId);
+    assert.equal(assets.length, 250);
+    assert.equal(assets.every((asset) => stagedIds.get(asset.relativePath) === asset.assetId), true);
+    await assert.rejects(access(stagePath));
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("an interrupted final publish removes the linked staging name and resumes", async () => {
+  const value = await fixture();
+  try {
+    const entry = legacyId("photo.jpg");
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: "/photos",
+      entries: { [entry]: { pick: "none", rating: 0, colorLabel: null, developUpdatedAt: 0, updatedAt: 1 } },
+      albums: [],
+      archivedEntryIds: [],
+    });
+    await assert.rejects(installCatalogV3Migration(inputFor(value, {
+      afterFinalDatabaseLink: () => {
+        throw new Error("intentional publish interrupt");
+      },
+    })), /intentional publish interrupt/);
+
+    const stagePath = path.join(value.userDataPath, "catalogs-v3", `.${value.catalogId}.${value.migrationId}.sqlite.tmp`);
+    const finalPath = path.join(value.userDataPath, "catalogs-v3", `${value.catalogId}.sqlite`);
+    await access(stagePath);
+    await access(finalPath);
+    assert.deepEqual((await createCatalogRegistryStore(value.userDataPath).read()).catalogs, []);
+
+    const result = await installCatalogV3Migration(inputFor(value));
+    assert.equal(result.phase, "registry-activated");
+    await assert.rejects(access(stagePath));
+    assert.equal((await createCatalogRegistryStore(value.userDataPath).read()).catalogs.length, 1);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("a source change after database sealing still blocks registry activation", async () => {
+  const value = await fixture();
+  try {
+    const entry = legacyId("photo.jpg");
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: "/photos",
+      entries: { [entry]: { pick: "none", rating: 0, colorLabel: null, developUpdatedAt: 0, updatedAt: 1 } },
+      albums: [],
+      archivedEntryIds: [],
+    });
+    await assert.rejects(installCatalogV3Migration(inputFor(value, {
+      afterFinalDatabaseLink: async () => {
+        await writeFile(value.catalogPath, '{"version":2,"rootPath":"/changed","entries":{},"albums":[],"archivedEntryIds":[]}\n');
+      },
+    })), /sources changed/);
+
+    await access(path.join(value.userDataPath, "catalogs-v3", `${value.catalogId}.sqlite`));
+    assert.deepEqual((await createCatalogRegistryStore(value.userDataPath).read()).catalogs, []);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("a final database retry recomputes exact migrated state before activation", async () => {
+  const value = await fixture();
+  try {
+    const entry = legacyId("photo.jpg");
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: "/photos",
+      entries: { [entry]: { pick: "none", rating: 0, colorLabel: null, developUpdatedAt: 0, updatedAt: 1 } },
+      albums: [],
+      archivedEntryIds: [],
+    });
+    await assert.rejects(installCatalogV3Migration(inputFor(value, {
+      beforeRegistryActivation: () => {
+        throw new Error("pause before registry");
+      },
+    })), /pause before registry/);
+
+    const finalPath = path.join(value.userDataPath, "catalogs-v3", `${value.catalogId}.sqlite`);
+    const database = new DatabaseSync(finalPath);
+    try {
+      database.prepare("UPDATE asset_metadata SET rating = 5 WHERE catalog_id = ?").run(value.catalogId);
+    } finally {
+      database.close();
+    }
+
+    await assert.rejects(
+      installCatalogV3Migration(inputFor(value)),
+      /final database no longer matches the frozen migration state/,
+    );
+    assert.deepEqual((await createCatalogRegistryStore(value.userDataPath).read()).catalogs, []);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("a post-commit registry interruption retries without duplicate activation", async () => {
+  const value = await fixture();
+  try {
+    const entry = legacyId("photo.jpg");
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: "/photos",
+      entries: { [entry]: { pick: "pick", rating: 3, colorLabel: null, developUpdatedAt: 0, updatedAt: 1 } },
+      albums: [],
+      archivedEntryIds: [],
+    });
+    await assert.rejects(installCatalogV3Migration(inputFor(value, {
+      afterRegistryActivation: () => {
+        throw new Error("intentional registry interrupt");
+      },
+    })), /intentional registry interrupt/);
+
+    const finalPath = path.join(value.userDataPath, "catalogs-v3", `${value.catalogId}.sqlite`);
+    await access(finalPath);
+    assert.equal((await createCatalogRegistryStore(value.userDataPath).read()).catalogs.length, 1);
+
+    const result = await installCatalogV3Migration(inputFor(value));
+    assert.equal(result.databasePath, finalPath);
+    assert.equal((await createCatalogRegistryStore(value.userDataPath).read()).catalogs.length, 1);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("preserved XMP with a mismatched digest never activates", async () => {
+  const value = await fixture();
+  try {
+    const entry = legacyId("photo.jpg");
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: "/photos",
+      entries: { [entry]: { pick: "none", rating: 0, colorLabel: null, developUpdatedAt: 0, updatedAt: 1 } },
+      albums: [],
+      archivedEntryIds: [],
+    });
+    await assert.rejects(installCatalogV3Migration(inputFor(value, {
+      xmpByRelativePath: {
+        "photo.jpg": {
+          state: "preserved",
+          contents: "<x:xmpmeta/>",
+          modifiedAt: 1,
+          sha256: "0".repeat(64),
+        },
+      },
+    })), /XMP evidence hash does not match/);
+    await assert.rejects(access(path.join(value.userDataPath, "catalogs-v3", `${value.catalogId}.sqlite`)));
+    assert.deepEqual((await createCatalogRegistryStore(value.userDataPath).read()).catalogs, []);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("an existing final path is never overwritten", async () => {
+  const value = await fixture();
+  try {
+    const entry = legacyId("photo.jpg");
+    await writeLegacy(value, {
+      version: 2,
+      rootPath: "/photos",
+      entries: { [entry]: { pick: "none", rating: 0, colorLabel: null, developUpdatedAt: 0, updatedAt: 1 } },
+      albums: [],
+      archivedEntryIds: [],
+    });
+    const finalDirectory = path.join(value.userDataPath, "catalogs-v3");
+    const finalPath = path.join(finalDirectory, `${value.catalogId}.sqlite`);
+    const original = Buffer.from("do not replace");
+    await mkdir(finalDirectory, { recursive: true });
+    await writeFile(finalPath, original, { flag: "wx" });
+    await assert.rejects(installCatalogV3Migration(inputFor(value)), /final database exists/);
+    assert.deepEqual(await readFile(finalPath), original);
+    assert.deepEqual((await createCatalogRegistryStore(value.userDataPath).read()).catalogs, []);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});

--- a/tests/catalog-v3-repository.test.mts
+++ b/tests/catalog-v3-repository.test.mts
@@ -1,0 +1,701 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  CatalogWorkerRequestError,
+  createCatalogWorkerTestClient,
+  type CatalogWorkerClient,
+} from "../electron/catalog-worker-client.ts";
+import {
+  parseCatalogWorkerRequest,
+  parseCatalogWorkerResponse,
+} from "../electron/catalog-worker-protocol.ts";
+import {
+  CATALOG_V3_TABLES,
+  verifyCatalogV3Schema,
+} from "../electron/catalog-v3-schema.ts";
+import { catalogV3ExpectedStateSha256 } from "../electron/catalog-v3-state.ts";
+import {
+  createCatalogId,
+  createOperationId,
+  createRootId,
+} from "../lib/catalog/ids.ts";
+
+function workerClient(): CatalogWorkerClient {
+  return createCatalogWorkerTestClient({
+    workerPath: path.resolve("electron/catalog-worker.ts"),
+    execArgv: ["--no-warnings", "--experimental-strip-types"],
+  });
+}
+
+function metadata(archive = false) {
+  return {
+    archive,
+    pick: "none" as const,
+    rating: 0 as const,
+    colorLabel: null,
+    developJson: null,
+    developUpdatedAt: 0,
+    updatedAt: 0,
+    title: null,
+    caption: null,
+    copyright: null,
+    keywordsJson: "[]",
+    rawXmp: null,
+    xmpState: "unknown" as const,
+    xmpMtime: null,
+    xmpSha256: null,
+  };
+}
+
+test("catalog v3 stages assets and ordered relations through the worker", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-catalog-v3-test-"));
+  let client: CatalogWorkerClient | undefined;
+  let direct: DatabaseSync | undefined;
+  try {
+    const databasePath = path.join(root, "catalog.db");
+    const catalogId = createCatalogId();
+    const rootId = createRootId();
+    const migrationId = createOperationId();
+    const missingPath = "😀-missing.jpg";
+    const presentPath = "\uE000-present.jpg";
+    const expectedCounts = {
+      assets: 2,
+      metadata: 2,
+      albums: 2,
+      albumAssets: 2,
+      archived: 1,
+      aliases: 4,
+      fingerprints: 2,
+      present: 1,
+      missing: 1,
+    };
+    const candidates = [
+      {
+        rootId,
+        relativePath: missingPath,
+        observation: null,
+        health: "missing" as const,
+        formatId: "jpg",
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        legacyIds: ["missing.jpg", "😀-alias", "\uE000-alias"],
+        metadata: metadata(),
+      },
+      {
+        rootId,
+        relativePath: presentPath,
+        observation: {
+          byteLength: 10,
+          modifiedAt: 20,
+          observedAt: 30,
+          localFileId: null,
+        },
+        health: "present" as const,
+        formatId: "jpg",
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        legacyIds: ["present.jpg"],
+        metadata: metadata(),
+      },
+    ];
+    const expectedStateSha256 = catalogV3ExpectedStateSha256({
+      assets: candidates,
+      albums: [
+        {
+          id: "z-first",
+          name: "First",
+          createdAt: -20,
+          updatedAt: -15,
+          position: 0,
+          entryIds: [],
+        },
+        {
+          id: "a-second",
+          name: "Ordered",
+          createdAt: -10,
+          updatedAt: -5,
+          position: 1,
+          entryIds: ["present.jpg", "missing.jpg"],
+        },
+      ],
+      archiveLegacyIds: ["missing.jpg"],
+    });
+    const reorderedStateSha256 = catalogV3ExpectedStateSha256({
+      assets: candidates,
+      albums: [
+        {
+          id: "a-second",
+          name: "Ordered",
+          createdAt: -10,
+          updatedAt: -5,
+          position: 0,
+          entryIds: ["present.jpg", "missing.jpg"],
+        },
+        {
+          id: "z-first",
+          name: "First",
+          createdAt: -20,
+          updatedAt: -15,
+          position: 1,
+          entryIds: [],
+        },
+      ],
+      archiveLegacyIds: ["missing.jpg"],
+    });
+    assert.notEqual(reorderedStateSha256, expectedStateSha256);
+    client = workerClient();
+    await client.open(databasePath);
+    const install = await client.installV3({
+      catalogId,
+      displayName: "Test catalog",
+      appVersion: "test",
+      root: {
+        rootId,
+        label: "Test root",
+        configuredPath: root,
+        canonicalPath: root,
+        health: "online",
+        scanState: "complete",
+        watchState: "disabled",
+      },
+      migration: {
+        migrationId,
+        sourceVersion: 2,
+        catalogPath: path.join(root, "legacy.json"),
+        settingsPath: null,
+        catalogSha256: "a".repeat(64),
+        settingsSha256: null,
+        rootAvailable: true,
+        expectedCounts,
+        expectedStateSha256,
+      },
+    });
+    assert.equal(install.created, true);
+    assert.equal(install.installState, "staging");
+
+    direct = new DatabaseSync(databasePath);
+    direct.exec("PRAGMA foreign_keys = ON;");
+    assert.deepEqual(verifyCatalogV3Schema(direct).tables, CATALOG_V3_TABLES);
+    const indexNames = direct.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_%'",
+    ).all().map((row) => Reflect.get(row, "name"));
+    assert.equal(indexNames.includes("fingerprints_by_catalog_digest"), true);
+    assert.equal(indexNames.includes("migration_aliases_by_asset"), true);
+    assert.equal(indexNames.includes("auto_import_one_enabled_per_catalog"), true);
+    assert.throws(() => direct.prepare(`
+      INSERT INTO roots (
+        catalog_id, root_id, label, configured_path, canonical_path,
+        health, scan_state, watch_state
+      ) VALUES (?, ?, ?, ?, ?, 'missing', 'unknown', 'disabled')
+    `).run(createCatalogId(), createRootId(), "Other root", root, null));
+    direct.close();
+    direct = undefined;
+
+    const firstAssets = await client.writeV3AssetBatch({ catalogId, migrationId, assets: candidates });
+    const retryAssets = await client.writeV3AssetBatch({ catalogId, migrationId, assets: candidates });
+    assert.equal(retryAssets.revision, firstAssets.revision);
+    assert.deepEqual(
+      retryAssets.assets.map((asset) => [asset.relativePath, asset.assetId, asset.fingerprintId]),
+      firstAssets.assets.map((asset) => [asset.relativePath, asset.assetId, asset.fingerprintId]),
+    );
+
+    const firstRelations = await client.writeV3RelationsBatch({
+      catalogId,
+      migrationId,
+      albums: [
+        {
+          id: "z-first",
+          name: "First",
+          createdAt: -20,
+          updatedAt: -15,
+          position: 0,
+          positionOffset: 0,
+          entryIds: [],
+        },
+        {
+          id: "a-second",
+          name: "Ordered",
+          createdAt: -10,
+          updatedAt: -5,
+          position: 1,
+          positionOffset: 0,
+          entryIds: ["present.jpg"],
+        },
+      ],
+      archiveLegacyIds: ["missing.jpg"],
+    });
+    assert.equal(firstRelations.albums, 2);
+    assert.equal(firstRelations.albumAssets, 1);
+    assert.equal(firstRelations.archived, 1);
+    const secondRelations = await client.writeV3RelationsBatch({
+      catalogId,
+      migrationId,
+      albums: [{
+        id: "a-second",
+        name: "Ordered",
+        createdAt: -10,
+        updatedAt: -5,
+        position: 1,
+        positionOffset: 1,
+        entryIds: ["missing.jpg"],
+      }],
+      archiveLegacyIds: [],
+    });
+    assert.equal(secondRelations.albums, 1);
+    assert.equal(secondRelations.albumAssets, 1);
+    assert.equal(secondRelations.archived, 0);
+    await client.finishV3Copy(catalogId, migrationId);
+    const validation = await client.validateV3(catalogId, migrationId);
+    assert.equal(validation.phase, "validated");
+    assert.equal(validation.report.clean, true);
+    assert.deepEqual(validation.report.integrity.foreignKeyCheck, []);
+    assert.deepEqual(validation.report.fingerprintCoverage, {
+      total: 2,
+      missing: 2,
+      hashing: 0,
+      valid: 0,
+      stale: 0,
+      failed: 0,
+    });
+    const activation = await client.prepareV3Activation(catalogId, migrationId);
+    assert.equal(activation.installState, "ready");
+    const seal = await client.sealV3ForInstall(catalogId, migrationId);
+    assert.equal(seal.busy, 0);
+    assert.equal(seal.journalMode, "delete");
+
+    const summary = await client.v3Summary(catalogId);
+    assert.equal(summary.installState, "ready");
+    assert.deepEqual(
+      {
+        assets: summary.counts.assets,
+        present: summary.counts.present,
+        missing: summary.counts.missing,
+        archived: summary.counts.archived,
+      },
+      { assets: 2, present: 1, missing: 1, archived: 1 },
+    );
+    const firstAlbumPage = await client.v3Albums({
+      catalogId,
+      expectedRevision: summary.revision,
+      cursor: null,
+      limit: 1,
+    });
+    assert.deepEqual(firstAlbumPage.albums.map((album) => album.id), ["z-first"]);
+    assert.equal(firstAlbumPage.nextCursor, 0);
+    const secondAlbumPage = await client.v3Albums({
+      catalogId,
+      expectedRevision: firstAlbumPage.revision,
+      cursor: firstAlbumPage.nextCursor,
+      limit: 1,
+    });
+    assert.deepEqual(secondAlbumPage.albums.map((album) => album.id), ["a-second"]);
+    assert.deepEqual(secondAlbumPage.albums.map((album) => album.position), [1]);
+    assert.equal(secondAlbumPage.nextCursor, null);
+    const firstMemberPage = await client.v3AlbumAssetsPage({
+      catalogId,
+      albumId: "a-second",
+      expectedRevision: secondAlbumPage.revision,
+      cursor: null,
+      limit: 1,
+    });
+    assert.deepEqual(firstMemberPage.assets.map((item) => item.relativePath), [presentPath]);
+    assert.equal(firstMemberPage.nextCursor, 0);
+    const secondMemberPage = await client.v3AlbumAssetsPage({
+      catalogId,
+      albumId: "a-second",
+      expectedRevision: firstMemberPage.revision,
+      cursor: firstMemberPage.nextCursor,
+      limit: 1,
+    });
+    assert.deepEqual(secondMemberPage.assets.map((item) => item.relativePath), [missingPath]);
+    assert.deepEqual(secondMemberPage.assets.map((item) => item.position), [1]);
+    assert.equal(secondMemberPage.nextCursor, null);
+    await client.shutdown();
+    client = undefined;
+    await assert.rejects(access(`${databasePath}-wal`));
+    await assert.rejects(access(`${databasePath}-shm`));
+  } finally {
+    direct?.close();
+    await client?.forceTerminate().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("catalog v3 validation rejects wrong same-count metadata, album, and archive state", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-catalog-v3-state-test-"));
+  let client: CatalogWorkerClient | undefined;
+  try {
+    const catalogId = createCatalogId();
+    const rootId = createRootId();
+    const migrationId = createOperationId();
+    const candidate = (relativePath: string, rating: 1 | 2, developJson: string) => ({
+      rootId,
+      relativePath,
+      observation: null,
+      health: "missing" as const,
+      formatId: "jpg",
+      cameraMake: null,
+      cameraModel: null,
+      lensModel: null,
+      legacyIds: [relativePath],
+      metadata: { ...metadata(), rating, developJson },
+    });
+    const expectedAssets = [candidate("a.jpg", 1, '{"exposure":1}'), candidate("b.jpg", 2, '{"exposure":2}')];
+    const expectedStateSha256 = catalogV3ExpectedStateSha256({
+      assets: expectedAssets,
+      albums: [{
+        id: "album",
+        name: "Album",
+        createdAt: 1,
+        updatedAt: 2,
+        position: 0,
+        entryIds: ["a.jpg"],
+      }],
+      archiveLegacyIds: ["a.jpg"],
+    });
+
+    client = workerClient();
+    await client.open(path.join(root, "catalog.db"));
+    await client.installV3({
+      catalogId,
+      displayName: "State mismatch",
+      appVersion: "test",
+      root: {
+        rootId,
+        label: "Missing root",
+        configuredPath: root,
+        canonicalPath: null,
+        health: "missing",
+        scanState: "unknown",
+        watchState: "disabled",
+      },
+      migration: {
+        migrationId,
+        sourceVersion: 2,
+        catalogPath: path.join(root, "legacy.json"),
+        settingsPath: null,
+        catalogSha256: "c".repeat(64),
+        settingsSha256: null,
+        rootAvailable: false,
+        expectedCounts: {
+          assets: 2,
+          metadata: 2,
+          albums: 1,
+          albumAssets: 1,
+          archived: 1,
+          aliases: 2,
+          fingerprints: 2,
+          present: 0,
+          missing: 2,
+        },
+        expectedStateSha256,
+      },
+    });
+    await client.writeV3AssetBatch({
+      catalogId,
+      migrationId,
+      assets: [candidate("a.jpg", 2, '{"exposure":2}'), candidate("b.jpg", 1, '{"exposure":1}')],
+    });
+    await client.writeV3RelationsBatch({
+      catalogId,
+      migrationId,
+      albums: [{
+        id: "album",
+        name: "Album",
+        createdAt: 1,
+        updatedAt: 2,
+        position: 0,
+        positionOffset: 0,
+        entryIds: ["b.jpg"],
+      }],
+      archiveLegacyIds: ["b.jpg"],
+    });
+    await client.finishV3Copy(catalogId, migrationId);
+    const validation = await client.validateV3(catalogId, migrationId);
+    assert.equal(validation.phase, "failed");
+    assert.equal(validation.report.clean, false);
+    assert.notEqual(validation.report.actualStateSha256, expectedStateSha256);
+    assert.equal(
+      validation.report.blockingErrors.includes("Catalog v3 migrated state does not match the frozen migration plan."),
+      true,
+    );
+  } finally {
+    await client?.forceTerminate().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("catalog v3 validation rejects every non-missing fingerprint state", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-catalog-v3-fingerprint-test-"));
+  let client: CatalogWorkerClient | undefined;
+  try {
+    const catalogId = createCatalogId();
+    const rootId = createRootId();
+    const migrationId = createOperationId();
+    const asset = {
+      rootId,
+      relativePath: "asset.jpg",
+      observation: null,
+      health: "missing" as const,
+      formatId: "jpg",
+      cameraMake: null,
+      cameraModel: null,
+      lensModel: null,
+      legacyIds: ["asset.jpg"],
+      metadata: metadata(),
+      fingerprint: {
+        status: "hashing" as const,
+        sha256: null,
+        observedAt: null,
+        observedByteLength: null,
+        observedModifiedAt: null,
+        localFileId: null,
+      },
+    };
+    const expectedStateSha256 = catalogV3ExpectedStateSha256({
+      assets: [asset],
+      albums: [],
+      archiveLegacyIds: [],
+    });
+
+    client = workerClient();
+    await client.open(path.join(root, "catalog.db"));
+    await client.installV3({
+      catalogId,
+      displayName: "Fingerprint gate",
+      appVersion: "test",
+      root: {
+        rootId,
+        label: "Missing root",
+        configuredPath: root,
+        canonicalPath: null,
+        health: "missing",
+        scanState: "unknown",
+        watchState: "disabled",
+      },
+      migration: {
+        migrationId,
+        sourceVersion: 2,
+        catalogPath: path.join(root, "legacy.json"),
+        settingsPath: null,
+        catalogSha256: "d".repeat(64),
+        settingsSha256: null,
+        rootAvailable: false,
+        expectedCounts: {
+          assets: 1,
+          metadata: 1,
+          albums: 0,
+          albumAssets: 0,
+          archived: 0,
+          aliases: 1,
+          fingerprints: 1,
+          present: 0,
+          missing: 1,
+        },
+        expectedStateSha256,
+      },
+    });
+    await client.writeV3AssetBatch({ catalogId, migrationId, assets: [asset] });
+    await client.finishV3Copy(catalogId, migrationId);
+    const validation = await client.validateV3(catalogId, migrationId);
+    assert.equal(validation.phase, "failed");
+    assert.equal(validation.report.actualStateSha256, expectedStateSha256);
+    assert.equal(
+      validation.report.blockingErrors.includes(
+        "Every legacy migration fingerprint must remain missing until post-migration hashing.",
+      ),
+      true,
+    );
+  } finally {
+    await client?.forceTerminate().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("catalog v3 snapshots bind revision and reject stale pages", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-catalog-v3-page-test-"));
+  let client: CatalogWorkerClient | undefined;
+  try {
+    const catalogId = createCatalogId();
+    const rootId = createRootId();
+    const migrationId = createOperationId();
+    const asset = (relativePath: string) => ({
+      rootId,
+      relativePath,
+      observation: {
+        byteLength: 1,
+        modifiedAt: 1,
+        observedAt: 1,
+        localFileId: null,
+      },
+      health: "present" as const,
+      formatId: "jpg",
+      cameraMake: null,
+      cameraModel: null,
+      lensModel: null,
+      legacyIds: [relativePath],
+      metadata: metadata(),
+    });
+    const candidates = [asset("a.jpg"), asset("b.jpg")];
+    client = workerClient();
+    await client.open(path.join(root, "catalog.db"));
+    await client.installV3({
+      catalogId,
+      displayName: "Page test",
+      appVersion: "test",
+      root: {
+        rootId,
+        label: "Page root",
+        configuredPath: root,
+        canonicalPath: root,
+        health: "online",
+        scanState: "complete",
+        watchState: "disabled",
+      },
+      migration: {
+        migrationId,
+        sourceVersion: 1,
+        catalogPath: path.join(root, "legacy.json"),
+        settingsPath: null,
+        catalogSha256: "b".repeat(64),
+        settingsSha256: null,
+        rootAvailable: true,
+        expectedCounts: {
+          assets: 2,
+          metadata: 2,
+          albums: 0,
+          albumAssets: 0,
+          archived: 0,
+          aliases: 2,
+          fingerprints: 2,
+          present: 2,
+          missing: 0,
+        },
+        expectedStateSha256: catalogV3ExpectedStateSha256({
+          assets: candidates,
+          albums: [],
+          archiveLegacyIds: [],
+        }),
+      },
+    });
+    await client.writeV3AssetBatch({ catalogId, migrationId, assets: candidates });
+    const first = await client.v3AssetsPage({ catalogId, expectedRevision: null, cursor: null, limit: 1 });
+    assert.equal(first.assets.length, 1);
+    assert.notEqual(first.nextCursor, null);
+    await client.writeV3AssetBatch({
+      catalogId,
+      migrationId,
+      assets: [{ ...asset("a.jpg"), formatId: "jpeg" }],
+    });
+    const updated = await client.v3AssetsPage({ catalogId, expectedRevision: null, cursor: null, limit: 1 });
+    assert.equal(updated.assets[0]?.revision, 2);
+    await client.writeV3AssetBatch({
+      catalogId,
+      migrationId,
+      assets: [{
+        ...asset("a.jpg"),
+        formatId: "jpeg",
+        fingerprint: {
+          status: "hashing" as const,
+          sha256: null,
+          observedAt: 1,
+          observedByteLength: 1,
+          observedModifiedAt: 1,
+          localFileId: null,
+        },
+      }],
+    });
+    const fingerprintUpdated = await client.v3AssetsPage({ catalogId, expectedRevision: null, cursor: null, limit: 1 });
+    assert.equal(fingerprintUpdated.assets[0]?.revision, 3);
+    await assert.rejects(
+      client.v3AssetsPage({ catalogId, expectedRevision: first.revision, cursor: first.nextCursor, limit: 1 }),
+      (error: unknown) => error instanceof CatalogWorkerRequestError && error.code === "runtime",
+    );
+    await client.shutdown();
+    client = undefined;
+  } finally {
+    await client?.forceTerminate().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("catalog v3 protocol rejects malformed requests and responses", () => {
+  const catalogId = createCatalogId();
+  const migrationId = createOperationId();
+  assert.throws(() => parseCatalogWorkerRequest({
+    kind: "v3-assets",
+    requestId: "request",
+    input: {
+      catalogId,
+      migrationId,
+      assets: Array.from({ length: 251 }, (_, index) => ({
+        rootId: createRootId(),
+        relativePath: `asset-${index}.jpg`,
+        observation: null,
+        health: "missing",
+        formatId: "jpg",
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        legacyIds: [],
+        metadata: null,
+      })),
+    },
+  }));
+  assert.throws(() => parseCatalogWorkerRequest({
+    kind: "v3-assets-page",
+    requestId: "request",
+    input: { catalogId, expectedRevision: null, cursor: "not-a-cursor", limit: 1 },
+  }));
+  assert.throws(() => parseCatalogWorkerRequest({
+    kind: "v3-relations",
+    requestId: "request",
+    input: {
+      catalogId,
+      migrationId,
+      albums: Array.from({ length: 251 }, (_, index) => ({
+        id: `album-${index}`,
+        name: "",
+        createdAt: 0,
+        updatedAt: 0,
+        position: index,
+        positionOffset: 0,
+        entryIds: [],
+      })),
+      archiveLegacyIds: [],
+    },
+  }));
+  assert.throws(() => parseCatalogWorkerResponse({
+    kind: "v3-summary",
+    requestId: "request",
+    result: { catalogId },
+  }));
+  assert.throws(() => parseCatalogWorkerResponse({
+    kind: "v3-assets-page",
+    requestId: "request",
+    result: {
+      catalogId,
+      revision: 0,
+      assets: [],
+      nextCursor: "not-a-cursor",
+    },
+  }));
+  assert.throws(() => parseCatalogWorkerResponse({
+    kind: "v3-seal-for-install",
+    requestId: "request",
+    result: {
+      catalogId,
+      migrationId,
+      busy: 1,
+      logFrames: 0,
+      checkpointedFrames: 0,
+      journalMode: "delete",
+    },
+  }));
+});

--- a/tests/catalog-v3-state.test.mts
+++ b/tests/catalog-v3-state.test.mts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  catalogV3StateSha256,
+  type CatalogV3State,
+  type CatalogV3StateAsset,
+} from "../electron/catalog-v3-state.ts";
+import { createRootId } from "../lib/catalog/ids.ts";
+
+function replaceFirstAsset(
+  state: CatalogV3State,
+  replace: (asset: CatalogV3StateAsset) => CatalogV3StateAsset,
+): CatalogV3State {
+  const first = state.assets[0];
+  if (first === undefined) throw new Error("State fixture needs an asset.");
+  return { ...state, assets: [replace(first), ...state.assets.slice(1)] };
+}
+
+function stateFixture(): CatalogV3State {
+  const rootId = createRootId();
+  return {
+    assets: [
+      {
+        rootId,
+        relativePath: "a.jpg",
+        observation: { byteLength: 10, modifiedAt: 20, observedAt: 30, localFileId: "file-a" },
+        health: "present",
+        formatId: "jpeg",
+        cameraMake: "Make",
+        cameraModel: "Model",
+        lensModel: "Lens",
+        legacyIds: ["a.jpg"],
+        metadata: {
+          archive: true,
+          pick: "pick",
+          rating: 4,
+          colorLabel: "red",
+          developJson: '{"version":2,"settings":{"basic":{"exposure":1.25}},"maskAssets":{}}',
+          developUpdatedAt: 40,
+          updatedAt: 41,
+          title: "Title",
+          caption: "Caption",
+          copyright: "Copyright",
+          keywordsJson: '["one","two"]',
+          rawXmp: "<x:xmpmeta>one</x:xmpmeta>",
+          xmpState: "preserved",
+          xmpMtime: 42,
+          xmpSha256: "a".repeat(64),
+        },
+        fingerprint: {
+          status: "missing",
+          sha256: null,
+          observedAt: 30,
+          observedByteLength: 10,
+          observedModifiedAt: 20,
+          localFileId: "file-a",
+        },
+      },
+      {
+        rootId,
+        relativePath: "b.jpg",
+        observation: null,
+        health: "missing",
+        formatId: "jpeg",
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        legacyIds: ["b.jpg"],
+        metadata: {
+          archive: false,
+          pick: "none",
+          rating: 0,
+          colorLabel: null,
+          developJson: null,
+          developUpdatedAt: 0,
+          updatedAt: 0,
+          title: null,
+          caption: null,
+          copyright: null,
+          keywordsJson: "[]",
+          rawXmp: null,
+          xmpState: "absent",
+          xmpMtime: null,
+          xmpSha256: null,
+        },
+        fingerprint: {
+          status: "missing",
+          sha256: null,
+          observedAt: null,
+          observedByteLength: null,
+          observedModifiedAt: null,
+          localFileId: null,
+        },
+      },
+    ],
+    albums: [
+      {
+        id: "z-first",
+        name: "First",
+        createdAt: 1,
+        updatedAt: 2,
+        position: 0,
+        members: [
+          { rootId, relativePath: "a.jpg" },
+          { rootId, relativePath: "b.jpg" },
+        ],
+      },
+      {
+        id: "a-second",
+        name: "Second",
+        createdAt: 3,
+        updatedAt: 4,
+        position: 1,
+        members: [],
+      },
+    ],
+  };
+}
+
+test("catalog v3 state digest changes for every protected migration field", () => {
+  const base = stateFixture();
+  const digest = catalogV3StateSha256(base);
+  assert.equal(catalogV3StateSha256(structuredClone(base)), digest);
+
+  const mutations: readonly [string, (state: CatalogV3State) => CatalogV3State][] = [
+    ["alias association", (state) => ({
+      ...state,
+      assets: [
+        { ...state.assets[0]!, legacyIds: ["b.jpg"] },
+        { ...state.assets[1]!, legacyIds: ["a.jpg"] },
+      ],
+    })],
+    ["metadata", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      metadata: { ...asset.metadata, rating: 3 },
+    }))],
+    ["full Develop JSON", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      metadata: { ...asset.metadata, developJson: asset.metadata.developJson?.replace("1.25", "-0.5") ?? null },
+    }))],
+    ["raw XMP", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      metadata: { ...asset.metadata, rawXmp: "<x:xmpmeta>two</x:xmpmeta>" },
+    }))],
+    ["XMP state", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      metadata: { ...asset.metadata, rawXmp: null, xmpState: "unknown" },
+    }))],
+    ["XMP digest", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      metadata: { ...asset.metadata, xmpSha256: "b".repeat(64) },
+    }))],
+    ["XMP mtime", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      metadata: { ...asset.metadata, xmpMtime: 43 },
+    }))],
+    ["archive target", (state) => ({
+      ...state,
+      assets: [
+        { ...state.assets[0]!, metadata: { ...state.assets[0]!.metadata, archive: false } },
+        { ...state.assets[1]!, metadata: { ...state.assets[1]!.metadata, archive: true } },
+      ],
+    })],
+    ["album list order", (state) => ({
+      ...state,
+      albums: [
+        { ...state.albums[1]!, position: 0 },
+        { ...state.albums[0]!, position: 1 },
+      ],
+    })],
+    ["album member order", (state) => ({
+      ...state,
+      albums: [{ ...state.albums[0]!, members: [...state.albums[0]!.members].reverse() }, ...state.albums.slice(1)],
+    })],
+    ["observed byte length", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      observation: { ...asset.observation!, byteLength: 11 },
+    }))],
+    ["observed mtime", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      observation: { ...asset.observation!, modifiedAt: 21 },
+    }))],
+    ["observation time", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      observation: { ...asset.observation!, observedAt: 31 },
+    }))],
+    ["local file ID", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      observation: { ...asset.observation!, localFileId: "file-b" },
+    }))],
+    ["fingerprint status", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      fingerprint: { ...asset.fingerprint, status: "hashing" },
+    }))],
+    ["fingerprint evidence", (state) => replaceFirstAsset(state, (asset) => ({
+      ...asset,
+      fingerprint: { ...asset.fingerprint, observedByteLength: 11 },
+    }))],
+  ];
+
+  for (const [label, mutate] of mutations) {
+    assert.notEqual(catalogV3StateSha256(mutate(base)), digest, label);
+  }
+});

--- a/tests/catalog-worker.test.mts
+++ b/tests/catalog-worker.test.mts
@@ -18,7 +18,9 @@ import {
   createCatalogId,
   createAssetId,
   createOperationId,
+  createRootId,
 } from "../lib/catalog/ids.ts";
+import { CATALOG_V3_APPLICATION_ID } from "../lib/catalog/v3.ts";
 import {
   createCatalogRegistryStore,
   parseCatalogRegistry,
@@ -87,12 +89,373 @@ test("worker protocol rejects unknown request and response shapes", () => {
   assert.throws(() => parseCatalogWorkerRequest({ kind: "open", requestId: "x", databasePath: "relative.db" }));
   assert.throws(() => parseCatalogWorkerResponse({ kind: "not-a-response", requestId: "x" }));
   assert.throws(() => parseCatalogWorkerResponse({ kind: "error", requestId: null, code: "wat", message: "no" }));
+  const catalogId = createCatalogId();
+  const migrationId = createOperationId();
+  assert.throws(() => parseCatalogWorkerResponse({
+    kind: "v3-assets",
+    requestId: "request",
+    result: {
+      catalogId,
+      migrationId,
+      revision: 0,
+      assets: [null],
+    },
+  }));
+  assert.throws(() => parseCatalogWorkerResponse({
+    kind: "v3-assets-page",
+    requestId: "request",
+    result: {
+      catalogId,
+      revision: 0,
+      assets: [null],
+      nextCursor: null,
+    },
+  }));
+
+  const expectedCounts = {
+    assets: 1,
+    metadata: 1,
+    albums: 0,
+    albumAssets: 0,
+    archived: 0,
+    aliases: 1,
+    fingerprints: 1,
+    present: 0,
+    missing: 1,
+  };
+  const cleanReport = {
+    catalogId,
+    migrationId,
+    clean: true,
+    before: expectedCounts,
+    after: { ...expectedCounts, ambiguous: 0, unreadable: 0 },
+    fingerprintCoverage: { total: 1, missing: 1, hashing: 0, valid: 0, stale: 0, failed: 0 },
+    expectedStateSha256: "a".repeat(64),
+    actualStateSha256: "a".repeat(64),
+    relationFailures: { aliases: 0, albums: 0, albumAssets: 0, archived: 0 },
+    integrity: { integrityCheck: ["ok"], foreignKeyCheck: [] },
+    applicationId: CATALOG_V3_APPLICATION_ID,
+    schemaVersion: 3,
+    userVersion: 3,
+    limitations: ["No asset has a proven digest; duplicate readiness is unavailable."],
+    blockingErrors: [],
+  };
+  const contradictoryReports = [
+    { ...cleanReport, actualStateSha256: "b".repeat(64) },
+    {
+      ...cleanReport,
+      fingerprintCoverage: { total: 1, missing: 0, hashing: 1, valid: 0, stale: 0, failed: 0 },
+    },
+    { ...cleanReport, blockingErrors: ["contradiction"] },
+  ];
+  for (const report of contradictoryReports) {
+    assert.throws(() => parseCatalogWorkerResponse({
+      kind: "v3-validate",
+      requestId: "request",
+      result: { catalogId, migrationId, phase: "validated", report, revision: 0 },
+    }));
+  }
+
+  const asset = {
+    catalogId,
+    assetId: createAssetId(),
+    rootId: createRootId(),
+    relativePath: "asset.jpg",
+    observation: { byteLength: 1, modifiedAt: 2, observedAt: 3, localFileId: null },
+    revision: 1,
+    health: "missing",
+    formatId: "jpeg",
+    cameraMake: null,
+    cameraModel: null,
+    lensModel: null,
+    fingerprintId: createAssetId(),
+    fingerprintStatus: "missing",
+    fingerprintSha256: null,
+    fingerprintObservedAt: 3,
+    fingerprintObservedByteLength: 1,
+    fingerprintObservedModifiedAt: 2,
+    fingerprintLocalFileId: null,
+    metadata: {
+      archive: false,
+      pick: "none",
+      rating: 0,
+      colorLabel: null,
+      developJson: null,
+      developUpdatedAt: 0,
+      updatedAt: 0,
+      title: null,
+      caption: null,
+      copyright: null,
+      keywordsJson: "[]",
+      rawXmp: null,
+      xmpState: "unknown",
+      xmpMtime: null,
+      xmpSha256: null,
+    },
+  };
+  assert.throws(() => parseCatalogWorkerResponse({
+    kind: "v3-assets-page",
+    requestId: "request",
+    result: { catalogId, revision: 1, assets: [asset], nextCursor: null },
+  }));
+
+  const album = (id: string, position: number) => ({
+    catalogId,
+    id,
+    name: id,
+    createdAt: 0,
+    updatedAt: 0,
+    position,
+  });
+  assert.throws(() => parseCatalogWorkerResponse({
+    kind: "v3-albums",
+    requestId: "request",
+    result: {
+      catalogId,
+      revision: 1,
+      albums: [album("first", 0), album("second", 2)],
+      nextCursor: null,
+    },
+  }));
+  assert.throws(() => parseCatalogWorkerResponse({
+    kind: "v3-album-assets-page",
+    requestId: "request",
+    result: {
+      catalogId,
+      albumId: "album",
+      revision: 1,
+      assets: [{
+        position: 0,
+        assetId: asset.assetId,
+        rootId: asset.rootId,
+        relativePath: "../escape.jpg",
+        health: "missing",
+        revision: 1,
+      }],
+      nextCursor: null,
+    },
+  }));
+});
+
+test("catalog worker client rejects valid v3 responses with mismatched identities", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-catalog-worker-identity-test-"));
+  let client: CatalogWorkerClient | undefined;
+  try {
+    const fakeWorkerPath = path.join(root, "mismatched-worker.mjs");
+    await writeFile(fakeWorkerPath, `
+      import { parentPort } from "node:worker_threads";
+      const wrongCatalogId = "00000000-0000-4000-8000-000000000001";
+      const wrongMigrationId = "00000000-0000-4000-8000-000000000002";
+      const rootId = "00000000-0000-4000-8000-000000000003";
+      const rootPath = ${JSON.stringify(root)};
+      const zeroCounts = {
+        assets: 0, metadata: 0, albums: 0, albumAssets: 0, archived: 0,
+        aliases: 0, fingerprints: 0, present: 0, missing: 0,
+      };
+      const counts = { ...zeroCounts, ambiguous: 0, unreadable: 0 };
+      const fingerprintCoverage = { total: 0, missing: 0, hashing: 0, valid: 0, stale: 0, failed: 0 };
+      const migration = {
+        migrationId: wrongMigrationId,
+        sourceVersion: 2,
+        catalogPath: ${JSON.stringify(path.join(root, "legacy.json"))},
+        settingsPath: null,
+        catalogSha256: "a".repeat(64),
+        settingsSha256: null,
+        rootAvailable: true,
+        expectedCounts: zeroCounts,
+        expectedStateSha256: "b".repeat(64),
+      };
+      const validationReport = {
+        catalogId: wrongCatalogId,
+        migrationId: wrongMigrationId,
+        clean: true,
+        before: zeroCounts,
+        after: counts,
+        fingerprintCoverage,
+        expectedStateSha256: "b".repeat(64),
+        actualStateSha256: "b".repeat(64),
+        relationFailures: { aliases: 0, albums: 0, albumAssets: 0, archived: 0 },
+        integrity: { integrityCheck: ["ok"], foreignKeyCheck: [] },
+        applicationId: 1146243891,
+        schemaVersion: 3,
+        userVersion: 3,
+        limitations: [],
+        blockingErrors: [],
+      };
+      parentPort.on("message", (request) => {
+        let result;
+        if (request.kind === "v3-install") {
+          result = { catalogId: wrongCatalogId, migrationId: request.input.migration.migrationId,
+            created: true, installState: "staging", revision: 0, schemaVersion: 3 };
+        } else if (request.kind === "v3-assets") {
+          result = { catalogId: request.input.catalogId, migrationId: wrongMigrationId, revision: 0, assets: [] };
+        } else if (request.kind === "v3-relations") {
+          result = { catalogId: request.input.catalogId, migrationId: wrongMigrationId, revision: 0,
+            albums: 0, albumAssets: 0, archived: 0 };
+        } else if (request.kind === "v3-finish-copy") {
+          result = { catalogId: request.catalogId, migrationId: wrongMigrationId, phase: "copied", revision: 0 };
+        } else if (request.kind === "v3-validate") {
+          result = { catalogId: wrongCatalogId, migrationId: wrongMigrationId, phase: "validated",
+            report: validationReport, revision: 0 };
+        } else if (request.kind === "v3-prepare-activation") {
+          result = { catalogId: request.catalogId, migrationId: wrongMigrationId,
+            installState: "ready", revision: 0 };
+        } else if (request.kind === "v3-seal-for-install") {
+          result = { catalogId: request.catalogId, migrationId: wrongMigrationId, busy: 0,
+            logFrames: 0, checkpointedFrames: 0, journalMode: "delete" };
+        } else if (request.kind === "v3-summary") {
+          result = {
+            catalogId: wrongCatalogId,
+            displayName: "Wrong",
+            appVersion: "test",
+            installState: "ready",
+            revision: 0,
+            migrationId: wrongMigrationId,
+            migrationPhase: "validated",
+            sourceVersion: 2,
+            migration,
+            root: { rootId, label: "Root", configuredPath: rootPath, canonicalPath: rootPath,
+              health: "online", scanState: "complete", watchState: "disabled" },
+            counts,
+            fingerprintCoverage,
+          };
+        } else if (request.kind === "v3-assets-page") {
+          result = request.input.limit === 2
+            ? { catalogId: request.input.catalogId, revision: 8, assets: [], nextCursor: null }
+            : { catalogId: wrongCatalogId, revision: 0, assets: [], nextCursor: null };
+        } else if (request.kind === "v3-albums") {
+          if (request.input.limit === 2) {
+            result = { catalogId: request.input.catalogId, revision: 8, albums: [], nextCursor: null };
+          } else if (request.input.limit === 3) {
+            result = { catalogId: request.input.catalogId, revision: 0, albums: [{
+              catalogId: request.input.catalogId, id: "album", name: "Album",
+              createdAt: 0, updatedAt: 0, position: 2,
+            }], nextCursor: null };
+          } else {
+            result = { catalogId: wrongCatalogId, revision: 0, albums: [], nextCursor: null };
+          }
+        } else if (request.kind === "v3-album-assets-page") {
+          if (request.input.limit === 2) {
+            result = { catalogId: request.input.catalogId, albumId: request.input.albumId,
+              revision: 8, assets: [], nextCursor: null };
+          } else if (request.input.limit === 3) {
+            result = { catalogId: request.input.catalogId, albumId: request.input.albumId,
+              revision: 0, assets: [{ position: 2, assetId: wrongCatalogId, rootId,
+                relativePath: "asset.jpg", health: "missing", revision: 0 }], nextCursor: null };
+          } else {
+            result = { catalogId: request.input.catalogId, albumId: "wrong", revision: 0,
+              assets: [], nextCursor: null };
+          }
+        }
+        if (result) parentPort.postMessage({ kind: request.kind, requestId: request.requestId, result });
+      });
+    `);
+    client = createCatalogWorkerTestClient({
+      workerPath: fakeWorkerPath,
+      requestTimeoutMs: 1_000,
+    });
+    const catalogId = createCatalogId();
+    const migrationId = createOperationId();
+    const input = {
+      catalogId,
+      displayName: "Identity test",
+      appVersion: "test",
+      root: {
+        rootId: createRootId(),
+        label: "Identity root",
+        configuredPath: root,
+        canonicalPath: root,
+        health: "online" as const,
+        scanState: "complete" as const,
+        watchState: "disabled" as const,
+      },
+      migration: {
+        migrationId,
+        sourceVersion: 2 as const,
+        catalogPath: path.join(root, "legacy.json"),
+        settingsPath: null,
+        catalogSha256: "a".repeat(64),
+        settingsSha256: null,
+        rootAvailable: true,
+        expectedCounts: {
+          assets: 0,
+          metadata: 0,
+          albums: 0,
+          albumAssets: 0,
+          archived: 0,
+          aliases: 0,
+          fingerprints: 0,
+          present: 0,
+          missing: 0,
+        },
+        expectedStateSha256: "b".repeat(64),
+      },
+    };
+    const mismatches: readonly [string, () => Promise<unknown>, RegExp][] = [
+      ["install", () => client!.installV3(input), /mismatched catalogId/],
+      ["assets", () => client!.writeV3AssetBatch({ catalogId, migrationId, assets: [] }), /mismatched migrationId/],
+      ["relations", () => client!.writeV3RelationsBatch({ catalogId, migrationId, albums: [], archiveLegacyIds: [] }), /mismatched migrationId/],
+      ["finish", () => client!.finishV3Copy(catalogId, migrationId), /mismatched migrationId/],
+      ["validate", () => client!.validateV3(catalogId, migrationId), /mismatched catalogId/],
+      ["prepare", () => client!.prepareV3Activation(catalogId, migrationId), /mismatched migrationId/],
+      ["seal", () => client!.sealV3ForInstall(catalogId, migrationId), /mismatched migrationId/],
+      ["summary", () => client!.v3Summary(catalogId), /mismatched catalogId/],
+      ["asset page", () => client!.v3AssetsPage({ catalogId, expectedRevision: null, cursor: null, limit: 1 }), /mismatched catalogId/],
+      ["asset page revision", () => client!.v3AssetsPage({
+        catalogId,
+        expectedRevision: 7,
+        cursor: null,
+        limit: 2,
+      }), /mismatched revision/],
+      ["albums", () => client!.v3Albums({ catalogId, expectedRevision: null, cursor: null, limit: 1 }), /mismatched catalogId/],
+      ["album revision", () => client!.v3Albums({
+        catalogId,
+        expectedRevision: 7,
+        cursor: null,
+        limit: 2,
+      }), /mismatched revision/],
+      ["album cursor", () => client!.v3Albums({
+        catalogId,
+        expectedRevision: null,
+        cursor: 0,
+        limit: 3,
+      }), /mismatched cursor/],
+      ["album assets", () => client!.v3AlbumAssetsPage({
+        catalogId,
+        albumId: "album",
+        expectedRevision: null,
+        cursor: null,
+        limit: 1,
+      }), /mismatched albumId/],
+      ["album asset revision", () => client!.v3AlbumAssetsPage({
+        catalogId,
+        albumId: "album",
+        expectedRevision: 7,
+        cursor: null,
+        limit: 2,
+      }), /mismatched revision/],
+      ["album asset cursor", () => client!.v3AlbumAssetsPage({
+        catalogId,
+        albumId: "album",
+        expectedRevision: null,
+        cursor: 0,
+        limit: 3,
+      }), /mismatched cursor/],
+    ];
+    for (const [label, operation, error] of mismatches) {
+      await assert.rejects(operation(), error, label);
+    }
+  } finally {
+    await client?.forceTerminate().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("catalog registry validates persisted data and serializes atomic writes", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "darkroom-catalog-registry-test-"));
   try {
     const store = createCatalogRegistryStore(root);
+    const concurrentStore = createCatalogRegistryStore(root);
     const first = {
       catalogId: createCatalogId(),
       displayName: "First",
@@ -107,7 +470,7 @@ test("catalog registry validates persisted data and serializes atomic writes", a
       health: "degraded" as const,
       lastOpenedAt: Date.now(),
     };
-    await Promise.all([store.upsert(first), store.upsert(second)]);
+    await Promise.all([store.upsert(first), concurrentStore.upsert(second)]);
     const document = await store.read();
     assert.equal(document.version, 1);
     assert.deepEqual(


### PR DESCRIPTION
## Problem

Darkroom v2 uses path-based JSON identity and cannot provide the durable asset graph, exact validation, or missing-root recovery required by later catalog work. Migration must preserve every recoverable relation without mutating the legacy source or claiming duplicate readiness before fingerprints exist.

## Change

- Add the constrained catalog v3 SQLite schema and worker-owned repository for stable catalog, root, asset, fingerprint, metadata, album, operation, preset, and migration identity.
- Add staged v1/v2 migration from frozen source bytes, with strict parsing, stable retry IDs, exact state hashing, recovery evidence, integrity and foreign-key checks, and registry activation only after validation.
- Preserve pick, rating, label, Develop, albums, archive, observations, and valid XMP state. Represent recoverable offline references as missing assets and mark every unhashed asset fingerprint-missing.
- Move cache identity to catalog ID, asset ID, revision, and variant. Add revision-bound, bounded asset, album, and membership snapshot pages.
- Keep watcher and file mutation out of scope. Production startup remains dormant until Step 3 because the renderer still writes v2 JSON.

## Proof

| Case | Before | After | Fingerprints |
| --- | --- | --- | --- |
| v1 online | 1 metadata entry, 1 album, 2 memberships, 1 archive reference, 3 distinct referenced IDs, 3 scanned assets, 4 expected assets, 4 aliases | 4 assets: 3 present, 1 missing, 1 archived; metadata, Develop, XMP, album order, and membership order preserved | 4 missing, 0 valid |
| v2 offline | 3 recoverable referenced assets | 3 missing assets, 0 present, 1 archived | all missing |

The v2 missing-root report states that the legacy format has no complete inventory, so unreferenced and unedited files cannot be reconstructed until root relink and rescan. It also records unknown offline XMP state and no proved digest.

- `npm test`: 55/55 passed, including online, offline, malformed, v1, v2, source mutation, interrupted copy/publish, registry retry, exact metadata/relation validation, pagination, and byte-identical legacy evidence.
- `npm run build`: Next static export and Electron build passed. Existing workspace-root and webpack circular-chunk warnings remain.
- Electron TypeScript check and scoped ESLint for every changed file passed.
- `npm run test:catalog-worker:worker`: Node 24.18.0, SQLite 3.53.1, transaction/backup/integrity proof, and reopen without a lock passed.
- `npm run test:catalog-worker:electron`: development and freshly packaged macOS arm64 app entrypoints passed.
- Scale probes: 8,000 assets validated in 245 ms; 2,000 assets with 20 KiB XMP each validated with no retained heap or RSS growth. Divergent UTF-8/UTF-16 asset and alias ordering validated cleanly.
- `git diff --check`: passed.

`npm run lint` still reports the three documented pre-existing errors in `AlbumPickerPopup.tsx`, `RemovePhotosPopup.tsx`, and `useScrollToSelectedRow.ts`, plus three existing TanStack Virtual warnings. No changed file reports a lint issue.

Implementation used `gpt-5.6-luna` at max reasoning. Review and debugging used `gpt-5.6-sol`, followed by independent scale, protocol-boundary, and final correctness audits.

## Recovery and rollback

The installer preserves exact catalog and settings bytes in recovery storage, leaves the legacy files untouched, and rechecks their hashes before registry activation. Before activation, discard the staged v3 database and continue with v2. After activation, close v3 and reopen the preserved legacy source in the older app; new v3 organization does not back-port. Step 3 will own the production startup cutover.

## Issues

Refs #21

Refs #26

Refs #27

Refs #129

Refs #131
